### PR TITLE
 fix: fix ip geo api error handling

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -15,7 +15,7 @@ module.exports = {
 	},
 	geoip: {
 		cache: {
-			ttl: 3 * 24 * 60 * 60 * 1000, // 24hrs
+			ttl: 3 * 24 * 60 * 60 * 1000, // 3 days
 		},
 	},
 	maxmind: {

--- a/config/test.cjs
+++ b/config/test.cjs
@@ -7,6 +7,11 @@ module.exports = {
 	admin: {
 		key: 'admin',
 	},
+	geoip: {
+		cache: {
+			ttl: 1, // 1 ms ttl here to disable redis cache in tests
+		},
+	},
 	ws: {
 		fetchSocketsCacheTTL: 0,
 	},

--- a/src/lib/cache/redis-cache.ts
+++ b/src/lib/cache/redis-cache.ts
@@ -5,7 +5,7 @@ export default class RedisCache implements CacheInterface {
 	constructor (private readonly redis: RedisClient) {}
 
 	async set (key: string, value: unknown, ttl?: number): Promise<void> {
-		await this.redis.set(this.buildCacheKey(key), JSON.stringify(value), { EX: ttl ? ttl / 1000 : 0 });
+		await this.redis.set(this.buildCacheKey(key), JSON.stringify(value), { PX: ttl ?? 0 });
 	}
 
 	async get<T = unknown> (key: string): Promise<T | undefined> {

--- a/src/lib/geoip/client.ts
+++ b/src/lib/geoip/client.ts
@@ -63,7 +63,7 @@ export default class GeoipClient {
 
 		const resultsWithCities = results.filter(s => s.city);
 
-		if (resultsWithCities.length < 2 && resultsWithCities[0]?.provider === 'fastly') {
+		if (resultsWithCities.length === 0 || (resultsWithCities.length === 1 && resultsWithCities[0]?.provider === 'fastly')) {
 			throw new InternalError(`unresolvable geoip: ${addr}`, true);
 		}
 

--- a/src/lib/geoip/providers/maxmind.ts
+++ b/src/lib/geoip/providers/maxmind.ts
@@ -27,7 +27,7 @@ const query = async (addr: string, retryCounter = 0): Promise<City> => {
 			}
 		}
 
-		throw new Error('no maxmind data');
+		throw error;
 	}
 };
 

--- a/src/lib/geoip/providers/maxmind.ts
+++ b/src/lib/geoip/providers/maxmind.ts
@@ -15,7 +15,8 @@ export const isMaxmindError = (error: unknown): error is WebServiceClientError =
 
 const query = async (addr: string, retryCounter = 0): Promise<City> => {
 	try {
-		return await client.city(addr);
+		const city = await client.city(addr);
+		return city;
 	} catch (error: unknown) {
 		if (isMaxmindError(error)) {
 			if (error.code === 'SERVER_ERROR' && retryCounter < 3) {

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -4,8 +4,8 @@ import type { MeasurementRecord, MeasurementResultMessage } from '../../measurem
 type CountScript = {
 	NUMBER_OF_KEYS: number;
 	SCRIPT: string;
-	transformArguments (this: void, key: string): Array<string>;
-	transformReply (this: void, reply: number): number;
+	transformArguments (key: string): Array<string>;
+	transformReply (reply: number): number;
 } & {
 	SHA1: string;
 };
@@ -13,8 +13,8 @@ type CountScript = {
 export type RecordResultScript = {
 	NUMBER_OF_KEYS: number;
 	SCRIPT: string;
-	transformArguments (this: void, measurementId: string, testId: string, data: MeasurementResultMessage['result']): string[];
-	transformReply (this: void, reply: string): MeasurementRecord | null;
+	transformArguments (measurementId: string, testId: string, data: MeasurementResultMessage['result']): string[];
+	transformReply (reply: string): MeasurementRecord | null;
 } & {
 	SHA1: string;
 };

--- a/src/lib/ws/helper/error-handler.ts
+++ b/src/lib/ws/helper/error-handler.ts
@@ -19,7 +19,7 @@ type NextArgument = NextConnectArgument | NextMwArgument;
 const isError = (error: unknown): error is Error => Boolean(error as Error['message']);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const errorHandler = (next: NextArgument) => (socket: Socket, mwNext?: (error?: any) => void | undefined) => {
+export const errorHandler = (next: NextArgument) => (socket: Socket, mwNext?: (error?: any) => void) => {
 	next(socket, mwNext!).catch((error) => { // eslint-disable-line @typescript-eslint/no-non-null-assertion
 		const clientIp = getProbeIp(socket.request) ?? '';
 		const reason = isError(error) ? error.message : 'unknown';

--- a/src/lib/ws/helper/reconnect-probes.ts
+++ b/src/lib/ws/helper/reconnect-probes.ts
@@ -1,8 +1,8 @@
-import { fetchSockets } from '../server.js';
+import type { ThrottledFetchSockets } from '../server';
 
 const TIME_TO_RECONNECT_PROBES = 60_000;
 
-export const reconnectProbes = async () => {
+export const reconnectProbes = async (fetchSockets: ThrottledFetchSockets) => { // passing fetchSockets in arguments to avoid cycle dependency
 	const sockets = await fetchSockets();
 
 	for (const socket of sockets) {

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -46,7 +46,7 @@ export const initWsServer = async () => {
 	);
 
 	setTimeout(() => {
-		reconnectProbes().catch(error => logger.error(error));
+		reconnectProbes(fetchSockets).catch(error => logger.error(error));
 	}, TIME_UNTIL_VM_BECOMES_HEALTHY);
 };
 
@@ -67,3 +67,5 @@ export const fetchSockets = async () => {
 
 	return sockets;
 };
+
+export type ThrottledFetchSockets = typeof fetchSockets;

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -18,18 +18,26 @@ import getProbeIp from '../lib/get-probe-ip.js';
 import { getRegion } from '../lib/ip-ranges.js';
 import type { Probe, ProbeLocation, Tag } from './types.js';
 
-const fakeIpForDebug = () => _.sample([
-	'18.200.0.1', // aws-eu-west-1
-	'34.140.0.10', // gcp-europe-west1
-	'95.155.94.127',
-	'65.49.22.66',
-	'185.229.226.83',
-	'51.158.22.211',
-	'131.255.7.26',
-	'213.136.174.80',
-	'94.214.253.78',
-	'79.205.97.254',
-]);
+const fakeIpForDebug = () => {
+	/**
+	 * Ips for test and dev should be separated so redis will not return dev data during the tests
+	 */
+	if (process.env['NODE_ENV'] === 'test') {
+		return '95.155.94.127';
+	}
+
+	return _.sample([
+		'18.200.0.1', // aws-eu-west-1
+		'34.140.0.10', // gcp-europe-west1
+		'65.49.22.66',
+		'185.229.226.83',
+		'51.158.22.211',
+		'131.255.7.26',
+		'213.136.174.80',
+		'94.214.253.78',
+		'79.205.97.254',
+	]);
+};
 
 const geoipClient = createGeoipClient();
 

--- a/src/probe/handler/dns.ts
+++ b/src/probe/handler/dns.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { Probe } from '../types.js';
 
 export const handleDnsUpdate = (probe: Probe) => (list: string[]): void => {
 	probe.resolvers = list;

--- a/src/probe/handler/stats.ts
+++ b/src/probe/handler/stats.ts
@@ -1,7 +1,4 @@
-import type {
-	Probe,
-	ProbeStats,
-} from '../../probe/types.js';
+import type { Probe, ProbeStats } from '../types.js';
 
 export const handleStatsReport = (probe: Probe) => (report: ProbeStats): void => {
 	probe.stats = report;

--- a/src/probe/handler/status.ts
+++ b/src/probe/handler/status.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { Probe } from '../types.js';
 
 export const handleStatusUpdate = (probe: Probe) => (status: Probe['status']): void => {
 	probe.status = status;

--- a/test/mocks/redis-cache.ts
+++ b/test/mocks/redis-cache.ts
@@ -1,5 +1,0 @@
-export default class RedisCacheMock {
-	set = () => Promise.resolve();
-	get = () => Promise.resolve();
-	delete = () => Promise.resolve();
-}

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -5,7 +5,6 @@ import request, { type SuperTest, type Test } from 'supertest';
 import * as td from 'testdouble';
 import nock from 'nock';
 import type { Socket } from 'socket.io-client';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
@@ -16,7 +15,6 @@ describe('Create measurement', () => {
 	let requestAgent: SuperTest<Test>;
 
 	before(async () => {
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: () => 'gcp-us-west4', populateMemList: () => Promise.resolve() });
 		({ getTestServer, addFakeProbe, deleteFakeProbe } = await import('../../../utils/server.js'));
 		const app = await getTestServer();

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -5,7 +5,6 @@ import nock from 'nock';
 import type { Socket } from 'socket.io-client';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
@@ -22,7 +21,6 @@ describe('Create measurement request', () => {
 
 	before(async () => {
 		await td.replaceEsm('crypto-random-string', {}, cryptoRandomString);
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: () => 'gcp-us-west4', populateMemList: () => Promise.resolve() });
 		({ getTestServer, addFakeProbe, deleteFakeProbe } = await import('../../../utils/server.js'));
 		const app = await getTestServer();

--- a/test/tests/integration/measurement/timeout-result.test.ts
+++ b/test/tests/integration/measurement/timeout-result.test.ts
@@ -5,7 +5,6 @@ import nock from 'nock';
 import type { Socket } from 'socket.io-client';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
@@ -23,7 +22,6 @@ describe('Timeout results', () => {
 		sandbox = sinon.createSandbox({ useFakeTimers: true });
 		await td.replaceEsm('@jcoreio/async-throttle', null, (f: any) => f);
 		await td.replaceEsm('crypto-random-string', {}, cryptoRandomString);
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: () => 'gcp-us-west4', populateMemList: () => Promise.resolve() });
 		({ getTestServer, addFakeProbe, deleteFakeProbe } = await import('../../../utils/server.js'));
 		const app = await getTestServer();

--- a/test/tests/integration/middleware/compress.test.ts
+++ b/test/tests/integration/middleware/compress.test.ts
@@ -1,26 +1,19 @@
 import fs from 'node:fs';
 import request, { type Response } from 'supertest';
 import { expect } from 'chai';
-import * as td from 'testdouble';
 import nock from 'nock';
 import type { Socket } from 'socket.io-client';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
+import { getTestServer, addFakeProbe, deleteFakeProbe } from '../../../utils/server.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
 describe('compression', () => {
-	let addFakeProbe: () => Promise<Socket>;
-	let deleteFakeProbe: (socket: Socket) => Promise<void>;
 	let requestAgent: any;
 	let probes: Socket[] = [];
 
 	describe('headers', () => {
 		before(async () => {
-			await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
-			const http = await import('../../../utils/server.js');
-			addFakeProbe = http.addFakeProbe;
-			deleteFakeProbe = http.deleteFakeProbe;
-			const app = await http.getTestServer();
+			const app = await getTestServer();
 			requestAgent = request(app);
 		});
 

--- a/test/tests/integration/probes/get-probes.test.ts
+++ b/test/tests/integration/probes/get-probes.test.ts
@@ -5,28 +5,23 @@ import { expect } from 'chai';
 import request, { type SuperTest, type Test } from 'supertest';
 import * as td from 'testdouble';
 import type { Socket } from 'socket.io-client';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
+import { getTestServer, addFakeProbe as addProbe, deleteFakeProbe } from '../../../utils/server.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
 describe('Get Probes', () => {
-	let addFakeProbe: () => Promise<Socket>;
-	let deleteFakeProbe: (socket: Socket) => Promise<void>;
 	let requestAgent: SuperTest<Test>;
+	let addFakeProbe: () => Promise<Socket>;
 	const probes: Socket[] = [];
 
 	before(async () => {
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
-		const http = await import('../../../utils/server.js');
-		deleteFakeProbe = http.deleteFakeProbe;
-
 		addFakeProbe = async () => {
-			const probe = await http.addFakeProbe();
+			const probe = await addProbe();
 			probes.push(probe);
 			return probe;
 		};
 
-		const app = await http.getTestServer();
+		const app = await getTestServer();
 		requestAgent = request(app);
 	});
 


### PR DESCRIPTION
V2 PR to trigger CI build.

Fixes https://github.com/jsdelivr/globalping/issues/372

Nock module throws errors as expected. Our source code catches 3rd party ip geo errors and that handling was wrong (explained in further comment). That was the real reason we were not able to see an explicit error.
Additionally redis cached some of the geo ip values during tests, which made them pass locally and fail on CI.