### PR TITLE
feat: show non-ready probes first on the API page

### DIFF
--- a/public/probes.vue.js
+++ b/public/probes.vue.js
@@ -44,7 +44,17 @@ const probes = () => ({
     async fetchProbes() {
       const adminKey = new URLSearchParams(window.location.search).get('adminkey');
       const url = `/v1/probes?adminkey=${adminKey}`;
-      this.probes = await (await fetch(url)).json();
+      const probes = await (await fetch(url)).json();
+      const sortNonReadyFirst = (probe1, probe2) => {
+        if (probe1.status === 'ready' && probe2.status !== 'ready') {
+          return 1;
+        } else if (probe1.status !== 'ready' && probe2.status === 'ready') {
+          return -1;
+        } else {
+          return 0;
+        }
+      };
+      this.probes = probes.sort(sortNonReadyFirst);
     },
   },
   template: `

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -32,7 +32,7 @@ export type Tag = {
 };
 
 export type Probe = {
-	status: 'initializing' | 'ready' | 'unbuffer-missing' | 'sigterm';
+	status: 'initializing' | 'ready' | 'unbuffer-missing' | 'ping-test-failed' | 'sigterm';
 	client: string;
 	version: string | undefined;
 	ipAddress: string;


### PR DESCRIPTION
Part of https://github.com/jsdelivr/globalping/issues/52