### PR TITLE
WIP: fix: use ascii names and custom map

### DIFF
--- a/src/lib/geoip/altnames.ts
+++ b/src/lib/geoip/altnames.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention, quote-props */
-export const altNames: Record<string, string> = {
+export const cities: Record<string, string> = {
 	'Geneve': 'Geneva',
 	'Frankfurt am Main': 'Frankfurt',
 	'New York City': 'New York',

--- a/src/lib/geoip/altnames.ts
+++ b/src/lib/geoip/altnames.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/naming-convention, quote-props */
+export const altNames: Record<string, string> = {
+	'Geneve': 'Geneva',
+	'Frankfurt am Main': 'Frankfurt',
+	'New York City': 'New York',
+};

--- a/src/lib/geoip/providers/fastly.ts
+++ b/src/lib/geoip/providers/fastly.ts
@@ -2,6 +2,7 @@ import got from 'got';
 import type {LocationInfo} from '../client.js';
 import {
 	normalizeCityName,
+	normalizeCityNamePublic,
 	normalizeNetworkName,
 } from '../utils.js';
 
@@ -46,7 +47,7 @@ export const fastlyLookup = async (addr: string): Promise<FastlyBundledResponse>
 		continent: data.continent_code,
 		country: data.country_code,
 		state: data.country_code === 'US' ? data.region : undefined,
-		city,
+		city: normalizeCityNamePublic(city),
 		normalizedCity: normalizeCityName(city),
 		asn: result.as.number,
 		latitude: data.latitude,

--- a/src/lib/geoip/providers/ipinfo.ts
+++ b/src/lib/geoip/providers/ipinfo.ts
@@ -4,6 +4,7 @@ import {getContinentByCountry, getStateIsoByName} from '../../location/location.
 import type {LocationInfo} from '../client.js';
 import {
 	normalizeCityName,
+	normalizeCityNamePublic,
 	normalizeNetworkName,
 } from '../utils.js';
 
@@ -30,7 +31,7 @@ export const ipinfoLookup = async (addr: string): Promise<LocationInfo> => {
 		continent: getContinentByCountry(result.country ?? ''),
 		state: result.country === 'US' ? getStateIsoByName(result.region ?? '') : undefined,
 		country: result.country ?? '',
-		city: result.city ?? '',
+		city: normalizeCityNamePublic(result.city ?? ''),
 		normalizedCity: normalizeCityName(result.city ?? ''),
 		asn: parsedAsn!,
 		latitude: Number(lat),

--- a/src/lib/geoip/providers/maxmind.ts
+++ b/src/lib/geoip/providers/maxmind.ts
@@ -5,6 +5,7 @@ import appsignal from '../../appsignal.js';
 import type {LocationInfo} from '../client.js';
 import {
 	normalizeCityName,
+	normalizeCityNamePublic,
 	normalizeNetworkName,
 } from '../utils.js';
 
@@ -40,7 +41,7 @@ export const maxmindLookup = async (addr: string): Promise<LocationInfo> => {
 		continent: data.continent?.code ?? '',
 		country: data.country?.isoCode ?? '',
 		state: data.country?.isoCode === 'US' ? data.subdivisions?.map(s => s.isoCode)[0] ?? '' : undefined,
-		city: data.city?.names?.en ?? '',
+		city: normalizeCityNamePublic(data.city?.names?.en ?? ''),
 		normalizedCity: normalizeCityName(data.city?.names?.en ?? ''),
 		asn: data.traits?.autonomousSystemNumber ?? 0,
 		latitude: data.location?.latitude ?? 0,

--- a/src/lib/geoip/utils.ts
+++ b/src/lib/geoip/utils.ts
@@ -1,12 +1,17 @@
 import anyAscii from 'any-ascii';
 
-const altNames: Array<[string, string]> = [['Geneve', 'Geneva'], ['Frankfurt am Main', 'Frankfurt'], ['New York City', 'New York']];
-const altNamesMap = new Map<string, string>(altNames);
+/* eslint-disable @typescript-eslint/naming-convention */
+const altNames: Record<string, string> = {
+	Geneve: 'Geneva',
+	'Frankfurt am Main': 'Frankfurt',
+	'New York City': 'New York',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export const normalizeCityNamePublic = (name: string): string => {
 	// We don't add city to the regex as there are valid names like 'Mexico City' or 'Kansas City'
 	const asciiName = anyAscii(name).replace(/(?:\s+|^)the(?:\s+|$)/gi, '');
-	return altNamesMap.get(asciiName) ?? asciiName;
+	return altNames[asciiName] ?? asciiName;
 };
 
 export const normalizeCityName = (name: string): string => normalizeCityNamePublic(name).toLowerCase();

--- a/src/lib/geoip/utils.ts
+++ b/src/lib/geoip/utils.ts
@@ -1,5 +1,15 @@
 import anyAscii from 'any-ascii';
 
-export const normalizeCityName = (name: string): string => anyAscii(name).toLowerCase().replace(/(?:\s+|^)(?:the|city)(?:\s+|$)/gi, '');
+const altNames: Array<[string, string]> = [['Geneve', 'Geneva'], ['Frankfurt am Main', 'Frankfurt'], ['New York City', 'New York']];
+const altNamesMap = new Map<string, string>(altNames);
+
+export const normalizeCityNamePublic = (name: string): string => {
+	// We don't add city to the regex as there are valid names like 'Mexico City' or 'Kansas City'
+	const asciiName = anyAscii(name).replace(/(?:\s+|^)the(?:\s+|$)/gi, '');
+	return altNamesMap.get(asciiName) ?? asciiName;
+};
+
+export const normalizeCityName = (name: string): string => normalizeCityNamePublic(name).toLowerCase();
+
 export const normalizeNetworkName = (name: string): string => name.toLowerCase();
 export const prettifyRegionName = (name: string): string => name.split(' ').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ');

--- a/src/lib/geoip/utils.ts
+++ b/src/lib/geoip/utils.ts
@@ -1,10 +1,10 @@
 import anyAscii from 'any-ascii';
-import {altNames} from './altnames.js';
+import {cities} from './altnames.js';
 
 export const normalizeCityNamePublic = (name: string): string => {
 	// We don't add city to the regex as there are valid names like 'Mexico City' or 'Kansas City'
 	const asciiName = anyAscii(name).replace(/(?:\s+|^)the(?:\s+|$)/gi, '');
-	return altNames[asciiName] ?? asciiName;
+	return cities[asciiName] ?? asciiName;
 };
 
 export const normalizeCityName = (name: string): string => normalizeCityNamePublic(name).toLowerCase();

--- a/src/lib/geoip/utils.ts
+++ b/src/lib/geoip/utils.ts
@@ -1,12 +1,5 @@
 import anyAscii from 'any-ascii';
-
-/* eslint-disable @typescript-eslint/naming-convention */
-const altNames: Record<string, string> = {
-	Geneve: 'Geneva',
-	'Frankfurt am Main': 'Frankfurt',
-	'New York City': 'New York',
-};
-/* eslint-enable @typescript-eslint/naming-convention */
+import {altNames} from './altnames.js';
 
 export const normalizeCityNamePublic = (name: string): string => {
 	// We don't add city to the regex as there are valid names like 'Mexico City' or 'Kansas City'

--- a/test/tests/unit/geoip.test.ts
+++ b/test/tests/unit/geoip.test.ts
@@ -280,7 +280,7 @@ describe('geoip service', () => {
 		expect(info).to.deep.equal({
 			asn: 61_493,
 			normalizedCity: 'new york',
-			city: 'The New York City',
+			city: 'New York',
 			normalizedRegion: 'northern america',
 			region: 'Northern America',
 			continent: 'NA',


### PR DESCRIPTION
Closes #190 and #163.

I removed the city element from the Regex as I'm not sure it's valid to denote places like Kansas City or Mexico City as other names. But I guess the same logic could be applied to New York as that can also be considered a state just like Kansas. Thoughts?

I think we should reopen #163 if we think maintaining a manual map is actually taking too much developer time in the long run, which I highly highly doubt. Otherwise, this should be suitable. 

This also fixes a bug with location filtering. While the probe on the demo/api results shows 'Kansas City', you can't use 'Kansas City' as the filter but only 'Kansas'. This makes both what's shown to the user and what should be inputted to be the same and unambiguous.