### PR TITLE
docs: fix link in docs to the right file

### DIFF
--- a/docs/measurement/get.md
+++ b/docs/measurement/get.md
@@ -17,7 +17,7 @@ Get the current state of the measurement.
 
 **status code**: `200 OK`
 
-**content**: response will contain results from all requested probes, alongside some basic metadata of the request. For more detailed schema description, please follow the guide on [MEASUREMENT RESPONSE SCHEMA](./schema/measurement-response.md)
+**content**: response will contain results from all requested probes, alongside some basic metadata of the request. For more detailed schema description, please follow the guide on [MEASUREMENT RESPONSE SCHEMA](./schema/response.md)
 
 ### schema
 


### PR DESCRIPTION
In the docs there is a link to a wrong filename. Edited to point to the right file.