### PR TITLE
Kill old probes - DONT MERGE

### DIFF
--- a/src/kill.ts
+++ b/src/kill.ts
@@ -1,0 +1,28 @@
+import {getWsServer, initWsServer, PROBES_NAMESPACE} from './lib/ws/server.js';
+import cryptoRandomString from 'crypto-random-string';
+import {initRedis} from './lib/redis/client.js';
+
+await initRedis();
+await initWsServer();
+
+const io = getWsServer();
+
+const spamProbes = async () => {
+	const probes = await io.of(PROBES_NAMESPACE).fetchSockets();
+	const oldProbes = probes.filter(p => p.data['probe'].version !== '0.5.0');
+
+	if (oldProbes.length === 0) {
+		process.exit(0);
+	}
+
+	for (const probe of oldProbes) {
+		io.of(PROBES_NAMESPACE).to(probe.id).emit('probe:measurement:request', {
+			id: cryptoRandomString({type: 'url-safe', length: 16 * 100}),
+			measurement: {type: 'unknown'} as any,
+		});
+	}
+
+	spamProbes();
+}
+
+spamProbes();

--- a/src/measurement/handler/ack.ts
+++ b/src/measurement/handler/ack.ts
@@ -1,11 +1,7 @@
 import type {Probe} from '../../probe/types.js';
-import {getMeasurementRunner} from '../runner.js';
 import type {MeasurementAckMessage} from '../types.js';
 
-const runner = getMeasurementRunner();
-
-export const handleMeasurementAck = (probe: Probe) => async (data: MeasurementAckMessage, ack: () => void): Promise<void> => {
-	await runner.addProbe(data.measurementId, data.id, probe).then(() => {
-		ack();
-	});
+export const handleMeasurementAck = (_probe: Probe) => async (_data: MeasurementAckMessage, ack: () => void): Promise<void> => {
+  ack();
+  await Promise.resolve()
 };

--- a/src/measurement/handler/progress.ts
+++ b/src/measurement/handler/progress.ts
@@ -1,8 +1,5 @@
-import {getMeasurementRunner} from '../runner.js';
 import type {MeasurementResultMessage} from '../types.js';
 
-const runner = getMeasurementRunner();
-
-export const handleMeasurementProgress = async (data: MeasurementResultMessage): Promise<void> => {
-	await runner.recordProgress(data);
+export const handleMeasurementProgress = async (_data: MeasurementResultMessage): Promise<void> => {
+  await Promise.resolve()
 };

--- a/src/measurement/handler/result.ts
+++ b/src/measurement/handler/result.ts
@@ -1,8 +1,5 @@
 import type {MeasurementResultMessage} from '../types.js';
-import {getMeasurementRunner} from '../runner.js';
 
-const runner = getMeasurementRunner();
-
-export const handleMeasurementResult = async (data: MeasurementResultMessage): Promise<void> => {
-	await runner.recordResult(data);
+export const handleMeasurementResult = async (_data: MeasurementResultMessage): Promise<void> => {
+  await Promise.resolve()
 };


### PR DESCRIPTION
DONT MERGE

- [x] disables measurement response handlers
- [x] adds `src/kill.ts` script

to run:
- deploy the server
- locally, run `npm run build && REDIS_URL=<ADDR> node dist/kill.js`