### PR TITLE
Add 200ms cache to fetchSockets method

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "scripts": {
     "build": "tsc && npm run blacklist",
-    "start": "NODE_ENV=production node --experimental-loader newrelic/esm-loader.mjs dist/index.js",
+    "start": "NODE_ENV=production node --max_old_space_size=6656 --max-semi-space-size=128 --experimental-loader newrelic/esm-loader.mjs dist/index.js",
     "dev": "NODE_ENV=development FAKE_PROBE_IP=1 NEW_RELIC_ENABLED=false node dist/index.js",
     "dev:tsx": "NODE_ENV=development FAKE_PROBE_IP=1 NEW_RELIC_ENABLED=false tsx src/index.ts",
     "lint": "xo",

--- a/src/probe/route/get-probes.ts
+++ b/src/probe/route/get-probes.ts
@@ -2,16 +2,13 @@ import type {DefaultContext, DefaultState, ParameterizedContext} from 'koa';
 import type Router from '@koa/router';
 import type {RemoteSocket} from 'socket.io';
 import type {DefaultEventsMap} from 'socket.io/dist/typed-events';
-import type {SocketData} from '../../lib/ws/server.js';
-import {getWsServer, PROBES_NAMESPACE} from '../../lib/ws/server.js';
+import {fetchSockets, SocketData} from '../../lib/ws/server.js';
 
 type Socket = RemoteSocket<DefaultEventsMap, SocketData>;
 
-const io = getWsServer();
-
 const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & Router.RouterParamContext>): Promise<void> => {
 	const {isAdmin} = ctx;
-	const socketList: Socket[] = await io.of(PROBES_NAMESPACE).fetchSockets();
+	const socketList = await fetchSockets();
 
 	ctx.body = socketList.map((socket: Socket) => ({
 		version: socket.data.probe.version,

--- a/src/probe/router.ts
+++ b/src/probe/router.ts
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import config from 'config';
 import type {RemoteSocket} from 'socket.io';
 import type {DefaultEventsMap} from 'socket.io/dist/typed-events';
-import type {SocketData, WsServer} from '../lib/ws/server.js';
-import {getWsServer, PROBES_NAMESPACE} from '../lib/ws/server.js';
+import type {SocketData} from '../lib/ws/server.js';
+import {fetchSockets} from '../lib/ws/server.js';
 import type {LocationWithLimit} from '../measurement/types.js';
 import type {Location} from '../lib/location/types.js';
 import type {Probe, ProbeLocation} from './types.js';
@@ -24,7 +24,7 @@ const locationKeyMap = [
 
 export class ProbeRouter {
 	constructor(
-		private readonly io: WsServer,
+		private readonly fetchWsSockets: typeof fetchSockets,
 	) {}
 
 	async findMatchingProbes(
@@ -44,7 +44,7 @@ export class ProbeRouter {
 	}
 
 	private async fetchSockets(): Promise<Socket[]> {
-		const sockets = await this.io.of(PROBES_NAMESPACE).fetchSockets();
+		const sockets = await this.fetchWsSockets();
 		return sockets.filter(s => s.data.probe.ready);
 	}
 
@@ -153,7 +153,7 @@ let router: ProbeRouter;
 
 export const getProbeRouter = () => {
 	if (!router) {
-		router = new ProbeRouter(getWsServer());
+		router = new ProbeRouter(fetchSockets);
 	}
 
 	return router;

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -1,6 +1,7 @@
 import type {Server} from 'node:http';
 import {expect} from 'chai';
 import request, {SuperTest, Test} from 'supertest';
+
 import {getTestServer} from '../../../utils/http.js';
 import {addFakeProbe, deleteFakeProbe} from '../../../utils/ws.js';
 

--- a/test/utils/http.ts
+++ b/test/utils/http.ts
@@ -1,4 +1,6 @@
 import type {Server} from 'node:http';
+import _ from 'lodash';
+
 import {createServer} from '../../src/lib/server.js';
 import {
 	populateIpList,
@@ -8,6 +10,8 @@ import {
 let app: Server;
 
 export const getTestServer = async (): Promise<Server> => {
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	_.throttle = ((func: Function) => func) as unknown as typeof _.throttle;
 	await populateIpList();
 	await populateDomainList();
 


### PR DESCRIPTION
- fixes https://github.com/jsdelivr/globalping/issues/244
- adds node memory limits according to our current server set up.