### PR TITLE
feat: live probe metrics

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -7,6 +7,9 @@ module.exports = {
 			rejectUnauthorized: false,
 		},
 	},
+	admin: {
+		key: '',
+	},
 	geoip: {
 		cache: {
 			ttl: 3 * 24 * 60 * 60 * 1000, // 24hrs

--- a/src/lib/http/middleware/is-admin.ts
+++ b/src/lib/http/middleware/is-admin.ts
@@ -1,0 +1,8 @@
+import type {Context, Next} from 'koa';
+import config from 'config';
+
+export const isAdminMw = async (ctx: Context, next: Next) => {
+	const adminKey = config.get<string>('admin.key');
+	ctx['isAdmin'] = adminKey.length > 0 && ctx.query['adminkey'] === adminKey;
+	return next();
+};

--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -14,6 +14,7 @@ import {errorHandler} from './error-handler.js';
 import {rateLimitHandler} from './middleware/ratelimit.js';
 import {errorHandlerMw} from './middleware/error-handler.js';
 import {corsHandler} from './middleware/cors.js';
+import {isAdminMw} from './middleware/is-admin.js';
 
 const app = new Koa();
 
@@ -51,6 +52,7 @@ app
 	.use(demoRouter.routes())
 	// Error handler must always be the first middleware in a chain unless you know what you are doing ;)
 	.use(errorHandlerMw)
+	.use(isAdminMw)
 	.use(rateLimitHandler())
 	.use(responseTime())
 	.use(corsHandler())

--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -8,6 +8,7 @@ import {
 	handleStatusNotReady,
 } from '../../probe/handler/status.js';
 import {handleDnsUpdate} from '../../probe/handler/dns.js';
+import {handleStatsReport} from '../../probe/handler/stats.js';
 import {scopedLogger} from '../logger.js';
 import {getWsServer, PROBES_NAMESPACE} from './server.js';
 import {probeMetadata} from './middleware/probe-metadata.js';
@@ -32,6 +33,7 @@ io
 		socket.on('probe:status:ready', handleStatusReady(probe));
 		socket.on('probe:status:not_ready', handleStatusNotReady(probe));
 		socket.on('probe:dns:update', handleDnsUpdate(probe));
+		socket.on('probe:stats:report', handleStatsReport(probe));
 		subscribeWithHandler(socket, 'probe:measurement:ack', handleMeasurementAck(probe));
 		subscribeWithHandler(socket, 'probe:measurement:progress', handleMeasurementProgress);
 		subscribeWithHandler(socket, 'probe:measurement:result', handleMeasurementResult);

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -94,6 +94,13 @@ export const buildProbe = async (socket: Socket): Promise<Probe> => {
 		location,
 		index,
 		resolvers: [],
+		stats: {
+			cpu: {
+				count: 0,
+				load: [],
+			},
+			jobs: {count: 0},
+		},
 		ready: true,
 	};
 };

--- a/src/probe/handler/stats.ts
+++ b/src/probe/handler/stats.ts
@@ -1,0 +1,8 @@
+import type {
+	Probe,
+	ProbeStats,
+} from '../../probe/types.js';
+
+export const handleStatsReport = (probe: Probe) => (report: ProbeStats): void => {
+	probe.stats = report;
+};

--- a/src/probe/route/get-probes.ts
+++ b/src/probe/route/get-probes.ts
@@ -27,6 +27,7 @@ const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & R
 			network: socket.data.probe.location.network,
 		},
 		resolvers: socket.data.probe.resolvers,
+		stats: socket.data.probe.stats,
 	}));
 };
 

--- a/src/probe/route/get-probes.ts
+++ b/src/probe/route/get-probes.ts
@@ -10,6 +10,7 @@ type Socket = RemoteSocket<DefaultEventsMap, SocketData>;
 const io = getWsServer();
 
 const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & Router.RouterParamContext>): Promise<void> => {
+	const {isAdmin} = ctx;
 	const socketList: Socket[] = await io.of(PROBES_NAMESPACE).fetchSockets();
 
 	ctx.body = socketList.map((socket: Socket) => ({
@@ -27,7 +28,8 @@ const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & R
 			network: socket.data.probe.location.network,
 		},
 		resolvers: socket.data.probe.resolvers,
-		stats: socket.data.probe.stats,
+		stats: isAdmin ? socket.data.probe.stats : undefined,
+		ipAddress: isAdmin ? socket.data.probe.ipAddress : undefined,
 	}));
 };
 

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -13,6 +13,19 @@ export type ProbeLocation = {
 	normalizedNetwork: string;
 };
 
+export type ProbeStats = {
+	cpu: {
+		count: number;
+		load: Array<{
+			idle: number;
+			usage: number;
+		}>;
+	};
+	jobs: {
+		count: number;
+	};
+};
+
 export type Probe = {
 	ready: boolean;
 	client: string;
@@ -21,4 +34,5 @@ export type Probe = {
 	location: ProbeLocation;
 	index: string[];
 	resolvers: string[];
+	stats: ProbeStats;
 };


### PR DESCRIPTION
#200 

- [x] probe types
- [x] ws event handler 
- [x] get probes body

relies on https://github.com/jsdelivr/globalping-probe/pull/97

GET /v1/probes
```
[
  {
    "version": "0.9.1",
    "ready": true,
    "location": {
      "continent": "EU",
      "region": "Western Europe",
      "country": "FR",
      "city": "Paris",
      "asn": 12876,
      "latitute": 48.8534,
      "longitude": 2.3488,
      "network": "ONLINE S.A.S."
    },
    "resolvers": [
      "private"
    ],
    "stats": {
      "cpu": {
        "count": 4,
        "load": [
          {
            "usage": 1.02,
            "idle": 98.98
          },
          {
            "usage": 1.98,
            "idle": 98.02
          },
          {
            "usage": 1.03,
            "idle": 98.97
          },
          {
            "usage": 1,
            "idle": 99
          }
        ]
      },
      "jobs": {
        "count": 0
      }
    }
  }
]
```