### PR TITLE
ref: remove type-based error matching

### DIFF
--- a/src/lib/http/middleware/validate.ts
+++ b/src/lib/http/middleware/validate.ts
@@ -1,26 +1,11 @@
 import type {Schema} from 'joi';
 import type {Context, Next} from 'koa';
-import {validCmdTypes} from '../../../measurement/schema/command-schema.js';
-
-type DeepFieldDetails = {
-	message: string;
-	context: {
-		message: string;
-	};
-	path: string[];
-};
 
 export const validate = (schema: Schema) => async (ctx: Context, next: Next) => {
 	const valid = schema.validate(ctx.request.body, {convert: true});
 
 	if (valid.error) {
-		const deepErrorMatch = valid.error.details
-			.filter(field => field?.context!['details'])
-			.flatMap(field => (field.context!['details'] as DeepFieldDetails))
-			.filter(item => item && !(item.path.includes('type') && validCmdTypes.includes(valid.error._original.measurement.type)));
-
-		const finalError = deepErrorMatch.length > 0 ? deepErrorMatch : valid.error.details;
-		const fields = finalError.map(field => ([field.path.join('.'), String(field.context?.message || field.message)]));
+		const fields = valid.error.details.map(field => ([field.path.join('.'), String(field?.message)]));
 
 		ctx.status = 422;
 		ctx.body = {


### PR DESCRIPTION
outdated quickfix, resolved by #170 
- replacing `alternatives()` with `when()` means Joi attempts to match just one command schema
- command schemas have no `type` field anymore
