### PR TITLE
fix: reenable brotli on level 5

### DIFF
--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -1,4 +1,5 @@
 import {createServer} from 'node:http';
+import * as zlib from 'node:zlib';
 import json from 'koa-json';
 import Router from '@koa/router';
 import conditionalGet from 'koa-conditional-get';
@@ -51,7 +52,7 @@ registerHealthRoute(healthRouter);
 
 app
 	.use(domainRedirect())
-	.use(compress({br: false}))
+	.use(compress({br: {params: {[zlib.constants.BROTLI_PARAM_QUALITY]: 5}}}))
 	.use(conditionalGet())
 	.use(etag({weak: true}))
 // Exclude root + demo routers from any checks


### PR DESCRIPTION
Turns out the problem wasn't brotli directly but a bad default, which had already been fixed, but there hasn't been a new release yet: https://github.com/koajs/compress/issues/179

On level 5, the performance is comparable to gzip 6 and compression is better.