### PR TITLE
fix: logger metadata

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,11 +1,17 @@
 import * as process from 'node:process';
 import * as winston from 'winston';
 
+const metaEntryToString = (data: unknown): string => typeof data === 'object' ? JSON.stringify(data) : String(data);
+
 const logger = winston.createLogger({
 	level: process.env['LOG_LEVEL'] ?? 'debug',
 	format: winston.format.combine(
 		winston.format.timestamp({format: 'YYYY-MM-DD HH:mm:ss'}),
-		winston.format.printf(info => `[${info['timestamp'] as string}] [${info.level.toUpperCase()}] [${process.pid}] [${info['scope'] as string}] ${info.message}`),
+		winston.format.printf(info => {
+			const {timestamp, level, scope, message, ...meta} = info;
+			const data = Object.keys(meta).map(k => `\n  ${k} -> ${metaEntryToString(meta[k])}`).join('');
+			return `[${timestamp as string}] [${level.toUpperCase()}] [${process.pid}] [${scope as string}] ${message}${data}`;
+		}),
 	),
 	transports: [
 		new winston.transports.Console({


### PR DESCRIPTION
resolve #178 

```
[2022-07-28 17:38:17] [DEBUG] [1063238] [ws:error] failed to collect probe metadata
 info -> {"socketId":"Od3Iad7jz6GXryjVAAAF"}
 stack -> Error: failed to collect probe metadata
    at file:///home/patryk/projects/globalping/api/dist/lib/ws/middleware/probe-metadata.js:18:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Array.<anonymous> (file:///home/patryk/projects/globalping/api/dist/lib/ws/helper/error-handler.js:8:9)
[2022-07-28 17:38:17] [ERROR] [1063238] [geoip] failed to find a correct value for a filed "normalizedCity"
 field -> normalizedCity
 sources -> [{"continent":"EU","country":"PL","city":"Kraków","normalizedCity":"krakow","asn":43939,"latitude":50.0614,"longitude":19.9366,"network":"Netia SA","normalizedNetwork":"netia sa","provider":"ipinfo"},{"continent":"EU","country":"PL","city":"Krakow","normalizedCity":"krakow","asn":43939,"latitude":50.0585,"longitude":19.9342,"network":"Internetia","normalizedNetwork":"internetia","provider":"maxmind"},{"continent":"EU","country":"PL","city":"krakow","normalizedCity":"krakow","asn":43939,"latitude":50.08,"longitude":19.88,"network":"netia sa","normalizedNetwork":"netia sa","provider":"fastly"}]
```