### PR TITLE
feat: nested filters

### DIFF
--- a/docs/measurement/schema/request.md
+++ b/docs/measurement/schema/request.md
@@ -43,6 +43,26 @@ Global limit controls the maximum number of tests the server will perform and do
     "limit": 5
 ```
 
+### filter
+
+Defines which filter mechanism should be used.
+
+`combined` tells the API to match probes based on all supplied values, while `default` will select the first probe in order, based on one of the matches. Runs in `default` mode, when not specified.
+
+**key**: `filter`
+
+**required**: `false`
+
+**rules**:
+- `default` or `combined`
+- `default` when not specified
+- location limits can't be defined, when running in `combined` mode
+- typeof `string`
+
+```json
+    "filter": "combined"
+```
+
 ### locations
 
 Specifies a list of desired locations from which tests should be run. The server distributes probes based on its preconfigured geo-weight algorithm if none is provided.

--- a/public/measurements.vue.js
+++ b/public/measurements.vue.js
@@ -6,6 +6,7 @@ const app = () => ({
         locations: [],
         target: 'google.com',
         limit: 1,
+        combineFilters: false,
         query: {}
       },
       response: {
@@ -172,7 +173,7 @@ const app = () => ({
         ...(limit ? { limit } : {})
       }))
 
-      this.postMeasurement(this.query.limit, measurement, locations);
+      this.postMeasurement(this.query.limit, measurement, locations, this.query.combineFilters);
     },
     addNewLocation(e) {
       e.preventDefault();
@@ -200,7 +201,7 @@ const app = () => ({
         ...this.query.locations.slice(index + 1)
       ];
     },
-    async postMeasurement(limit = 1, measurement = {}, locations = []) {
+    async postMeasurement(limit = 1, measurement = {}, locations = [], combineFilters) {
       const url = '/v1/measurements';
 
       const body = {
@@ -210,6 +211,10 @@ const app = () => ({
 
       if (!locations.find(l => l.limit)) {
         body.limit = limit;
+      }
+
+      if (combineFilters) {
+        body.filter = 'combined';
       }
 
       const response = await fetch(url, {
@@ -274,6 +279,12 @@ const app = () => ({
           <label for="query_target" class="col-sm-2 col-form-label">target</label>
           <div class="col-sm-10">
             <input v-model="query.target" name="query_target" id="query_target" placeholder="target" />
+          </div>
+        </div>
+        <div class="form-group row">
+          <label for="query_filter_combine" class="col-sm-2 col-form-label">combine filters</label>
+          <div class="col-sm-10">
+            <input type="checkbox" v-model="query.combineFilters" >
           </div>
         </div>
         <div class="form-group row">

--- a/src/lib/location/types.ts
+++ b/src/lib/location/types.ts
@@ -20,7 +20,7 @@ type StateLocation = {
 
 type CityLocation = {
 	type: 'city';
-	value: number;
+	value: string;
 };
 
 type AsnLocation = {

--- a/src/measurement/route/create-measurement.ts
+++ b/src/measurement/route/create-measurement.ts
@@ -7,7 +7,7 @@ import type {MeasurementRequest} from '../types.js';
 import {bodyParser} from '../../lib/http/middleware/body-parser.js';
 import {validate} from '../../lib/http/middleware/validate.js';
 import {dnsSchema, pingSchema, tracerouteSchema, mtrSchema, httpSchema} from '../schema/command-schema.js';
-import {schema as locationSchema} from '../schema/location-schema.js';
+import {schema as locationSchema, filterSchema} from '../schema/location-schema.js';
 
 const runner = getMeasurementRunner();
 const measurementConfig = config.get<{limits: {global: number; location: number}}>('measurement');
@@ -16,6 +16,7 @@ export const schema = Joi.object({
 	locations: locationSchema,
 	measurement: Joi.alternatives().try(pingSchema, tracerouteSchema, dnsSchema, mtrSchema, httpSchema).required(),
 	limit: Joi.number().min(1).max(measurementConfig.limits.global),
+	filter: filterSchema,
 });
 
 const handle = async (ctx: Context): Promise<void> => {

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -26,7 +26,7 @@ export class MeasurementRunner {
 	) {}
 
 	async run(request: MeasurementRequest): Promise<MeasurementConfig> {
-		const probes = await this.router.findMatchingProbes(request.locations, request.limit);
+		const probes = await this.router.findMatchingProbes(request.locations, request.limit, request.filter === 'combined');
 
 		if (probes.length === 0) {
 			throw createHttpError(400, 'No suitable probes found');

--- a/src/measurement/schema/location-schema.ts
+++ b/src/measurement/schema/location-schema.ts
@@ -10,6 +10,8 @@ import {regions} from '../../lib/location/regions.js';
 const {continents, countries} = geoLists;
 const measurementConfig = config.get<{limits: {global: number; location: number}}>('measurement');
 
+export const filterSchema = Joi.string().valid('combined', 'default').insensitive().default('default');
+
 export const schema = Joi.array().items(Joi.object({
 	type: Joi.string().valid('continent', 'region', 'country', 'state', 'city', 'network', 'asn', 'magic').insensitive().required(),
 	value: Joi.alternatives().conditional('type', {
@@ -42,5 +44,8 @@ export const schema = Joi.array().items(Joi.object({
 		is: Joi.exist(),
 		then: Joi.forbidden().messages({'any.unknown': 'limit per location is not allowed when a global limit is set'}),
 		otherwise: Joi.required().messages({'any.required': 'limit per location required when no global limit is set'}),
+	}).when(Joi.ref('/filter'), {
+		is: 'combined',
+		then: Joi.forbidden().messages({'any.unknown': 'limit per location can not be used with combined filter type'}),
 	}),
 })).default([]);

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -82,6 +82,7 @@ export type MeasurementRequest = {
 	measurement: NetworkTest;
 	locations: LocationWithLimit[];
 	limit?: number;
+	filter?: 'combined' | 'default';
 };
 
 export type MeasurementConfig = {

--- a/test/tests/unit/probe/router.test.ts
+++ b/test/tests/unit/probe/router.test.ts
@@ -8,6 +8,7 @@ import {PROBES_NAMESPACE, SocketData} from '../../../../src/lib/ws/server.js';
 import type {DeepPartial} from '../../../types.js';
 import type {ProbeLocation} from '../../../../src/probe/types.js';
 import type {Location} from '../../../../src/lib/location/types.js';
+import type {LocationWithLimit} from '../../../../src/measurement/types.js';
 import {
 	getCountryAliases,
 	getCountryByIso,
@@ -19,10 +20,24 @@ import {
 
 type Socket = RemoteSocket<DefaultEventsMap, SocketData>;
 
+const buildLocationIndexes = (location: Partial<ProbeLocation>) => [
+	...Object.entries(location)
+		.filter(([key, value]) => value && !['asn', 'latitude', 'longitude'].includes(key))
+		.map(entries => String(entries[1])),
+	...(location.asn ? [`as${location.asn}`] : []),
+	...(location.state ? [getStateNameByIso(location.state)] : []),
+	...(location.country ? [
+		getCountryByIso(location.country),
+		getCountryIso3ByIso2(location.country),
+		getCountryAliases(location.country),
+	] : []),
+	...(location.network ? [getNetworkAliases(location.network)] : []),
+].flat().filter(Boolean).map(s => s.toLowerCase().replace('-', ' '));
+
 const buildSocket = (
 	id: string,
 	location: Partial<ProbeLocation>,
-	index: string[] = [],
+	index: string[] = buildLocationIndexes(location),
 	ready = true,
 ): DeepPartial<Socket> => ({
 	id,
@@ -219,21 +234,9 @@ describe('probe router', () => {
 			network: 'a-virgin media',
 		};
 
-		const index = [
-			...Object.entries(location)
-				.filter(([key, value]) => value && !['asn', 'latitude', 'longitude'].includes(key))
-				.map(entries => String(entries[1])),
-			`as${location.asn}`,
-			...(location.state ? [getStateNameByIso(location.state)] : []),
-			getCountryByIso(location.country),
-			getCountryIso3ByIso2(location.country),
-			getCountryAliases(location.country),
-			getNetworkAliases(location.network),
-		].flat().map(s => s.toLowerCase().replace('-', ' '));
-
 		it('should return match (country alias)', async () => {
 			const sockets: DeepPartial<Socket[]> = [
-				buildSocket(String(Date.now()), location, index),
+				buildSocket(String(Date.now()), location),
 			];
 
 			const locations: Location[] = [
@@ -252,7 +255,7 @@ describe('probe router', () => {
 			for (const testCase of ['a-virgin', 'virgin', 'media']) {
 				it(`should match network - ${testCase}`, async () => {
 					const sockets: DeepPartial<Socket[]> = [
-						buildSocket(String(Date.now()), location, index),
+						buildSocket(String(Date.now()), location),
 					];
 
 					const locations: Location[] = [
@@ -273,7 +276,7 @@ describe('probe router', () => {
 			for (const testCase of ['5089', 'AS5089', 'as5089']) {
 				it(`should match ASN - ${testCase}`, async () => {
 					const sockets: DeepPartial<Socket[]> = [
-						buildSocket(String(Date.now()), location, index),
+						buildSocket(String(Date.now()), location),
 					];
 
 					const locations: Location[] = [
@@ -288,6 +291,44 @@ describe('probe router', () => {
 					expect(probes[0]!.location.country).to.equal('GB');
 				});
 			}
+		});
+	});
+
+	describe('sticky filters', () => {
+		const sockets: DeepPartial<Socket[]> = [
+			buildSocket('GB-1', {continent: 'EU', country: 'GB', city: 'london', asn: 100}),
+			buildSocket('FI-1', {continent: 'EU', country: 'FI', city: 'london', asn: 222}),
+			buildSocket('US-1', {continent: 'NA', country: 'US', city: 'london', state: 'OH', asn: 999}),
+			buildSocket('US-3', {continent: 'NA', country: 'US', city: 'london', state: 'AR', asn: 555}),
+			buildSocket('CA-1', {continent: 'NA', country: 'CA', city: 'london', asn: 888}),
+		];
+
+		it('should combine filters', async () => {
+			const locations: LocationWithLimit[] = [
+				{type: 'city', value: 'london'},
+				{type: 'country', value: 'US'},
+			];
+
+			wsServerMock.fetchSockets.resolves(sockets as never);
+
+			const probes = await router.findMatchingProbes(locations, 100, true);
+			const grouped = _.groupBy(probes, 'location.country');
+
+			expect(grouped['US']?.length).to.equal(2);
+		});
+
+		it('should combine filters - use magic', async () => {
+			const locations: LocationWithLimit[] = [
+				{type: 'city', value: 'london'},
+				{type: 'magic', value: 'uk'},
+			];
+
+			wsServerMock.fetchSockets.resolves(sockets as never);
+
+			const probes = await router.findMatchingProbes(locations, 100, true);
+			const grouped = _.groupBy(probes, 'location.country');
+
+			expect(grouped['GB']?.length).to.equal(1);
 		});
 	});
 });


### PR DESCRIPTION
https://github.com/jsdelivr/globalping/pull/143 should be merged first.

- [x] probe router logic
- [x] schema
- [x] error message
- [x] unit tests
- [x] demo page
- [x] update magic match (requires #143 merge)
- [x] docs

rules:
- `filter: combined | default` has to be added on 0-level body (next to global limit)
- `filter: default` is ignored
- `filter: combined` can not be used with per-location limits