### PR TITLE
add: magic world filter

### DIFF
--- a/src/probe/router.ts
+++ b/src/probe/router.ts
@@ -35,6 +35,10 @@ export class ProbeRouter {
 
 	private findByLocation(sockets: Socket[], location: Location): Socket[] {
 		if (location.type === 'magic') {
+			if (location.value === 'world') {
+				return this.filterGloballyDistributed(sockets, sockets.length);
+			}
+
 			return sockets.filter(s => s.data.probe.index.find(v => v.includes(location.value.replace('-', ' ').toLowerCase())));
 		}
 

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -99,5 +99,22 @@ describe('Create measurement', function () {
 					expect(body.probesCount).to.equal(1);
 				});
 		});
+
+		it('should create measurement with "magic: world" location', async () => {
+			await requestAgent.post('/v1/measurements')
+				.send({
+					locations: [{type: 'magic', value: 'world', limit: 2}],
+					measurement: {
+						type: 'ping',
+						target: 'example.com',
+						packets: 4,
+					},
+				})
+				.expect(200)
+				.expect(({body}) => {
+					expect(body.id).to.exist;
+					expect(body.probesCount).to.equal(1);
+				});
+		});
 	});
 });


### PR DESCRIPTION
adds location filter, behaving like no filter at all.  ¯\(°_o)/¯

```json
{ "type": "magic", "value": "world", "limit": 2 }
```