### PR TITLE
feat: optimize GET operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ node_modules/
 coverage/
 dist/
 config/local.cjs
-DOMAIN_BLACKLIST.json
-IP_BLACKLIST.json
-AWS_IP_RANGES.json
-GCP_IP_RANGES.json
+data/DOMAIN_BLACKLIST.json
+data/IP_BLACKLIST.json
+data/AWS_IP_RANGES.json
+data/GCP_IP_RANGES.json
 .eslintcache

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -22,7 +22,7 @@ module.exports = {
 		apiKey: '',
 	},
 	ws: {
-		fetchSocketsCacheTTL: 200,
+		fetchSocketsCacheTTL: 1000,
 	},
 	measurement: {
 		maxInProgressProbes: 5,

--- a/src/lib/ip-ranges.ts
+++ b/src/lib/ip-ranges.ts
@@ -16,11 +16,11 @@ const ipV6Ranges = new Map<ParsedIpRange, string>();
 export const sources: Record<'gcp' | 'aws', Source> = {
 	gcp: {
 		url: 'https://www.gstatic.com/ipranges/cloud.json',
-		file: 'GCP_IP_RANGES.json',
+		file: 'data/GCP_IP_RANGES.json',
 	},
 	aws: {
 		url: 'https://ip-ranges.amazonaws.com/ip-ranges.json',
-		file: 'AWS_IP_RANGES.json',
+		file: 'data/AWS_IP_RANGES.json',
 	},
 };
 

--- a/src/lib/malware/domain.ts
+++ b/src/lib/malware/domain.ts
@@ -10,7 +10,7 @@ export const sourceList = [
 	'https://urlhaus.abuse.ch/downloads/hostfile/',
 ];
 
-export const domainListPath = path.join(path.resolve(), 'DOMAIN_BLACKLIST.json');
+export const domainListPath = path.join(path.resolve(), 'data/DOMAIN_BLACKLIST.json');
 
 let domainListArray = new Set<string>();
 

--- a/src/lib/malware/ip.ts
+++ b/src/lib/malware/ip.ts
@@ -10,7 +10,7 @@ export const sourceList = [
 	'https://raw.githubusercontent.com/stamparm/ipsum/master/levels/2.txt',
 ];
 
-export const ipListPath = path.join(path.resolve(), 'IP_BLACKLIST.json');
+export const ipListPath = path.join(path.resolve(), 'data/IP_BLACKLIST.json');
 
 let ipListArray = new Set<string>();
 

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -58,16 +58,12 @@ export const getWsServer = (): WsServer => {
 	return io;
 };
 
-export const fetchSockets = () => {
+export const fetchSockets = async () => {
 	if (!io || !throttledFetchSockets) {
 		throw new Error('WS server not initialized yet');
 	}
 
-	const sockets = throttledFetchSockets();
-
-	if (sockets === undefined) {
-		throw new Error('undefined, the debounced function was not invoked yet');
-	}
+	const sockets = await throttledFetchSockets();
 
 	return sockets;
 };

--- a/src/measurement/route/get-measurement.ts
+++ b/src/measurement/route/get-measurement.ts
@@ -19,17 +19,8 @@ const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & R
 		return;
 	}
 
-	ctx.set('last-modified', new Date(result.createdAt).toUTCString());
-
-	ctx.body = {
-		id: result.id,
-		type: result.type,
-		status: result.status,
-		createdAt: new Date(result.createdAt).toISOString(),
-		updatedAt: new Date(result.updatedAt).toISOString(),
-		probesCount: result.probesCount,
-		results: Object.values(result.results),
-	};
+	ctx.type = 'application/json';
+	ctx.body = result;
 };
 
 export const registerGetMeasurementRoute = (router: Router): void => {

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -21,8 +21,8 @@ export const getMeasurementKey = (id: string, suffix: 'probes_awaiting' | undefi
 export class MeasurementStore {
 	constructor (private readonly redis: RedisClient) {}
 
-	async getMeasurementResults (id: string): Promise<MeasurementRecord> {
-		return await this.redis.json.get(getMeasurementKey(id)) as MeasurementRecord;
+	async getMeasurementResults (id: string): Promise<string> {
+		return this.redis.sendCommand([ 'JSON.GET', getMeasurementKey(id) ]);
 	}
 
 	async createMeasurement (type: string, probes: Probe[]): Promise<string> {
@@ -31,17 +31,17 @@ export class MeasurementStore {
 
 		const results = this.probesToResults(probes);
 		const probesAwaitingTtl = config.get<number>('measurement.timeout') + 5;
-		const startTime = Date.now();
+		const startTime = new Date();
 
 		await Promise.all([
-			this.redis.hSet('gp:in-progress', id, startTime),
+			this.redis.hSet('gp:in-progress', id, startTime.getTime()),
 			this.redis.set(getMeasurementKey(id, 'probes_awaiting'), probes.length, { EX: probesAwaitingTtl }),
 			this.redis.json.set(key, '$', {
 				id,
 				type,
 				status: 'in-progress',
-				createdAt: startTime,
-				updatedAt: startTime,
+				createdAt: startTime.toISOString(),
+				updatedAt: startTime.toISOString(),
 				probesCount: probes.length,
 				results,
 			}),
@@ -59,7 +59,7 @@ export class MeasurementStore {
 				? this.redis.json.set(key, `$.results[${data.testId}].result.rawOutput`, data.result.rawOutput)
 				: this.redis.json.strAppend(key, `$.results[${data.testId}].result.rawOutput`, data.result.rawOutput),
 
-			this.redis.json.set(key, '$.updatedAt', Date.now()),
+			this.redis.json.set(key, '$.updatedAt', new Date().toISOString()),
 		]);
 	}
 
@@ -69,7 +69,7 @@ export class MeasurementStore {
 		const [ remainingProbes ] = await Promise.all([
 			this.redis.decr(`${key}:probes_awaiting`),
 			this.redis.json.set(key, `$.results[${data.testId}].result`, data.result),
-			this.redis.json.set(key, '$.updatedAt', Date.now()),
+			this.redis.json.set(key, '$.updatedAt', new Date().toISOString()),
 		]);
 
 		return remainingProbes;
@@ -82,7 +82,7 @@ export class MeasurementStore {
 			this.redis.hDel('gp:in-progress', id),
 			this.redis.del(`${key}:probes_awaiting`),
 			this.redis.json.set(key, '$.status', 'finished'),
-			this.redis.json.set(key, '$.updatedAt', Date.now()),
+			this.redis.json.set(key, '$.updatedAt', new Date().toISOString()),
 		]);
 	}
 
@@ -98,7 +98,7 @@ export class MeasurementStore {
 
 		for (const measurement of existingMeasurements) {
 			measurement.status = 'finished';
-			measurement.updatedAt = Date.now();
+			measurement.updatedAt = new Date().toISOString();
 			const inProgressResults = Object.values(measurement.results).filter(resultObject => resultObject.result.status === 'in-progress');
 
 			for (const resultObject of inProgressResults) {

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -190,8 +190,8 @@ export type MeasurementRecord = {
 	id: string;
 	type: MeasurementRequest['type'];
 	status: MeasurementStatus;
-	createdAt: number;
-	updatedAt: number;
+	createdAt: string;
+	updatedAt: string;
 	probesCount: number;
 	results: Record<string, MeasurementResult>;
 };

--- a/test/tests/integration/health/health.test.ts
+++ b/test/tests/integration/health/health.test.ts
@@ -10,9 +10,7 @@ after(() => {
 	process.removeAllListeners('SIGINT');
 });
 
-describe('Get health', function () {
-	this.timeout(15_000);
-
+describe('Get health', () => {
 	let app: Server;
 	let requestAgent: SuperTest<Test>;
 	let sandbox: sinon.SinonSandbox;

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -9,9 +9,7 @@ import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
-describe('Create measurement', function () {
-	this.timeout(15_000);
-
+describe('Create measurement', () => {
 	let addFakeProbe: () => Promise<Socket>;
 	let deleteFakeProbe: (Socket) => Promise<void>;
 	let getTestServer;

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -20,7 +20,7 @@ describe('Create measurement request', function () {
 
 	const locationHandlerStub = sinon.stub();
 	const requestHandlerStub = sinon.stub();
-	const cryptoRandomString = sinon.stub();
+	const cryptoRandomString = sinon.stub().returns('measurementid');
 
 	before(async () => {
 		await td.replaceEsm('crypto-random-string', {}, cryptoRandomString);
@@ -40,10 +40,6 @@ describe('Create measurement request', function () {
 			'api:connect:location': locationHandlerStub,
 			'probe:measurement:request': requestHandlerStub,
 		});
-
-		cryptoRandomString.reset();
-		cryptoRandomString.onFirstCall().returns('testid');
-		cryptoRandomString.onSecondCall().returns('measurementid');
 	});
 
 	afterEach(async () => {
@@ -96,12 +92,14 @@ describe('Create measurement request', function () {
 
 		expect(requestHandlerStub.firstCall.args[0]).to.deep.equal({
 			measurementId: 'measurementid',
-			testId: 'testid',
+			testId: '0',
 			measurement: { packets: 4, type: 'ping', target: 'jsdelivr.com', inProgressUpdates: false },
 		});
 
 		await requestAgent.get(`/v1/measurements/measurementid`).send()
 			.expect(200).expect((response) => {
+				expect(response.headers['content-type']).to.equal('application/json; charset=utf-8');
+
 				expect(response.body).to.deep.include({
 					id: 'measurementid',
 					type: 'ping',
@@ -131,7 +129,7 @@ describe('Create measurement request', function () {
 		probe.emit('probe:measurement:ack');
 
 		probe.emit('probe:measurement:progress', {
-			testId: 'testid',
+			testId: '0',
 			measurementId: 'measurementid',
 			result: {
 				rawOutput: 'abc',
@@ -167,7 +165,7 @@ describe('Create measurement request', function () {
 			});
 
 		probe.emit('probe:measurement:progress', {
-			testId: 'testid',
+			testId: '0',
 			measurementId: 'measurementid',
 			result: {
 				rawOutput: 'def',
@@ -203,7 +201,7 @@ describe('Create measurement request', function () {
 			});
 
 		probe.emit('probe:measurement:result', {
-			testId: 'testid',
+			testId: '0',
 			measurementId: 'measurementid',
 			result: {
 				status: 'finished',

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -9,9 +9,7 @@ import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
-describe('Create measurement request', function () {
-	this.timeout(5000);
-
+describe('Create measurement request', () => {
 	let probe: Socket;
 	let addFakeProbe: (events?: Record<string, any>) => Promise<Socket>;
 	let deleteFakeProbe: (Socket) => Promise<void>;

--- a/test/tests/integration/measurement/timeout-result.test.ts
+++ b/test/tests/integration/measurement/timeout-result.test.ts
@@ -9,9 +9,7 @@ import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
-describe('Timeout results', function () {
-	this.timeout(5000);
-
+describe('Timeout results', () => {
 	let probe: Socket;
 	let addFakeProbe: (events?: Record<string, any>) => Promise<Socket>;
 	let deleteFakeProbe: (Socket) => Promise<void>;

--- a/test/tests/integration/measurement/timeout-result.test.ts
+++ b/test/tests/integration/measurement/timeout-result.test.ts
@@ -19,7 +19,7 @@ describe('Timeout results', function () {
 	let requestAgent: SuperTest<Test>;
 	let sandbox: sinon.SinonSandbox;
 
-	const cryptoRandomString = sinon.stub();
+	const cryptoRandomString = sinon.stub().returns('measurementid');
 
 	before(async () => {
 		sandbox = sinon.createSandbox({ useFakeTimers: true });
@@ -36,10 +36,6 @@ describe('Timeout results', function () {
 		nock('https://globalping-geoip.global.ssl.fastly.net').get(/.*/).reply(200, nockMocks['01.00'].fastly);
 		nock('https://ipinfo.io').get(/.*/).reply(200, nockMocks['01.00'].ipinfo);
 		nock('https://geoip.maxmind.com/geoip/v2.1/city/').get(/.*/).reply(200, nockMocks['01.00'].maxmind);
-
-		cryptoRandomString.reset();
-		cryptoRandomString.onFirstCall().returns('testid');
-		cryptoRandomString.onSecondCall().returns('measurementid');
 
 		probe = await addFakeProbe();
 	});

--- a/test/tests/integration/middleware/compress.test.ts
+++ b/test/tests/integration/middleware/compress.test.ts
@@ -8,9 +8,7 @@ import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
-describe('compression', function () {
-	this.timeout(15_000);
-
+describe('compression', () => {
 	let addFakeProbe: () => Promise<Socket>;
 	let deleteFakeProbe: (Socket) => Promise<void>;
 	let requestAgent: any;

--- a/test/tests/integration/middleware/cors.test.ts
+++ b/test/tests/integration/middleware/cors.test.ts
@@ -4,8 +4,7 @@ import { expect } from 'chai';
 
 import { getTestServer } from '../../../utils/server.js';
 
-describe('cors', function () {
-	this.timeout(15_000);
+describe('cors', () => {
 	let app: Server;
 	let requestAgent: any;
 

--- a/test/tests/integration/middleware/domain-redirect.test.ts
+++ b/test/tests/integration/middleware/domain-redirect.test.ts
@@ -4,9 +4,7 @@ import { expect } from 'chai';
 
 import { getTestServer } from '../../../utils/server.js';
 
-describe('domain redirect', function () {
-	this.timeout(15_000);
-
+describe('domain redirect', () => {
 	let app: Server;
 	let requestAgent: any;
 

--- a/test/tests/integration/middleware/etag.test.ts
+++ b/test/tests/integration/middleware/etag.test.ts
@@ -4,9 +4,7 @@ import { expect } from 'chai';
 
 import { getTestServer } from '../../../utils/server.js';
 
-describe('etag', function () {
-	this.timeout(15_000);
-
+describe('etag', () => {
 	let app: Server;
 	let requestAgent: any;
 

--- a/test/tests/integration/middleware/ratelimit.test.ts
+++ b/test/tests/integration/middleware/ratelimit.test.ts
@@ -11,8 +11,7 @@ describe('rate limiter', () => {
 	let clientIpv6: string;
 	let rateLimiterInstance: RateLimiterRedis;
 
-	before(async function () {
-		this.timeout(15_000);
+	before(async () => {
 		app = await getTestServer();
 		requestAgent = request(app);
 

--- a/test/tests/integration/middleware/responsetime.test.ts
+++ b/test/tests/integration/middleware/responsetime.test.ts
@@ -8,8 +8,7 @@ describe('response time', () => {
 	let app: Server;
 	let requestAgent: any;
 
-	before(async function () {
-		this.timeout(15_000);
+	before(async () => {
 		app = await getTestServer();
 		requestAgent = request(app);
 	});

--- a/test/tests/integration/probes/get-probes.test.ts
+++ b/test/tests/integration/probes/get-probes.test.ts
@@ -9,9 +9,7 @@ import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
-describe('Get Probes', function () {
-	this.timeout(15_000);
-
+describe('Get Probes', () => {
 	let addFakeProbe: () => Promise<Socket>;
 	let deleteFakeProbe: (Socket) => Promise<void>;
 	let requestAgent: SuperTest<Test>;

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -58,12 +58,7 @@ describe('MeasurementRunner', () => {
 		expect(router.findMatchingProbes.args[0]).to.deep.equal([ [], 10 ]);
 		expect(store.createMeasurement.callCount).to.equal(1);
 
-		expect(store.createMeasurement.args[0]).to.deep.equal([ 'ping', new Map([
-			[ 0, { client: 0 }],
-			[ 1, { client: 1 }],
-			[ 2, { client: 2 }],
-			[ 3, { client: 3 }],
-		]) ]);
+		expect(store.createMeasurement.args[0]).to.deep.equal([ 'ping', [{ client: 0 }, { client: 1 }, { client: 2 }, { client: 3 }] ]);
 
 		expect(to.callCount).to.equal(4);
 		expect(emit.callCount).to.equal(4);
@@ -77,7 +72,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 0,
+			testId: '0',
 		}]);
 
 		expect(to.args[1][0]).to.equal(1);
@@ -90,7 +85,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 1,
+			testId: '1',
 		}]);
 
 		expect(to.args[2][0]).to.equal(2);
@@ -103,7 +98,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 2,
+			testId: '2',
 		}]);
 
 		expect(to.args[3][0]).to.equal(3);
@@ -116,7 +111,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 3,
+			testId: '3',
 		}]);
 
 		expect(metrics.recordMeasurement.callCount).to.equal(1);
@@ -142,12 +137,7 @@ describe('MeasurementRunner', () => {
 		expect(router.findMatchingProbes.args[0]).to.deep.equal([ [], 10 ]);
 		expect(store.createMeasurement.callCount).to.equal(1);
 
-		expect(store.createMeasurement.args[0]).to.deep.equal([ 'ping', new Map([
-			[ 0, { client: 0 }],
-			[ 1, { client: 1 }],
-			[ 2, { client: 2 }],
-			[ 3, { client: 3 }],
-		]) ]);
+		expect(store.createMeasurement.args[0]).to.deep.equal([ 'ping', [{ client: 0 }, { client: 1 }, { client: 2 }, { client: 3 }] ]);
 
 		expect(to.callCount).to.equal(4);
 		expect(emit.callCount).to.equal(4);
@@ -160,7 +150,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 0,
+			testId: '0',
 		}]);
 
 		expect(emit.args[1]).to.deep.equal([ 'probe:measurement:request', {
@@ -171,7 +161,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 1,
+			testId: '1',
 		}]);
 
 		expect(emit.args[2]).to.deep.equal([ 'probe:measurement:request', {
@@ -182,7 +172,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 2,
+			testId: '2',
 		}]);
 
 		expect(emit.args[3]).to.deep.equal([ 'probe:measurement:request', {
@@ -193,7 +183,7 @@ describe('MeasurementRunner', () => {
 				type: 'ping',
 			},
 			measurementId: 'measurementid',
-			testId: 3,
+			testId: '3',
 		}]);
 
 		expect(metrics.recordMeasurement.callCount).to.equal(1);

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -76,15 +76,13 @@ describe('measurement store', () => {
 			createdAt: 1_677_510_747_483,
 			updatedAt: 1_677_510_747_483,
 			probesCount: 1,
-			results: {
-				measurementId1: {
-					probe: {},
-					result: {
-						status: 'in-progress',
-						rawOutput: '',
-					},
+			results: [{
+				probe: {},
+				result: {
+					status: 'in-progress',
+					rawOutput: '',
 				},
-			},
+			}],
 		}]);
 
 		getMeasurementStore();
@@ -104,28 +102,21 @@ describe('measurement store', () => {
 			type: 'ping',
 			status: 'finished',
 			createdAt: 1_677_510_747_483,
-			updatedAt: 1_678_000_012_000,
+			updatedAt: '2023-03-05T07:06:52.000Z',
 			probesCount: 1,
-			results: {
-				measurementId1: {
-					probe: {},
-					result: {
-						status: 'failed',
-						rawOutput: '\n\nThe measurement timed out',
-					},
+			results: [{
+				probe: {},
+				result: {
+					status: 'failed',
+					rawOutput: '\n\nThe measurement timed out',
 				},
-			},
+			}],
 		}]);
 	});
 
 	it('should store measurement probes in the same order as in arguments', async () => {
 		const store = getMeasurementStore();
-		store.createMeasurement('ping', new Map([
-			[ 'z', getProbe('z') ],
-			[ '10', getProbe('10') ],
-			[ 'x', getProbe('x') ],
-			[ '0', getProbe('0') ],
-		]));
+		store.createMeasurement('ping', [ getProbe('z'), getProbe('10'), getProbe('x'), getProbe('0') ]);
 
 		expect(redisMock.hSet.callCount).to.equal(1);
 		expect(redisMock.hSet.args[0]).to.deep.equal([ 'gp:in-progress', 'measurementid', 1678000000000 ]);
@@ -137,75 +128,73 @@ describe('measurement store', () => {
 			id: 'measurementid',
 			type: 'ping',
 			status: 'in-progress',
-			createdAt: 1678000000000,
-			updatedAt: 1678000000000,
+			createdAt: '2023-03-05T07:06:40.000Z',
+			updatedAt: '2023-03-05T07:06:40.000Z',
 			probesCount: 4,
-			results: {
-				z: {
-					probe: {
-						continent: 'continent',
-						region: 'region',
-						country: 'country',
-						state: 'state',
-						city: 'city',
-						asn: 'asn',
-						longitude: 'longitude',
-						latitude: 'latitude',
-						network: 'z',
-						tags: [],
-						resolvers: [],
-					},
-					result: { status: 'in-progress', rawOutput: '' },
+			results: [{
+				probe: {
+					continent: 'continent',
+					region: 'region',
+					country: 'country',
+					state: 'state',
+					city: 'city',
+					asn: 'asn',
+					longitude: 'longitude',
+					latitude: 'latitude',
+					network: 'z',
+					tags: [],
+					resolvers: [],
 				},
-				10: {
-					probe: {
-						continent: 'continent',
-						region: 'region',
-						country: 'country',
-						state: 'state',
-						city: 'city',
-						asn: 'asn',
-						longitude: 'longitude',
-						latitude: 'latitude',
-						network: '10',
-						tags: [],
-						resolvers: [],
-					},
-					result: { status: 'in-progress', rawOutput: '' },
-				},
-				x: {
-					probe: {
-						continent: 'continent',
-						region: 'region',
-						country: 'country',
-						state: 'state',
-						city: 'city',
-						asn: 'asn',
-						longitude: 'longitude',
-						latitude: 'latitude',
-						network: 'x',
-						tags: [],
-						resolvers: [],
-					},
-					result: { status: 'in-progress', rawOutput: '' },
-				},
-				0: {
-					probe: {
-						continent: 'continent',
-						region: 'region',
-						country: 'country',
-						state: 'state',
-						city: 'city',
-						asn: 'asn',
-						longitude: 'longitude',
-						latitude: 'latitude',
-						network: '0',
-						tags: [],
-						resolvers: [],
-					},
-					result: { status: 'in-progress', rawOutput: '' },
-				},
+				result: { status: 'in-progress', rawOutput: '' },
 			},
+			{
+				probe: {
+					continent: 'continent',
+					region: 'region',
+					country: 'country',
+					state: 'state',
+					city: 'city',
+					asn: 'asn',
+					longitude: 'longitude',
+					latitude: 'latitude',
+					network: '10',
+					tags: [],
+					resolvers: [],
+				},
+				result: { status: 'in-progress', rawOutput: '' },
+			},
+			{
+				probe: {
+					continent: 'continent',
+					region: 'region',
+					country: 'country',
+					state: 'state',
+					city: 'city',
+					asn: 'asn',
+					longitude: 'longitude',
+					latitude: 'latitude',
+					network: 'x',
+					tags: [],
+					resolvers: [],
+				},
+				result: { status: 'in-progress', rawOutput: '' },
+			},
+			{
+				probe: {
+					continent: 'continent',
+					region: 'region',
+					country: 'country',
+					state: 'state',
+					city: 'city',
+					asn: 'asn',
+					longitude: 'longitude',
+					latitude: 'latitude',
+					network: '0',
+					tags: [],
+					resolvers: [],
+				},
+				result: { status: 'in-progress', rawOutput: '' },
+			}],
 		}]);
 
 		expect(redisMock.expire.callCount).to.equal(1);


### PR DESCRIPTION
- fixes https://github.com/jsdelivr/globalping/issues/318
- sets `fetchSocketsCacheTTL` to 1000ms

Note: data migration or flush of db is required as old measurent results will be returned as object instead of array.