### PR TITLE
feat: esm mocking

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -7,7 +7,8 @@
   ],
   "node-option": [
     "experimental-specifier-resolution=node",
-    "loader=tsx"
+    "loader=ts-node/esm",
+    "loader=testdouble"
   ],
   "globals": ["__extends", "__assign", "__rest", "__decorate", "__param", "__metadata", "__awaiter", "__generator", "__exportStar", "__createBinding", "__values", "__read", "__spread", "__spreadArrays", "__spreadArray", "__await", "__asyncGenerator", "__asyncDelegator", "__asyncValues", "__makeTemplateObject", "__importStar", "__importDefault", "__classPrivateFieldGet", "__classPrivateFieldSet"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "request-ip": "^3.3.0",
         "semver": "^7.3.8",
         "socket.io": "^4.5.4",
+        "testdouble": "^3.16.8",
+        "ts-node": "^10.9.1",
         "validator": "^13.7.0",
         "winston": "^3.8.2"
       },
@@ -1239,6 +1241,26 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
@@ -1515,7 +1537,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1544,8 +1565,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -3101,6 +3121,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
     "node_modules/@tsconfig/node18-strictest-esm": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18-strictest-esm/-/node18-strictest-esm-1.0.1.tgz",
@@ -3772,7 +3812,6 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
       "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3803,7 +3842,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4081,6 +4119,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -6308,6 +6351,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -10409,7 +10457,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
       "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -10660,7 +10707,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10707,6 +10753,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-relative": {
@@ -11935,6 +11989,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
@@ -14849,8 +14908,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.1",
@@ -15318,6 +15376,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quibble": {
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
+      "integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -15808,7 +15879,6 @@
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
       "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
@@ -16535,6 +16605,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -16783,7 +16865,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -16999,6 +17080,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/testdouble": {
+      "version": "3.16.8",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.8.tgz",
+      "integrity": "sha512-jOKYRJ9mfgDxwuUOj84sl9DWiP1+KpHcgnhjlSHC8h1ZxJT3KD1FAAFVqnqmmyrzc/+0DRbI/U5xo1/K3PLi8w==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.14",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -17042,6 +17137,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA=="
     },
     "node_modules/thrift": {
       "version": "0.14.2",
@@ -17240,6 +17340,56 @@
       "integrity": "sha512-aMzrGUIA/R2LwUgvsOusx+GTy8ERyNjpBzbWgS1Qx4oTFlXCMxY3PyyXbPE1pvrvK/CXpO+BBREEqrTkNroC+A==",
       "dev": true
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -17369,7 +17519,6 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17737,6 +17886,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -19521,6 +19675,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -20692,6 +20854,25 @@
         "node-gyp-build": "^4.4.0"
       }
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@dabh/diagnostics": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
@@ -20916,8 +21097,7 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -20940,8 +21120,7 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -22197,6 +22376,26 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
     "@tsconfig/node18-strictest-esm": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18-strictest-esm/-/node18-strictest-esm-1.0.1.tgz",
@@ -22864,8 +23063,7 @@
     "acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -22885,8 +23083,7 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -23112,6 +23309,11 @@
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -24832,6 +25034,11 @@
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -27802,7 +28009,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
       "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -27975,8 +28181,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
     },
     "is-plain-object": {
       "version": "5.0.0",
@@ -28011,6 +28216,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA=="
     },
     "is-relative": {
       "version": "1.0.0",
@@ -28990,6 +29200,11 @@
           "dev": true
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "make-fetch-happen": {
       "version": "9.1.0",
@@ -31190,8 +31405,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "6.2.1",
@@ -31540,6 +31754,15 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quibble": {
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
+      "integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      }
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -31922,7 +32145,6 @@
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
       "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
@@ -32487,6 +32709,15 @@
         "es-abstract": "^1.20.4"
       }
     },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -32679,8 +32910,7 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "taketalk": {
       "version": "1.0.0",
@@ -32838,6 +33068,17 @@
         "minimatch": "^3.0.4"
       }
     },
+    "testdouble": {
+      "version": "3.16.8",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.8.tgz",
+      "integrity": "sha512-jOKYRJ9mfgDxwuUOj84sl9DWiP1+KpHcgnhjlSHC8h1ZxJT3KD1FAAFVqnqmmyrzc/+0DRbI/U5xo1/K3PLi8w==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.14",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      }
+    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -32872,6 +33113,11 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA=="
     },
     "thrift": {
       "version": "0.14.2",
@@ -33040,6 +33286,33 @@
       "integrity": "sha512-aMzrGUIA/R2LwUgvsOusx+GTy8ERyNjpBzbWgS1Qx4oTFlXCMxY3PyyXbPE1pvrvK/CXpO+BBREEqrTkNroC+A==",
       "dev": true
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -33141,8 +33414,7 @@
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "uid2": {
       "version": "1.0.0",
@@ -33427,6 +33699,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -34625,6 +34902,11 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.3.2.tgz",
       "integrity": "sha512-RXRJzMiK6U2ye0BlGGZnmpwJDPgakn6aNQ0A7gHRbD4I0uvK4TW6UqkK1V0pp9jskjJBAXd3dRrbzWkqJ+6cxA=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "request-ip": "^3.3.0",
     "semver": "^7.3.8",
     "socket.io": "^4.5.4",
+    "testdouble": "^3.16.8",
+    "ts-node": "^10.9.1",
     "validator": "^13.7.0",
     "winston": "^3.8.2"
   },

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -76,7 +76,7 @@ export const buildProbe = async (socket: Socket): Promise<Probe> => {
 		tags.filter(tag => tag.type === 'system').map(tag => tag.value),
 		location.normalizedNetwork,
 		getNetworkAliases(location.normalizedNetwork),
-	].flat().filter(Boolean).map(s => s.toLowerCase().replace('-', ' '));
+	].flat().filter(Boolean).map(s => s.toLowerCase().replaceAll('-', ' '));
 
 	// Todo: add validation and handle missing or partial data
 	return {

--- a/test/tests/unit/probe/router.test.ts
+++ b/test/tests/unit/probe/router.test.ts
@@ -1,631 +1,661 @@
-/* eslint-disable max-nested-callbacks */
 import * as sinon from 'sinon';
 import _ from 'lodash';
 import {expect} from 'chai';
 import {type RemoteSocket} from 'socket.io';
+import * as td from 'testdouble';
 import type {DefaultEventsMap} from 'socket.io/dist/typed-events.js';
+
 import {ProbeRouter} from '../../../../src/probe/router.js';
-import {type SocketData} from '../../../../src/lib/ws/server.js';
+import type {SocketData} from '../../../../src/lib/ws/server.js';
 import type {DeepPartial} from '../../../types.js';
-import type {ProbeLocation, Tag} from '../../../../src/probe/types.js';
+import type {Probe, ProbeLocation} from '../../../../src/probe/types.js';
 import type {Location} from '../../../../src/lib/location/types.js';
-import {
-	getCountryAliases,
-	getCountryByIso,
-	getCountryIso3ByIso2,
-	getNetworkAliases,
-	getRegionByCountry,
-	getStateNameByIso,
-} from '../../../../src/lib/location/location.js';
+import {getRegionByCountry,} from '../../../../src/lib/location/location.js';
 
 type Socket = RemoteSocket<DefaultEventsMap, SocketData>;
 
-const buildLocationIndexes = (location: Partial<ProbeLocation>, tags: Tag[] = []) => [
-	...Object.entries(location)
-		.filter(([key, value]) => value && !['asn', 'latitude', 'longitude'].includes(key))
-		.map(entries => String(entries[1])),
-	...(location.asn ? [`as${location.asn}`] : []),
-	...(location.state ? [getStateNameByIso(location.state)] : []),
-	...(location.country ? [
-		getCountryByIso(location.country),
-		getCountryIso3ByIso2(location.country),
-		getCountryAliases(location.country),
-	] : []),
-	tags.filter(tag => tag.type === 'system').map(tag => tag.value),
-	...(location.network ? [getNetworkAliases(location.network)] : []),
-].flat().filter(Boolean).map(s => s.toLowerCase().replace('-', ' '));
-
-const buildSocket = (
-	id: string,
-	location: Partial<ProbeLocation>,
-	index: string[] = buildLocationIndexes(location),
-	ready = true,
-	tags: Tag[] = [],
-): DeepPartial<Socket> => ({
-	id,
-	data: {
-		probe: {
-			ready,
-			location,
-			index,
-			tags,
-		},
-	},
-});
+const defaultLocation = {
+  continent: '',
+  country: 'PL',
+  state: undefined,
+  city: '',
+  region: '',
+  normalizedRegion: '',
+  normalizedCity: '',
+  asn: 43_939,
+  latitude: 50.0787,
+  longitude: 19.874,
+  network: '',
+  normalizedNetwork: '',
+};
 
 describe('probe router', () => {
-	const sandbox = sinon.createSandbox();
-	const fetchSocketsMock = sinon.stub();
-	const router = new ProbeRouter(fetchSocketsMock);
-
-	beforeEach(() => {
-		sandbox.reset();
-	});
-
-	afterEach(() => {
-		fetchSocketsMock.reset();
-	});
-
-	describe('route with location limit', () => {
-		it('should find probes for each location', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
-				buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-3', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-4', {continent: 'NA', country: 'UA'}),
-				buildSocket('socket-5', {continent: 'EU', country: 'PL'}),
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([
-				{country: 'UA', limit: 2},
-				{country: 'PL', limit: 2},
-			]);
-
-			expect(fetchSocketsMock.calledOnce).to.be.true;
-			expect(fetchSocketsMock.firstCall.args).to.deep.equal([]);
-
-			expect(probes.length).to.equal(4);
-			expect(probes.filter(p => p.location.country === 'UA').length).to.equal(2);
-			expect(probes.filter(p => p.location.country === 'PL').length).to.equal(2);
-		});
-
-		it('should return 1 probe if location limit is not set', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
-				buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-3', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-4', {continent: 'NA', country: 'UA'}),
-				buildSocket('socket-5', {continent: 'EU', country: 'PL'}),
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([
-				{country: 'UA', limit: 2},
-				{country: 'PL'},
-			]);
-
-			expect(fetchSocketsMock.calledOnce).to.be.true;
-			expect(fetchSocketsMock.firstCall.args).to.deep.equal([]);
-
-			expect(probes.length).to.equal(3);
-			expect(probes.filter(p => p.location.country === 'UA').length).to.equal(2);
-			expect(probes.filter(p => p.location.country === 'PL').length).to.equal(1);
-		});
-
-		it('should shuffle result probes', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
-				buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-3', {continent: 'EU', country: 'LV'}),
-				buildSocket('socket-4', {continent: 'EU', country: 'LT'}),
-				buildSocket('socket-5', {continent: 'EU', country: 'DE'}),
-				buildSocket('socket-6', {continent: 'EU', country: 'AT'}),
-				buildSocket('socket-7', {continent: 'EU', country: 'BE'}),
-				buildSocket('socket-8', {continent: 'EU', country: 'BG'}),
-				buildSocket('socket-9', {continent: 'EU', country: 'CZ'}),
-				buildSocket('socket-10', {continent: 'EU', country: 'FR'}),
-			];
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes1 = await router.findMatchingProbes([
-				{continent: 'EU', limit: 10},
-			]);
-			const probes2 = await router.findMatchingProbes([
-				{continent: 'EU', limit: 10},
-			]);
-
-			expect(fetchSocketsMock.calledTwice).to.be.true;
-			expect(probes1.length).to.equal(10);
-			expect(probes2.length).to.equal(10);
-			const countries1 = probes1.map(probe => probe.location.country);
-			const countries2 = probes2.map(probe => probe.location.country);
-			expect(countries1).to.not.deep.equal(countries2);
-		});
-	});
-
-	describe('probe readiness', () => {
-		it('should find 2 probes', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-1', {continent: 'EU', country: 'GB'}, [], false),
-				buildSocket('socket-2', {continent: 'EU', country: 'PL'}, [], false),
-				buildSocket('socket-4', {continent: 'EU', country: 'GB'}),
-				buildSocket('socket-5', {continent: 'EU', country: 'PL'}),
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([
-				{country: 'GB', limit: 2},
-				{country: 'PL', limit: 2},
-			]);
-
-			expect(fetchSocketsMock.calledOnce).to.be.true;
-			expect(fetchSocketsMock.firstCall.args).to.deep.equal([]);
-
-			expect(probes.length).to.equal(2);
-			expect(probes.filter(p => p.location.country === 'GB').length).to.equal(1);
-			expect(probes.filter(p => p.location.country === 'PL').length).to.equal(1);
-		});
-	});
-
-	describe('route globally distributed', () => {
-		type Socket = RemoteSocket<DefaultEventsMap, SocketData>;
-
-		it('should find probes when each group is full', async () => {
-			const sockets = ['AF', 'AS', 'EU', 'OC', 'NA', 'SA']
-				.flatMap(continent => _.range(50).map(i => buildSocket(`${continent}-${i}`, {continent})));
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([], 100);
-			const grouped = _.groupBy(probes, 'location.continent');
-
-			expect(probes.length).to.equal(100);
-			expect(grouped['AF']?.length).to.equal(5);
-			expect(grouped['AS']?.length).to.equal(15);
-			expect(grouped['EU']?.length).to.equal(30);
-			expect(grouped['OC']?.length).to.equal(10);
-			expect(grouped['NA']?.length).to.equal(30);
-			expect(grouped['SA']?.length).to.equal(10);
-		});
-
-		it('should find probes when some groups are not full', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				...(_.range(15).map(i => buildSocket(`AF-${i}`, {continent: 'AF'}))),
-				...(_.range(15).map(i => buildSocket(`AS-${i}`, {continent: 'AS'}))),
-				...(_.range(20).map(i => buildSocket(`EU-${i}`, {continent: 'EU'}))),
-				...(_.range(10).map(i => buildSocket(`OC-${i}`, {continent: 'OC'}))),
-				...(_.range(20).map(i => buildSocket(`NA-${i}`, {continent: 'NA'}))),
-				...(_.range(30).map(i => buildSocket(`SA-${i}`, {continent: 'SA'}))),
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([], 100);
-			const grouped = _.groupBy(probes, 'location.continent');
-
-			expect(probes.length).to.equal(100);
-			expect(grouped['AF']?.length).to.equal(13);
-			expect(grouped['AS']?.length).to.equal(15);
-			expect(grouped['EU']?.length).to.equal(20);
-			expect(grouped['OC']?.length).to.equal(10);
-			expect(grouped['NA']?.length).to.equal(20);
-			expect(grouped['SA']?.length).to.equal(22);
-		});
-
-		it('should find when probes not enough', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				...(_.range(15).map(i => buildSocket(`AF-${i}`, {continent: 'AF'}))),
-				...(_.range(20).map(i => buildSocket(`EU-${i}`, {continent: 'EU'}))),
-				...(_.range(10).map(i => buildSocket(`OC-${i}`, {continent: 'OC'}))),
-				...(_.range(20).map(i => buildSocket(`NA-${i}`, {continent: 'NA'}))),
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([], 100);
-			const grouped = _.groupBy(probes, 'location.continent');
-
-			expect(probes.length).to.equal(65);
-			expect(grouped['AF']?.length).to.equal(15);
-			expect(grouped['EU']?.length).to.equal(20);
-			expect(grouped['OC']?.length).to.equal(10);
-			expect(grouped['NA']?.length).to.equal(20);
-		});
-
-		it('should shuffle result probes', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
-				buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-3', {continent: 'EU', country: 'LV'}),
-				buildSocket('socket-4', {continent: 'EU', country: 'LT'}),
-				buildSocket('socket-5', {continent: 'EU', country: 'DE'}),
-				buildSocket('socket-6', {continent: 'EU', country: 'AT'}),
-				buildSocket('socket-7', {continent: 'EU', country: 'BE'}),
-				buildSocket('socket-8', {continent: 'EU', country: 'BG'}),
-				buildSocket('socket-9', {continent: 'EU', country: 'CZ'}),
-				buildSocket('socket-10', {continent: 'EU', country: 'FR'}),
-			];
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes1 = await router.findMatchingProbes([], 100);
-			const probes2 = await router.findMatchingProbes([], 100);
-
-			expect(fetchSocketsMock.calledTwice).to.be.true;
-			expect(probes1.length).to.equal(10);
-			expect(probes2.length).to.equal(10);
-			const countries1 = probes1.map(probe => probe.location.country);
-			const countries2 = probes2.map(probe => probe.location.country);
-			expect(countries1).to.not.deep.equal(countries2);
-		});
-	});
-
-	describe('route with global limit', () => {
-		it('should find probes even in overlapping locations', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				...(_.range(10_000).map(i => buildSocket(`PL-${i}`, {continent: 'EU', country: 'PL'}))),
-				...(_.range(1).map(i => buildSocket(`UA-${i}`, {continent: 'EU', country: 'UA'}))),
-			];
-			const locations: Location[] = [
-				{continent: 'EU'},
-				{country: 'UA'},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-			const grouped = _.groupBy(probes, 'location.country');
-
-			expect(probes.length).to.equal(100);
-			expect(grouped['PL']?.length).to.equal(99);
-			expect(grouped['UA']?.length).to.equal(1);
-		});
-
-		it('should evenly distribute probes', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				...(_.range(100).map(i => buildSocket(`PL-${i}`, {country: 'PL'}))),
-				...(_.range(100).map(i => buildSocket(`UA-${i}`, {country: 'UA'}))),
-				...(_.range(100).map(i => buildSocket(`NL-${i}`, {country: 'NL'}))),
-			];
-			const locations: Location[] = [
-				{country: 'PL'},
-				{country: 'UA'},
-				{country: 'NL'},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-			const grouped = _.groupBy(probes, 'location.country');
-
-			expect(probes.length).to.equal(100);
-			expect(grouped['PL']?.length).to.equal(34);
-			expect(grouped['UA']?.length).to.equal(33);
-			expect(grouped['NL']?.length).to.equal(33);
-		});
-
-		it('should shuffle result probes', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
-				buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
-				buildSocket('socket-3', {continent: 'EU', country: 'LV'}),
-				buildSocket('socket-4', {continent: 'EU', country: 'LT'}),
-				buildSocket('socket-5', {continent: 'EU', country: 'DE'}),
-				buildSocket('socket-6', {continent: 'EU', country: 'AT'}),
-				buildSocket('socket-7', {continent: 'EU', country: 'BE'}),
-				buildSocket('socket-8', {continent: 'EU', country: 'BG'}),
-				buildSocket('socket-9', {continent: 'EU', country: 'CZ'}),
-				buildSocket('socket-10', {continent: 'EU', country: 'FR'}),
-			];
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes1 = await router.findMatchingProbes([
-				{continent: 'EU'},
-			], 100);
-			const probes2 = await router.findMatchingProbes([
-				{continent: 'EU'},
-			], 100);
-
-			expect(fetchSocketsMock.calledTwice).to.be.true;
-			expect(probes1.length).to.equal(10);
-			expect(probes2.length).to.equal(10);
-			const countries1 = probes1.map(probe => probe.location.country);
-			const countries2 = probes2.map(probe => probe.location.country);
-			expect(countries1).to.not.deep.equal(countries2);
-		});
-	});
-
-	describe('normalized fields', () => {
-		const location = {
-			continent: 'NA',
-			region: getRegionByCountry('US'),
-			country: 'US',
-			state: 'NY',
-			city: 'The New York City',
-			normalizedCity: 'new york',
-			asn: 5089,
-			network: 'abc',
-		};
-
-		it('should find probe by normalizedCity value', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				buildSocket(String(Date.now), location),
-			];
-
-			const locations: Location[] = [
-				{city: 'new york'},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-
-			expect(probes.length).to.equal(1);
-			expect(probes[0]!.location.country).to.equal('US');
-		});
-	});
-
-	describe('route with magic location', () => {
-		const location = {
-			continent: 'EU',
-			region: getRegionByCountry('GB'),
-			country: 'GB',
-			state: undefined,
-			city: 'london',
-			asn: 5089,
-			network: 'a-virgin media',
-		};
-
-		it('should return match (country alias)', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				buildSocket(String(Date.now()), location),
-			];
-
-			const locations: Location[] = [
-				{magic: 'england'},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-
-			expect(probes.length).to.equal(1);
-			expect(probes[0]!.location.country).to.equal('GB');
-		});
-
-		it('should return match (magic nested)', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				buildSocket(String(Date.now()), location),
-			];
-
-			const locations: Location[] = [
-				{magic: 'england+as5089'},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-
-			expect(probes.length).to.equal(1);
-			expect(probes[0]!.location.country).to.equal('GB');
-		});
-
-		it('should return result sorted by priority of magic fields', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-3', {country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-2', {country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-1', {country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-			];
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes([
-				{magic: 'de'},
-			], 100);
-
-			expect(fetchSocketsMock.calledOnce).to.be.true;
-			expect(probes.length).to.equal(3);
-			expect(probes[0].location.country).to.equal('DE');
-			expect(probes[1].location.country).to.equal('RS');
-			expect(probes[2].location.country).to.equal('PL');
-		});
-
-		it('should shuffle result considering priority of magic fields', async () => {
-			const sockets: Array<DeepPartial<Socket>> = [
-				buildSocket('socket-3', {city: 'city1', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city2', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city3', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city4', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city5', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city6', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city7', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city8', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city9', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-3', {city: 'city10', country: 'PL'}, ['pl', 'warsaw', 'ultra development networks']),
-				buildSocket('socket-2', {city: 'city1', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city2', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city3', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city4', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city5', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city6', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city7', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city8', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city9', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-2', {city: 'city10', country: 'RS'}, ['rs', 'belgrade', 'belgrade networks']),
-				buildSocket('socket-1', {city: 'city1', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city2', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city3', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city4', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city5', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city6', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city7', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city8', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city9', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-				buildSocket('socket-1', {city: 'city10', country: 'DE'}, ['de', 'berlin', 'berlin networks']),
-			];
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes1 = await router.findMatchingProbes([
-				{magic: 'de'},
-			], 100);
-			const probes2 = await router.findMatchingProbes([
-				{magic: 'de'},
-			], 100);
-
-			expect(fetchSocketsMock.calledTwice).to.be.true;
-			expect(probes1.length).to.equal(30);
-			expect(probes2.length).to.equal(30);
-			expect(probes1.slice(0, 9).every(probe => probe.location.country === 'DE')).to.be.true;
-			expect(probes2.slice(0, 9).every(probe => probe.location.country === 'DE')).to.be.true;
-			expect(probes1.slice(0, 9).map(probe => probe.location.city)).to.not.deep.equal(probes2.slice(0, 9).map(probe => probe.location.city));
-			expect(probes1.slice(10, 19).every(probe => probe.location.country === 'RS')).to.be.true;
-			expect(probes1.slice(10, 19).every(probe => probe.location.country === 'RS')).to.be.true;
-			expect(probes1.slice(10, 19).map(probe => probe.location.city)).to.not.deep.equal(probes2.slice(0, 9).map(probe => probe.location.city));
-			expect(probes1.slice(20, 29).every(probe => probe.location.country === 'PL')).to.be.true;
-			expect(probes1.slice(20, 29).every(probe => probe.location.country === 'PL')).to.be.true;
-			expect(probes1.slice(20, 29).map(probe => probe.location.city)).to.not.deep.equal(probes2.slice(0, 9).map(probe => probe.location.city));
-		});
-
-		describe('Location type - Network', () => {
-			for (const testCase of ['a-virgin', 'virgin', 'media']) {
-				it(`should match network - ${testCase}`, async () => {
-					const sockets: DeepPartial<Socket[]> = [
-						buildSocket(String(Date.now()), location),
-					];
-
-					const locations: Location[] = [
-						{magic: testCase},
-					];
-
-					fetchSocketsMock.resolves(sockets as never);
-
-					const probes = await router.findMatchingProbes(locations, 100);
-
-					expect(probes.length).to.equal(1);
-					expect(probes[0]!.location.country).to.equal('GB');
-				});
-			}
-		});
-
-		describe('Location type - ASN', () => {
-			for (const testCase of ['5089', 'as5089']) {
-				it(`should match ASN - ${testCase}`, async () => {
-					const sockets: DeepPartial<Socket[]> = [
-						buildSocket(String(Date.now()), location),
-					];
-
-					const locations: Location[] = [
-						{magic: testCase},
-					];
-
-					fetchSocketsMock.resolves(sockets as never);
-
-					const probes = await router.findMatchingProbes(locations, 100);
-
-					expect(probes.length).to.equal(1);
-					expect(probes[0]!.location.country).to.equal('GB');
-				});
-			}
-		});
-
-		describe('Location type - State', () => {
-			for (const testCase of ['dc', 'district of columbia', 'district']) {
-				it(`should match state value - ${testCase}`, async () => {
-					const location = {
-						continent: 'NA',
-						region: getRegionByCountry('US'),
-						country: 'US',
-						state: 'DC',
-						city: 'Washington',
-						asn: 3969,
-						network: 'Google Cloud',
-					};
-
-					const sockets: DeepPartial<Socket[]> = [
-						buildSocket(String(Date.now()), location),
-					];
-
-					const locations: Location[] = [
-						{magic: testCase},
-					];
-
-					fetchSocketsMock.resolves(sockets as never);
-
-					const probes = await router.findMatchingProbes(locations, 100);
-
-					expect(probes.length).to.equal(1);
-					expect(probes[0]!.location.country).to.equal('US');
-				});
-			}
-		});
-
-		describe('Location type - tag', () => {
-			for (const testCase of ['tag-value', 'tag-v']) {
-				it(`should match tag - ${testCase}`, async () => {
-					const tags: Tag[] = [{type: 'system', value: 'tag-value'}];
-					const sockets: DeepPartial<Socket[]> = [
-						buildSocket(String(Date.now()), location, buildLocationIndexes(location, tags), true, tags),
-					];
-
-					const locations: Location[] = [
-						{magic: testCase},
-					];
-
-					fetchSocketsMock.resolves(sockets as never);
-
-					const probes = await router.findMatchingProbes(locations, 100);
-
-					expect(probes.length).to.equal(1);
-					expect(probes[0]!.location.country).to.equal('GB');
-				});
-			}
-		});
-	});
-
-	describe('route with tags location', () => {
-		const location = {
-			continent: 'EU',
-			region: getRegionByCountry('GB'),
-			country: 'GB',
-			state: undefined,
-			city: 'london',
-			asn: 5089,
-			network: 'a-virgin media',
-		};
-
-		it('should return match for existing tag', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				buildSocket(String(Date.now()), location, buildLocationIndexes(location), true, [{type: 'system', value: 'tag-value'}]),
-			];
-
-			const locations: Location[] = [
-				{tags: ['tag-value']},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-
-			expect(probes.length).to.equal(1);
-			expect(probes[0]!.location.country).to.equal('GB');
-		});
-
-		it('should return 0 matches for partial tag value', async () => {
-			const sockets: DeepPartial<Socket[]> = [
-				buildSocket(String(Date.now()), location, buildLocationIndexes(location), true, [{type: 'system', value: 'tag-value'}]),
-			];
-
-			const locations: Location[] = [
-				{tags: ['tag-v']},
-			];
-
-			fetchSocketsMock.resolves(sockets as never);
-
-			const probes = await router.findMatchingProbes(locations, 100);
-
-			expect(probes.length).to.equal(0);
-		});
-	});
+  const sandbox = sinon.createSandbox();
+  const fetchSocketsMock = sinon.stub();
+  const geoLookupMock = sinon.stub();
+  const getRegionMock = sinon.stub();
+  const router = new ProbeRouter(fetchSocketsMock);
+  let buildProbe: (socket: Socket) => Promise<Probe>;
+
+  const buildSocket = async (
+    id: string,
+    location: Partial<ProbeLocation>,
+    ready = true,
+  ) => {
+    const socket: DeepPartial<Socket> = {
+      id,
+      handshake: {
+        query: {
+          version: '0.11.0',
+        },
+      },
+      data: {},
+    };
+    geoLookupMock.resolves({...defaultLocation, ...location});
+    socket.data!.probe = {
+      ...(await buildProbe(socket as Socket)),
+      ready,
+    };
+    return socket;
+  };
+
+  before(async () => {
+    await td.replaceEsm('../../../../src/lib/geoip/client.ts', {createGeoipClient: () => ({lookup: geoLookupMock})});
+    await td.replaceEsm('request-ip', null, {getClientIp: () => '18.200.0.1'});
+    await td.replaceEsm('../../../../src/lib/ip-ranges.ts', {getRegion: getRegionMock});
+    // eslint-disable-next-line unicorn/no-await-expression-member
+    buildProbe = (await import('../../../../src/probe/builder.js')).buildProbe as unknown as (socket: Socket) => Promise<Probe>;
+  });
+
+  beforeEach(() => {
+    sandbox.reset();
+  });
+
+  afterEach(() => {
+    geoLookupMock.reset();
+    fetchSocketsMock.reset();
+    getRegionMock.reset();
+  });
+
+  after(() => {
+    td.reset();
+  });
+
+  describe('route with location limit', () => {
+    it('should find probes for each location', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
+        await buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-3', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-4', {continent: 'NA', country: 'UA'}),
+        await buildSocket('socket-5', {continent: 'EU', country: 'PL'}),
+      ];
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([
+        {country: 'UA', limit: 2},
+        {country: 'PL', limit: 2},
+      ]);
+
+      expect(fetchSocketsMock.calledOnce).to.be.true;
+      expect(fetchSocketsMock.firstCall.args).to.deep.equal([]);
+      expect(probes.length).to.equal(4);
+      expect(probes.filter(p => p.location.country === 'UA').length).to.equal(2);
+      expect(probes.filter(p => p.location.country === 'PL').length).to.equal(2);
+    });
+
+    it('should return 1 probe if location limit is not set', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
+        await buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-3', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-4', {continent: 'NA', country: 'UA'}),
+        await buildSocket('socket-5', {continent: 'EU', country: 'PL'}),
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([
+        {country: 'UA', limit: 2},
+        {country: 'PL'},
+      ]);
+
+      expect(fetchSocketsMock.calledOnce).to.be.true;
+      expect(fetchSocketsMock.firstCall.args).to.deep.equal([]);
+
+      expect(probes.length).to.equal(3);
+      expect(probes.filter(p => p.location.country === 'UA').length).to.equal(2);
+      expect(probes.filter(p => p.location.country === 'PL').length).to.equal(1);
+    });
+
+    it('should shuffle result probes', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
+        await buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-3', {continent: 'EU', country: 'LV'}),
+        await buildSocket('socket-4', {continent: 'EU', country: 'LT'}),
+        await buildSocket('socket-5', {continent: 'EU', country: 'DE'}),
+        await buildSocket('socket-6', {continent: 'EU', country: 'AT'}),
+        await buildSocket('socket-7', {continent: 'EU', country: 'BE'}),
+        await buildSocket('socket-8', {continent: 'EU', country: 'BG'}),
+        await buildSocket('socket-9', {continent: 'EU', country: 'CZ'}),
+        await buildSocket('socket-10', {continent: 'EU', country: 'FR'}),
+      ];
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes1 = await router.findMatchingProbes([
+        {continent: 'EU', limit: 10},
+      ]);
+      const probes2 = await router.findMatchingProbes([
+        {continent: 'EU', limit: 10},
+      ]);
+
+      expect(fetchSocketsMock.calledTwice).to.be.true;
+      expect(probes1.length).to.equal(10);
+      expect(probes2.length).to.equal(10);
+      const countries1 = probes1.map(probe => probe.location.country);
+      const countries2 = probes2.map(probe => probe.location.country);
+      expect(countries1).to.not.deep.equal(countries2);
+    });
+  });
+
+  describe('probe readiness', () => {
+    it('should find 2 probes', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-1', {continent: 'EU', country: 'GB'}, false),
+        await buildSocket('socket-2', {continent: 'EU', country: 'PL'}, false),
+        await buildSocket('socket-4', {continent: 'EU', country: 'GB'}),
+        await buildSocket('socket-5', {continent: 'EU', country: 'PL'}),
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([
+        {country: 'GB', limit: 2},
+        {country: 'PL', limit: 2},
+      ]);
+
+      expect(fetchSocketsMock.calledOnce).to.be.true;
+      expect(fetchSocketsMock.firstCall.args).to.deep.equal([]);
+
+      expect(probes.length).to.equal(2);
+      expect(probes.filter(p => p.location.country === 'GB').length).to.equal(1);
+      expect(probes.filter(p => p.location.country === 'PL').length).to.equal(1);
+    });
+  });
+
+  describe('route globally distributed', () => {
+    type Socket = RemoteSocket<DefaultEventsMap, SocketData>;
+
+    it('should find probes when each group is full', async () => {
+      const sockets = await Promise.all(['AF', 'AS', 'EU', 'OC', 'NA', 'SA']
+        .flatMap(continent => _.range(50).map(i => buildSocket(`${continent}-${i}`, {continent}))));
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([], 100);
+      const grouped = _.groupBy(probes, 'location.continent');
+
+      expect(probes.length).to.equal(100);
+      expect(grouped['AF']?.length).to.equal(5);
+      expect(grouped['AS']?.length).to.equal(15);
+      expect(grouped['EU']?.length).to.equal(30);
+      expect(grouped['OC']?.length).to.equal(10);
+      expect(grouped['NA']?.length).to.equal(30);
+      expect(grouped['SA']?.length).to.equal(10);
+    });
+
+    it('should find probes when some groups are not full', async () => {
+      const sockets: DeepPartial<Socket[]> = await Promise.all([
+        ...(_.range(15).map(i => buildSocket(`AF-${i}`, {continent: 'AF'}))),
+        ...(_.range(15).map(i => buildSocket(`AS-${i}`, {continent: 'AS'}))),
+        ...(_.range(20).map(i => buildSocket(`EU-${i}`, {continent: 'EU'}))),
+        ...(_.range(10).map(i => buildSocket(`OC-${i}`, {continent: 'OC'}))),
+        ...(_.range(20).map(i => buildSocket(`NA-${i}`, {continent: 'NA'}))),
+        ...(_.range(30).map(i => buildSocket(`SA-${i}`, {continent: 'SA'}))),
+      ]);
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([], 100);
+      const grouped = _.groupBy(probes, 'location.continent');
+
+      expect(probes.length).to.equal(100);
+      expect(grouped['AF']?.length).to.equal(13);
+      expect(grouped['AS']?.length).to.equal(15);
+      expect(grouped['EU']?.length).to.equal(20);
+      expect(grouped['OC']?.length).to.equal(10);
+      expect(grouped['NA']?.length).to.equal(20);
+      expect(grouped['SA']?.length).to.equal(22);
+    });
+
+    it('should find when probes not enough', async () => {
+      const sockets: DeepPartial<Socket[]> = await Promise.all([
+        ...(_.range(15).map(i => buildSocket(`AF-${i}`, {continent: 'AF'}))),
+        ...(_.range(20).map(i => buildSocket(`EU-${i}`, {continent: 'EU'}))),
+        ...(_.range(10).map(i => buildSocket(`OC-${i}`, {continent: 'OC'}))),
+        ...(_.range(20).map(i => buildSocket(`NA-${i}`, {continent: 'NA'}))),
+      ]);
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([], 100);
+      const grouped = _.groupBy(probes, 'location.continent');
+
+      expect(probes.length).to.equal(65);
+      expect(grouped['AF']?.length).to.equal(15);
+      expect(grouped['EU']?.length).to.equal(20);
+      expect(grouped['OC']?.length).to.equal(10);
+      expect(grouped['NA']?.length).to.equal(20);
+    });
+
+    it('should shuffle result probes', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
+        await buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-3', {continent: 'EU', country: 'LV'}),
+        await buildSocket('socket-4', {continent: 'EU', country: 'LT'}),
+        await buildSocket('socket-5', {continent: 'EU', country: 'DE'}),
+        await buildSocket('socket-6', {continent: 'EU', country: 'AT'}),
+        await buildSocket('socket-7', {continent: 'EU', country: 'BE'}),
+        await buildSocket('socket-8', {continent: 'EU', country: 'BG'}),
+        await buildSocket('socket-9', {continent: 'EU', country: 'CZ'}),
+        await buildSocket('socket-10', {continent: 'EU', country: 'FR'}),
+      ];
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes1 = await router.findMatchingProbes([], 100);
+      const probes2 = await router.findMatchingProbes([], 100);
+
+      expect(fetchSocketsMock.calledTwice).to.be.true;
+      expect(probes1.length).to.equal(10);
+      expect(probes2.length).to.equal(10);
+      const countries1 = probes1.map(probe => probe.location.country);
+      const countries2 = probes2.map(probe => probe.location.country);
+      expect(countries1).to.not.deep.equal(countries2);
+    });
+  });
+
+  describe('route with global limit', () => {
+    it('should find probes even in overlapping locations', async () => {
+      const cache = {};
+      const memoizedBuildSocket = async (id, location, ready?) => {
+        const cached = cache[location.country];
+        if (cached) {
+          return {...cached}
+        }
+        const socket = await buildSocket(id, location, ready);
+        cache[location.country] = socket;
+        return socket;
+      }
+
+      const euSockets = [];
+      for (const i of _.range(10_000)) {
+        const socket = await memoizedBuildSocket(`PL-${i}`, {continent: 'EU', country: 'PL'});
+        euSockets.push(socket as never);
+      }
+      const uaSocket = await buildSocket(`UA-${1}`, {continent: 'EU', country: 'UA'});
+      const sockets: DeepPartial<Socket[]> = [...euSockets, uaSocket];
+      const locations: Location[] = [
+        {continent: 'EU'},
+        {country: 'UA'},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+      const grouped = _.groupBy(probes, 'location.country');
+
+      expect(probes.length).to.equal(100);
+      expect(grouped['PL']?.length).to.equal(99);
+      expect(grouped['UA']?.length).to.equal(1);
+    });
+
+    it('should evenly distribute probes', async () => {
+      const sockets: DeepPartial<Socket[]> = await Promise.all([
+        ...(_.range(100).map(i => buildSocket(`PL-${i}`, {country: 'PL'}))),
+        ...(_.range(100).map(i => buildSocket(`UA-${i}`, {country: 'UA'}))),
+        ...(_.range(100).map(i => buildSocket(`NL-${i}`, {country: 'NL'}))),
+      ]);
+      const locations: Location[] = [
+        {country: 'PL'},
+        {country: 'UA'},
+        {country: 'NL'},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+      const grouped = _.groupBy(probes, 'location.country');
+
+      expect(probes.length).to.equal(100);
+      expect(grouped['PL']?.length).to.equal(34);
+      expect(grouped['UA']?.length).to.equal(33);
+      expect(grouped['NL']?.length).to.equal(33);
+    });
+
+    it('should shuffle result probes', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-1', {continent: 'EU', country: 'UA'}),
+        await buildSocket('socket-2', {continent: 'EU', country: 'PL'}),
+        await buildSocket('socket-3', {continent: 'EU', country: 'LV'}),
+        await buildSocket('socket-4', {continent: 'EU', country: 'LT'}),
+        await buildSocket('socket-5', {continent: 'EU', country: 'DE'}),
+        await buildSocket('socket-6', {continent: 'EU', country: 'AT'}),
+        await buildSocket('socket-7', {continent: 'EU', country: 'BE'}),
+        await buildSocket('socket-8', {continent: 'EU', country: 'BG'}),
+        await buildSocket('socket-9', {continent: 'EU', country: 'CZ'}),
+        await buildSocket('socket-10', {continent: 'EU', country: 'FR'}),
+      ];
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes1 = await router.findMatchingProbes([
+        {continent: 'EU'},
+      ], 100);
+      const probes2 = await router.findMatchingProbes([
+        {continent: 'EU'},
+      ], 100);
+
+      expect(fetchSocketsMock.calledTwice).to.be.true;
+      expect(probes1.length).to.equal(10);
+      expect(probes2.length).to.equal(10);
+      const countries1 = probes1.map(probe => probe.location.country);
+      const countries2 = probes2.map(probe => probe.location.country);
+      expect(countries1).to.not.deep.equal(countries2);
+    });
+  });
+
+  describe('normalized fields', () => {
+    const location = {
+      continent: 'NA',
+      region: getRegionByCountry('US'),
+      country: 'US',
+      state: 'NY',
+      city: 'The New York City',
+      normalizedCity: 'new york',
+      asn: 5089,
+      normalizedNetwork: 'abc',
+    };
+
+    it('should find probe by normalizedCity value', async () => {
+      const sockets: DeepPartial<Socket[]> = [
+        await buildSocket(String(Date.now), location),
+      ];
+
+      const locations: Location[] = [
+        {city: 'new york'},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+
+      expect(probes.length).to.equal(1);
+      expect(probes[0]!.location.country).to.equal('US');
+    });
+  });
+
+  describe('route with magic location', () => {
+    const location = {
+      continent: 'EU',
+      region: getRegionByCountry('GB'),
+      country: 'GB',
+      state: undefined,
+      city: 'London',
+      normalizedCity: 'london',
+      asn: 5089,
+      normalizedNetwork: 'a-virgin media',
+    };
+
+    it('should return match (country alias)', async () => {
+      const sockets: DeepPartial<Socket[]> = [
+        await buildSocket(String(Date.now()), location),
+      ];
+
+      const locations: Location[] = [
+        {magic: 'england'},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+
+      expect(probes.length).to.equal(1);
+      expect(probes[0]!.location.country).to.equal('GB');
+    });
+
+    it('should return match (magic nested)', async () => {
+      const sockets: DeepPartial<Socket[]> = [
+        await buildSocket(String(Date.now()), location),
+      ];
+
+      const locations: Location[] = [
+        {magic: 'england+as5089'},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+
+      expect(probes.length).to.equal(1);
+      expect(probes[0]!.location.country).to.equal('GB');
+    });
+
+    it('should return result sorted by priority of magic fields', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-3', {country: 'PL', normalizedCity: 'warsaw', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-2', {country: 'RS', normalizedCity: 'belgrade', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-1', {country: 'DE', normalizedCity: 'berlin', normalizedNetwork: 'berlin networks'}),
+      ];
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes([
+        {magic: 'de'},
+      ], 100);
+
+      expect(fetchSocketsMock.calledOnce).to.be.true;
+      expect(probes.length).to.equal(3);
+      expect(probes[0].location.country).to.equal('DE');
+      expect(probes[1].location.country).to.equal('RS');
+      expect(probes[2].location.country).to.equal('PL');
+    });
+
+    it('should shuffle result considering priority of magic fields', async () => {
+      const sockets: Array<DeepPartial<Socket>> = [
+        await buildSocket('socket-3', {normalizedCity: 'warsaw1', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw2', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw3', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw4', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw5', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw6', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw7', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw8', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw9', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-3', {normalizedCity: 'warsaw10', country: 'PL', normalizedNetwork: 'ultra development networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade1', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade2', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade3', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade4', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade5', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade6', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade7', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade8', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade9', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-2', {normalizedCity: 'belgrade10', country: 'RS', normalizedNetwork: 'belgrade networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin1', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin2', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin3', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin4', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin5', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin6', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin7', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin8', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin9', country: 'DE', normalizedNetwork: 'berlin networks'}),
+        await buildSocket('socket-1', {normalizedCity: 'berlin10', country: 'DE', normalizedNetwork: 'berlin networks'}),
+      ];
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes1 = await router.findMatchingProbes([
+        {magic: 'de'},
+      ], 100);
+      const probes2 = await router.findMatchingProbes([
+        {magic: 'de'},
+      ], 100);
+
+      expect(fetchSocketsMock.calledTwice).to.be.true;
+      expect(probes1.length).to.equal(30);
+      expect(probes2.length).to.equal(30);
+      expect(probes1.slice(0, 9).every(probe => probe.location.country === 'DE')).to.be.true;
+      expect(probes2.slice(0, 9).every(probe => probe.location.country === 'DE')).to.be.true;
+      expect(probes1.slice(0, 9).map(probe => probe.location.normalizedCity)).to.not.deep.equal(probes2.slice(0, 9).map(probe => probe.location.normalizedCity));
+      expect(probes1.slice(10, 19).every(probe => probe.location.country === 'RS')).to.be.true;
+      expect(probes1.slice(10, 19).every(probe => probe.location.country === 'RS')).to.be.true;
+      expect(probes1.slice(10, 19).map(probe => probe.location.normalizedCity)).to.not.deep.equal(probes2.slice(0, 9).map(probe => probe.location.normalizedCity));
+      expect(probes1.slice(20, 29).every(probe => probe.location.country === 'PL')).to.be.true;
+      expect(probes1.slice(20, 29).every(probe => probe.location.country === 'PL')).to.be.true;
+      expect(probes1.slice(20, 29).map(probe => probe.location.normalizedCity)).to.not.deep.equal(probes2.slice(0, 9).map(probe => probe.location.normalizedCity));
+    });
+
+    describe('Location type - Network', () => {
+      for (const testCase of ['a-virgin', 'virgin', 'media']) {
+        it(`should match network - ${testCase}`, async () => {
+          const sockets: DeepPartial<Socket[]> = [
+            await buildSocket(String(Date.now()), location),
+          ];
+
+          const locations: Location[] = [
+            {magic: testCase},
+          ];
+
+          fetchSocketsMock.resolves(sockets as never);
+
+          const probes = await router.findMatchingProbes(locations, 100);
+
+          expect(probes.length).to.equal(1);
+          expect(probes[0]!.location.country).to.equal('GB');
+        });
+      }
+    });
+
+    describe('Location type - ASN', () => {
+      for (const testCase of ['5089', 'as5089']) {
+        it(`should match ASN - ${testCase}`, async () => {
+          const sockets: DeepPartial<Socket[]> = [
+            await buildSocket(String(Date.now()), location),
+          ];
+
+          const locations: Location[] = [
+            {magic: testCase},
+          ];
+
+          fetchSocketsMock.resolves(sockets as never);
+
+          const probes = await router.findMatchingProbes(locations, 100);
+
+          expect(probes.length).to.equal(1);
+          expect(probes[0]!.location.country).to.equal('GB');
+        });
+      }
+    });
+
+    describe('Location type - State', () => {
+      for (const testCase of ['dc', 'district of columbia', 'district']) {
+        it(`should match state value - ${testCase}`, async () => {
+          const location = {
+            continent: 'NA',
+            region: getRegionByCountry('US'),
+            country: 'US',
+            state: 'DC',
+            city: 'Washington',
+            asn: 3969,
+            network: 'Google Cloud',
+          };
+
+          const sockets: DeepPartial<Socket[]> = [
+            await buildSocket(String(Date.now()), location),
+          ];
+
+          const locations: Location[] = [
+            {magic: testCase},
+          ];
+
+          fetchSocketsMock.resolves(sockets as never);
+
+          const probes = await router.findMatchingProbes(locations, 100);
+
+          expect(probes.length).to.equal(1);
+          expect(probes[0]!.location.country).to.equal('US');
+        });
+      }
+    });
+
+    describe('Location type - tag', () => {
+      for (const testCase of ['aws-eu', 'west 1']) {
+        it(`should match tag - ${testCase}`, async () => {
+          getRegionMock.returns('aws-eu-west-1');
+          const sockets: DeepPartial<Socket[]> = [
+            await buildSocket(String(Date.now()), location, true),
+          ];
+
+          const locations: Location[] = [
+            {magic: testCase},
+          ];
+
+          fetchSocketsMock.resolves(sockets as never);
+
+          const probes = await router.findMatchingProbes(locations, 100);
+
+          expect(probes.length).to.equal(1);
+          expect(probes[0]!.location.country).to.equal('GB');
+        });
+      }
+    });
+  });
+
+  describe('route with tags location', () => {
+    const location = {
+      continent: 'EU',
+      region: getRegionByCountry('GB'),
+      country: 'GB',
+      state: undefined,
+      city: 'london',
+      asn: 5089,
+      network: 'a-virgin media',
+    };
+
+    it('should return match for existing tag', async () => {
+      getRegionMock.returns('aws-eu-west-1');
+      const sockets: DeepPartial<Socket[]> = [
+        await buildSocket(String(Date.now()), location, true),
+      ];
+
+      const locations: Location[] = [
+        {tags: ['aws-eu-west-1']},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+
+      expect(probes.length).to.equal(1);
+      expect(probes[0]!.location.country).to.equal('GB');
+    });
+
+    it('should return 0 matches for partial tag value', async () => {
+      getRegionMock.returns('aws-eu-west-1');
+      const sockets: DeepPartial<Socket[]> = [
+        await buildSocket(String(Date.now()), location, true),
+      ];
+
+      const locations: Location[] = [
+        {tags: ['tag-v']},
+      ];
+
+      fetchSocketsMock.resolves(sockets as never);
+
+      const probes = await router.findMatchingProbes(locations, 100);
+
+      expect(probes.length).to.equal(0);
+    });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
     "moduleResolution": "node",
     "sourceMap": true
   },
+  "ts-node": {
+    "transpileOnly": true
+  },
   "include": [
     "src/**/*"
   ],

--- a/wallaby.js
+++ b/wallaby.js
@@ -34,5 +34,6 @@ export default function wallaby() {
 			'**/*.ts': file => file.content.replace(/\.ts/g, '.js'),
 		},
 		workers: {restart: true, initial: 1, regular: 1},
+		runMode: 'onsave',
 	};
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,38 @@
+import * as path from 'node:path';
+import * as url from 'node:url';
+
+export default function wallaby() {
+	const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+	return {
+		testFramework: 'mocha',
+		files: [
+			'src/**/*.ts',
+			'src/**/*.cjs',
+			'config/*',
+			'test/utils/**/*.ts',
+			'test/mocks/**/*',
+			'test/setup.ts',
+			'test/types.ts',
+			'package.json',
+			'GCP_IP_RANGES.json',
+			'AWS_IP_RANGES.json',
+			'DOMAIN_BLACKLIST.json',
+			'IP_BLACKLIST.json',
+		],
+		tests: [
+			'test/tests/**/*.test.ts',
+		],
+		env: {
+			type: 'node',
+			params: {
+				runner: '--experimental-specifier-resolution=node --loader '
+          + path.join(__dirname, 'node_modules/testdouble/lib/index.mjs'),
+				env: 'NODE_ENV=test;NEW_RELIC_ENABLED=false;NEW_RELIC_LOG_ENABLED=false',
+			},
+		},
+		preprocessors: {
+			'**/*.ts': file => file.content.replace(/\.ts/g, '.js'),
+		},
+		workers: {restart: true, initial: 1, regular: 1},
+	};
+}


### PR DESCRIPTION
Resolves https://github.com/jsdelivr/globalping/issues/262 .

Additionally:
- adds wallaby.js support
- updates router.test.ts to use probe data builder from source code, instead of utility one