### PR TITLE
fix: API crash on partial JSON update (missing key)

### DIFF
--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -6,6 +6,9 @@ import {
 	RedisClientOptions,
 	RedisFunctions, RedisScripts,
 } from 'redis';
+import {scopedLogger} from '../logger.js';
+
+const logger = scopedLogger('redis');
 
 export type RedisClient = RedisClientType<RedisDefaultModules, RedisFunctions, RedisScripts>;
 
@@ -20,6 +23,12 @@ export const createRedisClient = async (options?: RedisClientOptions): Promise<R
 		...config.util.toObject(config.get('redis')),
 		...options,
 	});
+
+	client
+		.on('error', (error: Error) => logger.error('connection error', error))
+		.on('ready', () => logger.info('connection ready'))
+		.on('reconnecting', () => logger.info('reconnecting'));
+
 	await client.connect();
 
 	return client;

--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -13,6 +13,7 @@ import {getWsServer, PROBES_NAMESPACE} from './server.js';
 import {probeMetadata} from './middleware/probe-metadata.js';
 import {verifyIpLimit} from './helper/probe-ip-limit.js';
 import {errorHandler} from './helper/error-handler.js';
+import {subscribeWithHandler} from './helper/subscribe-handler.js';
 
 const io = getWsServer();
 const logger = scopedLogger('gateway');
@@ -31,9 +32,9 @@ io
 		socket.on('probe:status:ready', handleStatusReady(probe));
 		socket.on('probe:status:not_ready', handleStatusNotReady(probe));
 		socket.on('probe:dns:update', handleDnsUpdate(probe));
-		socket.on('probe:measurement:ack', handleMeasurementAck(probe));
-		socket.on('probe:measurement:progress', handleMeasurementProgress);
-		socket.on('probe:measurement:result', handleMeasurementResult);
+		subscribeWithHandler(socket, 'probe:measurement:ack', handleMeasurementAck(probe));
+		subscribeWithHandler(socket, 'probe:measurement:progress', handleMeasurementProgress);
+		subscribeWithHandler(socket, 'probe:measurement:result', handleMeasurementResult);
 
 		socket.on('disconnect', reason => {
 			logger.debug(`Probe disconnected. (reason: ${reason}) [${socket.id}][${probe.ipAddress}]`);


### PR DESCRIPTION
```
[2022-08-10 14:25:10] [INFO] [2162000] [ws:handler:error] event "probe:measurement:ack" failed to handle. 3LYkdAWt7aNUj7tgAAAH for (ERR new objects must be created at the root) [::ffff:127.0.0.1]
[2022-08-10 14:25:10] [DEBUG] [2162000] [ws:handler:error] ERR new objects must be created at the root
  stack -> undefined
[2022-08-10 14:25:40] [ERROR] [2162000] [measurement] ERR new objects must be created at the root
  stack -> undefined
```

```
[2022-08-11 12:49:33] [ERROR] [2181278] [redis] connection error connect ECONNREFUSED 127.0.0.1:6379
  errno -> -111
  code -> ECONNREFUSED
  syscall -> connect
  address -> 127.0.0.1
  port -> 6379
  stack -> Error: connect ECONNREFUSED 127.0.0.1:6379
    at __node_internal_captureLargerStackTrace (node:internal/errors:466:5)
    at __node_internal_exceptionWithHostPort (node:internal/errors:644:12)
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1195:16)
[2022-08-11 12:49:33] [INFO] [2181278] [redis] reconnecting
[2022-08-11 12:49:33] [INFO] [2181278] [redis] connection ready
```