### PR TITLE
fix: reduce compression levels

### DIFF
--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -54,7 +54,7 @@ registerHealthRoute(healthRouter);
 
 app
 	.use(domainRedirect())
-	.use(compress({ br: { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 5 } } }))
+	.use(compress({ br: { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 } }, gzip: { level: 3 }, deflate: false }))
 	.use(conditionalGet())
 	.use(etag({ weak: true }))
 // Exclude root + demo routers from any checks


### PR DESCRIPTION
Brotli 4 is almost twice as fast and since we expect the GET endpoint to be called often, prioritizing performance makes more sense here. Gzip level is also reduced to roughly match the brotli speed. Deflate isn't really used these days so rather than testing it too I just disabled it.