### PR TITLE
feat: ignore partial matches after exact match in magic field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ if (cluster.isPrimary) {
 	}
 
 	cluster.on('exit', (worker, code, signal) => {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		logger.error(`worker ${worker.process.pid!} died with code ${code} and signal ${signal}`);
 		cluster.fork();
 	});

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -62,21 +62,22 @@ export const buildProbe = async (socket: Socket): Promise<Probe> => {
 
 	const tags = getTags(clientIp);
 
+	// Storing index values as string[][] so every category will have it's exact position in the index array across all probes
 	const index = [
-		location.country,
-		getCountryIso3ByIso2(location.country),
-		getCountryByIso(location.country),
+		[ location.country ],
+		[ getCountryIso3ByIso2(location.country) ],
+		[ getCountryByIso(location.country) ],
 		getCountryAliases(location.country),
-		location.normalizedCity,
-		location.state ?? [],
-		...location.state ? [ getStateNameByIso(location.state) ] : [],
-		location.continent,
-		location.normalizedRegion,
-		`as${location.asn}`,
+		[ location.normalizedCity ],
+		location.state ? [ location.state ] : [],
+		location.state ? [ getStateNameByIso(location.state) ] : [],
+		[ location.continent ],
+		[ location.normalizedRegion ],
+		[ `as${location.asn}` ],
 		tags.filter(tag => tag.type === 'system').map(tag => tag.value),
-		location.normalizedNetwork,
+		[ location.normalizedNetwork ],
 		getNetworkAliases(location.normalizedNetwork),
-	].flat().filter(Boolean).map(s => s.toLowerCase().replaceAll('-', ' '));
+	].map(category => category.map(s => s.toLowerCase().replaceAll('-', ' ')));
 
 	// Todo: add validation and handle missing or partial data
 	return {

--- a/src/probe/sockets-location-filter.ts
+++ b/src/probe/sockets-location-filter.ts
@@ -31,11 +31,13 @@ export class SocketsLocationFilter {
 
 				return exactMatchPosition < smallestExactMatchPosition ? exactMatchPosition : smallestExactMatchPosition;
 			}, Number.POSITIVE_INFINITY);
-			filteredSockets = filteredSockets.filter((socket) => {
-				const matchPosition = SocketsLocationFilter.getIndexPosition(socket, keyword);
-				const socketIsValid = matchPosition !== -1 && matchPosition <= closestExactMatchPosition;
-				return socketIsValid;
-			});
+			const noExactMatches = closestExactMatchPosition === Number.POSITIVE_INFINITY;
+
+			if (noExactMatches) {
+				filteredSockets = filteredSockets.filter(socket => SocketsLocationFilter.getIndexPosition(socket, keyword) !== -1);
+			} else {
+				filteredSockets = filteredSockets.filter(socket => SocketsLocationFilter.getExactIndexPosition(socket, keyword) === closestExactMatchPosition);
+			}
 		}
 
 		return filteredSockets;

--- a/src/probe/sockets-location-filter.ts
+++ b/src/probe/sockets-location-filter.ts
@@ -19,7 +19,7 @@ const locationKeyMap = [
 export class SocketsLocationFilter {
 	static magicFilter (sockets: Socket[], magicLocation: string) {
 		let filteredSockets = sockets;
-		const keywords = magicLocation.split('+'); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+		const keywords = magicLocation.split('+');
 
 		for (const keyword of keywords) {
 			const closestExactMatchPosition = sockets.reduce((smallestExactMatchPosition, socket) => {
@@ -67,8 +67,10 @@ export class SocketsLocationFilter {
 
 		Object.keys(location).forEach((key) => {
 			if (key === 'tags') {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				filteredSockets = filteredSockets.filter(socket => location.tags!.every(tag => SocketsLocationFilter.hasTag(socket, tag)));
 			} else if (key === 'magic') {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				filteredSockets = SocketsLocationFilter.magicFilter(filteredSockets, location.magic!);
 			} else {
 				const probeKey = locationKeyMap.find(m => m.includes(key))?.[1] ?? key;

--- a/src/probe/sockets-location-filter.ts
+++ b/src/probe/sockets-location-filter.ts
@@ -42,11 +42,11 @@ export class SocketsLocationFilter {
 	}
 
 	static getExactIndexPosition (socket: Socket, value: string) {
-		return socket.data.probe.index.findIndex(index => index === value.replaceAll('-', ' ').trim());
+		return socket.data.probe.index.findIndex(category => category.some(index => index === value.replaceAll('-', ' ').trim()));
 	}
 
 	static getIndexPosition (socket: Socket, value: string) {
-		return socket.data.probe.index.findIndex(index => index.includes(value.replaceAll('-', ' ').trim()));
+		return socket.data.probe.index.findIndex(category => category.some(index => index.includes(value.replaceAll('-', ' ').trim())));
 	}
 
 	static hasTag (socket: Socket, tag: string) {

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -38,7 +38,7 @@ export type Probe = {
 	ipAddress: string;
 	host: string;
 	location: ProbeLocation;
-	index: string[];
+	index: string[][];
 	resolvers: string[];
 	tags: Tag[];
 	stats: ProbeStats;

--- a/test/tests/unit/probe/router.test.ts
+++ b/test/tests/unit/probe/router.test.ts
@@ -468,19 +468,19 @@ describe('probe router', () => {
 
 		it('should ignore matches on the lower levels after exact match', async () => {
 			const sockets: Array<DeepPartial<Socket>> = [
-				await buildSocket('socket-3', { country: 'PL', normalizedCity: 'warsaw', normalizedNetwork: 'ultra development networks' }),
-				await buildSocket('socket-2', { country: 'RS', normalizedCity: 'belgrade', normalizedNetwork: 'belgrade networks' }),
-				await buildSocket('socket-1', { country: 'DE', normalizedCity: 'berlin', normalizedNetwork: 'berlin networks' }),
+				await buildSocket('socket-3', { country: 'VN', normalizedCity: 'hanoi', normalizedNetwork: 'ultra networks' }),
+				await buildSocket('socket-2', { country: 'RU', normalizedCity: 'vnukovo', normalizedNetwork: 'super networks' }),
+				await buildSocket('socket-1', { country: 'HU', normalizedCity: 'budapest', normalizedNetwork: '23VNet Kft' }),
 			];
 			fetchSocketsMock.resolves(sockets as never);
 
 			const probes = await router.findMatchingProbes([
-				{ magic: 'de' },
+				{ magic: 'vn' },
 			], 100);
 
 			expect(fetchSocketsMock.calledOnce).to.be.true;
 			expect(probes.length).to.equal(1);
-			expect(probes[0]!.location.country).to.equal('DE');
+			expect(probes[0]!.location.country).to.equal('VN');
 		});
 
 		it('should accept partial matches on the higher or same level as exact match', async () => {


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/247 and https://github.com/jsdelivr/globalping/issues/334