### PR TITLE
Cache whitelist ips in memory

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -4,13 +4,15 @@ import {initWsServer} from './ws/server.js';
 import {getMetricsAgent} from './metrics.js';
 import {populateMemList as populateMemMalwareList} from './malware/client.js';
 import {populateMemList as populateMemIpRangesList} from './ip-ranges.js';
+import {populateMemList as populateIpWhiteList} from './geoip/whitelist.js';
 
 export const createServer = async (): Promise<Server> => {
-	// Populate memory malware list before opening HTTP server
+	// Populate memory malware list
 	await populateMemMalwareList();
-
-	// Populate memory cloud regions list before opening HTTP server
+	// Populate memory cloud regions list
 	await populateMemIpRangesList();
+	// Populate ip whiltelist
+	await populateIpWhiteList();
 
 	await initRedis();
 	await initWsServer();


### PR DESCRIPTION
Currently API is reading 'whitelist-ips.txt' file on every connection of probe. In the PR we are caching content in a JS Set.