### PR TITLE
Add: force run lint checks on precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ that connects to the API will get an IP address from the list of predefined "rea
 
 1. clone repository
 2. `docker-compose up -d` - run redis
-3. `npm install && npm run build`
+3. `npm install && npm run init:hooks && npm run build`
 4. `node dist/index.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/throng": "^5.0.3",
         "c8": "^7.11.0",
         "chai": "^4.3.6",
+        "husky": "^7.0.4",
         "mocha": "^9.2.2",
         "rimraf": "^3.0.2",
         "sinon": "^13.0.1",
@@ -3928,6 +3929,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -11860,6 +11876,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/throng": "^5.0.3",
     "c8": "^7.11.0",
     "chai": "^4.3.6",
+    "husky": "^7.0.4",
     "mocha": "^9.2.2",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",
@@ -53,9 +54,11 @@
   "scripts": {
     "build": "tsc",
     "lint": "xo",
+    "lint:fix": "xo --fix",
     "clean": "rimraf .nyc_output coverage",
     "test": "mocha",
-    "test:coverage": "npm run clean && c8 mocha"
+    "test:coverage": "npm run clean && c8 mocha",
+    "init:hooks": "husky install"
   },
   "xo": {
     "rules": {


### PR DESCRIPTION
Installs husky and forces lint check on precommit.

@zarianec I would also like to replace tabs with spaces. Their size is uniform across all environments, and will greatly improve readability - github seems to be using 8 spaces, which is radicilous.