### PR TITLE
fix: add ip support to dns ptr

### DIFF
--- a/src/measurement/schema/command-schema.ts
+++ b/src/measurement/schema/command-schema.ts
@@ -57,7 +57,9 @@ export const tracerouteSchema = Joi.object({
 const allowedDnsTypes = ['A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV'];
 const allowedDnsProtocols = ['UDP', 'TCP'];
 
-const dnsTargetSchema = Joi.string().domain().custom(joiValidateTarget('domain')).required();
+const dnsDefaultTargetSchema = Joi.string().domain().custom(joiValidateTarget('domain')).required();
+const dnsPtrTargetSchema = Joi.string().ip(globalIpOptions).custom(joiValidateTarget('ip')).required();
+const dnsTargetSchema = Joi.when(Joi.ref('.measurementOptions.query.type'), {is: Joi.string().insensitive().valid('PTR'), then: dnsPtrTargetSchema, otherwise: dnsDefaultTargetSchema});
 export const dnsSchema = Joi.object({
 	query: Joi.object({
 		type: Joi.string().valid(...allowedDnsTypes).insensitive().default('A'),

--- a/src/measurement/schema/command-schema.ts
+++ b/src/measurement/schema/command-schema.ts
@@ -59,7 +59,7 @@ const allowedDnsProtocols = ['UDP', 'TCP'];
 
 const dnsDefaultTargetSchema = Joi.string().domain().custom(joiValidateTarget('domain')).required();
 const dnsPtrTargetSchema = Joi.string().ip(globalIpOptions).custom(joiValidateTarget('ip')).required();
-const dnsTargetSchema = Joi.when(Joi.ref('.measurementOptions.query.type'), {is: Joi.string().insensitive().valid('PTR'), then: dnsPtrTargetSchema, otherwise: dnsDefaultTargetSchema});
+const dnsTargetSchema = Joi.when(Joi.ref('..measurementOptions.query.type'), {is: Joi.string().insensitive().valid('PTR'), then: dnsPtrTargetSchema, otherwise: dnsDefaultTargetSchema});
 export const dnsSchema = Joi.object({
 	query: Joi.object({
 		type: Joi.string().valid(...allowedDnsTypes).insensitive().default('A'),

--- a/src/measurement/schema/command-schema.ts
+++ b/src/measurement/schema/command-schema.ts
@@ -59,7 +59,7 @@ const allowedDnsProtocols = ['UDP', 'TCP'];
 
 const dnsDefaultTargetSchema = Joi.string().domain().custom(joiValidateTarget('domain')).required();
 const dnsPtrTargetSchema = Joi.string().ip(globalIpOptions).custom(joiValidateTarget('ip')).required();
-const dnsTargetSchema = Joi.when(Joi.ref('..measurementOptions.query.type'), {is: Joi.string().insensitive().valid('PTR'), then: dnsPtrTargetSchema, otherwise: dnsDefaultTargetSchema});
+const dnsTargetSchema = Joi.when(Joi.ref('..measurementOptions.query.type'), {is: Joi.string().insensitive().valid('PTR').required(), then: dnsPtrTargetSchema, otherwise: dnsDefaultTargetSchema});
 export const dnsSchema = Joi.object({
 	query: Joi.object({
 		type: Joi.string().valid(...allowedDnsTypes).insensitive().default('A'),

--- a/test/tests/unit/measurement/schema.test.ts
+++ b/test/tests/unit/measurement/schema.test.ts
@@ -589,6 +589,60 @@ describe('command schema', () => {
 		});
 	});
 
+	describe('dns ptr', () => {
+		it('should fail (uses domain for target)', async () => {
+			const input = {
+				type: 'dns',
+				target: 'abc.com',
+				measurementOptions: {
+					query: {
+						type: 'PTR',
+					},
+				},
+			};
+
+			const valid = globalSchema.validate(input);
+
+			expect(valid.error).to.exist;
+		});
+
+		it('should pass (uses ip for target)', async () => {
+			const input = {
+				type: 'dns',
+				target: '1.1.1.1',
+				measurementOptions: {
+					query: {
+						type: 'PTR',
+					},
+				},
+			};
+
+			const valid = globalSchema.validate(input);
+
+			expect(valid.error).not.to.exist;
+			expect(valid.value.type).to.equal('dns');
+			expect(valid.value.measurementOptions.query.type).to.equal('PTR');
+		});
+
+		it('should pass (uses ip for target incorrect caps for type)', async () => {
+			const input = {
+				type: 'dns',
+				target: '1.1.1.1',
+				measurementOptions: {
+					query: {
+						type: 'ptr',
+					},
+				},
+			};
+
+			const valid = globalSchema.validate(input);
+
+			expect(valid.error).not.to.exist;
+			expect(valid.value.type).to.equal('dns');
+			expect(valid.value.measurementOptions.query.type).to.equal('PTR');
+		});
+	});
+
 	describe('mtr', () => {
 		it('should fail (missing values)', async () => {
 			const input = {


### PR DESCRIPTION
Partially resolves #172. It adds conditional validation when PTR is selected to prevent domains from being used and only IPs. 

Adds 3 test cases, but I still need to test the whole build locally once I figure out how to do that properly. So might need to wait a little before merging just to be sure.

Do we want IPv6 support for PTR? Currently, globalIpOptions only allows IPv4 but I don't know if that's applicable for this.

I'll look into adding `dig -x` support in the probe repo tomorrow.