### PR TITLE
feat: update socketio-timeouts

### DIFF
--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -31,6 +31,10 @@ export class MetricsAgent {
 		newrelic.incrementMetric('measurement_count_total', 1);
 	}
 
+	recordDisconnect(type: string): void {
+		newrelic.incrementMetric(`probe_disconnect_${type.replaceAll(' ', '_')}`, 1);
+	}
+
 	private async intervalHandler(): Promise<void> {
 		await this.updateProbeCount();
 		await this.updateMeasurementCount();

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -29,8 +29,8 @@ export const initWsServer = async () => {
 	io = new Server({
 		transports: ['websocket'],
 		serveClient: false,
-		pingInterval: 10_000,
-		pingTimeout: 4000,
+		pingInterval: 3000,
+		pingTimeout: 3000,
 	});
 
 	io.adapter(createAdapter(pubClient, subClient));


### PR DESCRIPTION
Part of #124 

It was measured that average socket.io ping-pong time is ~100ms.
Highest value for the minute vary from 1700ms to 3700ms.