### PR TITLE
fix: validation http codes

### DIFF
--- a/src/lib/http/middleware/error-handler.ts
+++ b/src/lib/http/middleware/error-handler.ts
@@ -14,7 +14,7 @@ export const errorHandlerMw = async (ctx: Context, next: Next) => {
 			ctx.body = {
 				error: {
 					message: error.expose ? error.message : createHttpError(error.status).message,
-					type: 'api_error',
+					type: error['type'] as string ?? 'api_error',
 				},
 			};
 

--- a/src/lib/http/middleware/validate.ts
+++ b/src/lib/http/middleware/validate.ts
@@ -7,7 +7,7 @@ export const validate = (schema: Schema) => async (ctx: Context, next: Next) => 
 	if (valid.error) {
 		const fields = valid.error.details.map(field => ([field.path.join('.'), String(field?.message)]));
 
-		ctx.status = 422;
+		ctx.status = 400;
 		ctx.body = {
 			error: {
 				message: 'Validation Failed',

--- a/src/lib/http/middleware/validate.ts
+++ b/src/lib/http/middleware/validate.ts
@@ -11,7 +11,7 @@ export const validate = (schema: Schema) => async (ctx: Context, next: Next) => 
 		ctx.body = {
 			error: {
 				message: 'Validation Failed',
-				type: 'invalid_request_error',
+				type: 'validation_error',
 				params: Object.fromEntries(fields) as never,
 			},
 		};

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -35,7 +35,7 @@ export class MeasurementRunner {
 		const probes = await this.router.findMatchingProbes(request.locations, request.limit);
 
 		if (probes.length === 0) {
-			throw createHttpError(400, 'No suitable probes found');
+			throw createHttpError(422, 'No suitable probes found');
 		}
 
 		const measurement: NetworkTest = {

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -45,13 +45,13 @@ export class MeasurementRunner {
 		};
 
 		const id = await this.store.createMeasurement(measurement, probes.length);
-		const config: MeasurementConfig = {id, probes, measurementOptions: measurement};
+		const measurementConfig: MeasurementConfig = {id, probes, measurementOptions: measurement};
 
-		this.sendToProbes(config);
-		this.setTimeout(config.id);
+		this.sendToProbes(measurementConfig);
+		this.setTimeout(measurementConfig.id);
 		this.metrics.recordMeasurement(request.type);
 
-		return config;
+		return measurementConfig;
 	}
 
 	async addProbe(measurementId: string, resultId: string, probe: Probe): Promise<void> {
@@ -79,11 +79,11 @@ export class MeasurementRunner {
 		}
 	}
 
-	private sendToProbes(config: MeasurementConfig) {
-		for (const probe of config.probes) {
+	private sendToProbes(measurementConfig: MeasurementConfig) {
+		for (const probe of measurementConfig.probes) {
 			this.io.of('probes').to(probe.client).emit('probe:measurement:request', {
-				id: config.id,
-				measurement: config.measurementOptions,
+				id: measurementConfig.id,
+				measurement: measurementConfig.measurementOptions,
 			});
 		}
 	}

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -35,7 +35,7 @@ export class MeasurementRunner {
 		const probes = await this.router.findMatchingProbes(request.locations, request.limit);
 
 		if (probes.length === 0) {
-			throw createHttpError(422, 'No suitable probes found');
+			throw createHttpError(422, 'No suitable probes found', {type: 'no_probes_found'});
 		}
 
 		const measurement: NetworkTest = {

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -27,7 +27,7 @@ describe('Create measurement', function () {
 					},
 					limit: 2,
 				})
-				.expect(400)
+				.expect(422)
 				.expect(response => {
 					expect(response.body).to.deep.equal({
 						error: {

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -32,7 +32,7 @@ describe('Create measurement', function () {
 					expect(response.body).to.deep.equal({
 						error: {
 							message: 'No suitable probes found',
-							type: 'api_error',
+							type: 'no_probes_found',
 						},
 					});
 				});

--- a/test/tests/unit/middleware/validate.test.ts
+++ b/test/tests/unit/middleware/validate.test.ts
@@ -30,7 +30,7 @@ describe('Validate middleware', () => {
 
 		expect(nextMock.notCalled).to.be.true;
 
-		expect(ctx.status).to.equal(422);
+		expect(ctx.status).to.equal(400);
 		expect(ctx.body).to.deep.equal({
 			error: {
 				message: 'Validation Failed',

--- a/test/tests/unit/middleware/validate.test.ts
+++ b/test/tests/unit/middleware/validate.test.ts
@@ -34,7 +34,7 @@ describe('Validate middleware', () => {
 		expect(ctx.body).to.deep.equal({
 			error: {
 				message: 'Validation Failed',
-				type: 'invalid_request_error',
+				type: 'validation_error',
 				params: {hello: '"hello" must be [world!]'},
 			},
 		});


### PR DESCRIPTION
Updated /POST "measurement" validation error to send 400, like on other endpoints.
Updated "No suitable probes found" error code to 422. It is annoying to get 400 both for validation and no probes during usage/dev/test.

Fixes #208 