### PR TITLE
docs: remove trailing "/" in urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you're building something custom  or simply want to learn more about all the 
 It's as simple as: 
 
 ```
-POST https://api.globalping.io/v1/measurements/
+POST https://api.globalping.io/v1/measurements
 {
     "limit": 10,
     "locations": [],

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Open endpoints require no Authentication.
 
 ### measurement
 
-- [post measurement](measurement/post-create.md): `POST /v1/measurements/`
+- [post measurement](measurement/post-create.md): `POST /v1/measurements`
 - [get measurement](measurement/get.md): `GET /v1/measurements/:id`
 
 ### schemas

--- a/docs/measurement/post-create.md
+++ b/docs/measurement/post-create.md
@@ -46,7 +46,7 @@ below is presented a schema containing all possible input values; some are gener
 ```
 example:
 ```json
-POST https://api.globalping.io/v1/measurements/
+POST https://api.globalping.io/v1/measurements
 {
     "target": "jsdelivr.com",
     "type": "ping"
@@ -79,7 +79,7 @@ for `Locations` schema, please see [LOCATION SCHEMA](./schema/location.md).
 ### example
 
 ```json
-POST https://api.globalping.io/v1/measurements/
+POST https://api.globalping.io/v1/measurements
 {
     "id": "PY5fMsREMmIq45VR",
     "probesCount": 1,

--- a/docs/measurement/schema/response.md
+++ b/docs/measurement/schema/response.md
@@ -19,7 +19,7 @@ Jump to:
 
 **type**: `string`
 
-Measurement Id number, obtained from [`POST /v1/measurements/`](../post-create.md) request.
+Measurement Id number, obtained from [`POST /v1/measurements`](../post-create.md) request.
 
 #### type
 

--- a/docs/probes/get.md
+++ b/docs/probes/get.md
@@ -39,7 +39,7 @@ Get list of all probes currently online and connected to the API server.
 ### example
 
 ```json
-GET https://api.globalping.io/v1/probes/
+GET https://api.globalping.io/v1/probes
 [
     {
         "version": "0.10.1",


### PR DESCRIPTION
Some urls in the docs have a "/" at the end when it shouldn't and therefore it doesn't work.