### PR TITLE
feat: fix ip geo api error handling

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -15,7 +15,7 @@ module.exports = {
 	},
 	geoip: {
 		cache: {
-			ttl: 3 * 24 * 60 * 60 * 1000, // 24hrs
+			ttl: 3 * 24 * 60 * 60 * 1000, // 3 days
 		},
 	},
 	maxmind: {

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -29,7 +29,8 @@ module.exports = {
 		fetchSocketsCacheTTL: 1000,
 	},
 	measurement: {
-		rateLimit: 300,
+		rateLimit: 100000,
+		rateLimitReset: 3600,
 		maxInProgressProbes: 5,
 		// Timeout after which measurement will be marked as finished even if not all probes respond
 		timeout: 30, // 30 seconds

--- a/config/test.cjs
+++ b/config/test.cjs
@@ -7,6 +7,11 @@ module.exports = {
 	admin: {
 		key: 'admin',
 	},
+	geoip: {
+		cache: {
+			ttl: 1, // 1 ms ttl here to disable redis cache in tests
+		},
+	},
 	ws: {
 		fetchSocketsCacheTTL: 0,
 	},

--- a/src/lib/cache/redis-cache.ts
+++ b/src/lib/cache/redis-cache.ts
@@ -5,7 +5,7 @@ export default class RedisCache implements CacheInterface {
 	constructor (private readonly redis: RedisClient) {}
 
 	async set (key: string, value: unknown, ttl?: number): Promise<void> {
-		await this.redis.set(this.buildCacheKey(key), JSON.stringify(value), { EX: ttl ? ttl / 1000 : 0 });
+		await this.redis.set(this.buildCacheKey(key), JSON.stringify(value), { PX: ttl ?? 0 });
 	}
 
 	async get<T = unknown> (key: string): Promise<T | undefined> {

--- a/src/lib/geoip/client.ts
+++ b/src/lib/geoip/client.ts
@@ -63,7 +63,7 @@ export default class GeoipClient {
 
 		const resultsWithCities = results.filter(s => s.city);
 
-		if (resultsWithCities.length < 2 && resultsWithCities[0]?.provider === 'fastly') {
+		if (resultsWithCities.length === 0 || (resultsWithCities.length === 1 && resultsWithCities[0]?.provider === 'fastly')) {
 			throw new InternalError(`unresolvable geoip: ${addr}`, true);
 		}
 

--- a/src/lib/geoip/providers/maxmind.ts
+++ b/src/lib/geoip/providers/maxmind.ts
@@ -27,7 +27,7 @@ const query = async (addr: string, retryCounter = 0): Promise<City> => {
 			}
 		}
 
-		throw new Error('no maxmind data');
+		throw error;
 	}
 };
 

--- a/src/lib/geoip/providers/maxmind.ts
+++ b/src/lib/geoip/providers/maxmind.ts
@@ -15,7 +15,8 @@ export const isMaxmindError = (error: unknown): error is WebServiceClientError =
 
 const query = async (addr: string, retryCounter = 0): Promise<City> => {
 	try {
-		return await client.city(addr);
+		const city = await client.city(addr);
+		return city;
 	} catch (error: unknown) {
 		if (isMaxmindError(error)) {
 			if (error.code === 'SERVER_ERROR' && retryCounter < 3) {

--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -15,7 +15,6 @@ import { registerGetMeasurementRoute } from '../../measurement/route/get-measure
 import { registerCreateMeasurementRoute } from '../../measurement/route/create-measurement.js';
 import { registerHealthRoute } from '../../health/route/get.js';
 import { errorHandler } from './error-handler.js';
-import { rateLimitHandler } from './middleware/ratelimit.js';
 import { errorHandlerMw } from './middleware/error-handler.js';
 import { corsHandler } from './middleware/cors.js';
 import { isAdminMw } from './middleware/is-admin.js';
@@ -40,8 +39,7 @@ rootRouter.get('/', (ctx) => {
 const apiRouter = new Router({ strict: true, sensitive: true });
 
 apiRouter.prefix('/v1')
-	.use(isAdminMw)
-	.use(rateLimitHandler());
+	.use(isAdminMw);
 
 // POST /measurements
 registerCreateMeasurementRoute(apiRouter);

--- a/src/lib/ratelimiter.ts
+++ b/src/lib/ratelimiter.ts
@@ -4,11 +4,18 @@ import { createRedisClient } from './redis/client.js';
 
 const redisClient = await createRedisClient({ legacyMode: true });
 
-export const rateLimiter = new RateLimiterRedis({
+export const defaultState = {
+	remainingPoints: config.get<number>('measurement.rateLimit'),
+	msBeforeNext: config.get<number>('measurement.rateLimitReset') * 1000,
+	consumedPoints: 0,
+	isFirstInDuration: true,
+};
+
+const rateLimiter = new RateLimiterRedis({
 	storeClient: redisClient,
 	keyPrefix: 'rate',
 	points: config.get<number>('measurement.rateLimit'),
-	duration: 60,
+	duration: config.get<number>('measurement.rateLimitReset'),
 });
 
 export default rateLimiter;

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -4,8 +4,8 @@ import type { MeasurementRecord, MeasurementResultMessage } from '../../measurem
 type CountScript = {
 	NUMBER_OF_KEYS: number;
 	SCRIPT: string;
-	transformArguments (this: void, key: string): Array<string>;
-	transformReply (this: void, reply: number): number;
+	transformArguments (key: string): Array<string>;
+	transformReply (reply: number): number;
 } & {
 	SHA1: string;
 };
@@ -13,8 +13,8 @@ type CountScript = {
 export type RecordResultScript = {
 	NUMBER_OF_KEYS: number;
 	SCRIPT: string;
-	transformArguments (this: void, measurementId: string, testId: string, data: MeasurementResultMessage['result']): string[];
-	transformReply (this: void, reply: string): MeasurementRecord | null;
+	transformArguments (measurementId: string, testId: string, data: MeasurementResultMessage['result']): string[];
+	transformReply (reply: string): MeasurementRecord | null;
 } & {
 	SHA1: string;
 };

--- a/src/lib/ws/helper/error-handler.ts
+++ b/src/lib/ws/helper/error-handler.ts
@@ -19,7 +19,7 @@ type NextArgument = NextConnectArgument | NextMwArgument;
 const isError = (error: unknown): error is Error => Boolean(error as Error['message']);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const errorHandler = (next: NextArgument) => (socket: Socket, mwNext?: (error?: any) => void | undefined) => {
+export const errorHandler = (next: NextArgument) => (socket: Socket, mwNext?: (error?: any) => void) => {
 	next(socket, mwNext!).catch((error) => { // eslint-disable-line @typescript-eslint/no-non-null-assertion
 		const clientIp = getProbeIp(socket.request) ?? '';
 		const reason = isError(error) ? error.message : 'unknown';

--- a/src/lib/ws/helper/reconnect-probes.ts
+++ b/src/lib/ws/helper/reconnect-probes.ts
@@ -1,8 +1,8 @@
-import { fetchSockets } from '../server.js';
+import type { ThrottledFetchSockets } from '../server';
 
 const TIME_TO_RECONNECT_PROBES = 60_000;
 
-export const reconnectProbes = async () => {
+export const reconnectProbes = async (fetchSockets: ThrottledFetchSockets) => { // passing fetchSockets in arguments to avoid cycle dependency
 	const sockets = await fetchSockets();
 
 	for (const socket of sockets) {

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -46,7 +46,7 @@ export const initWsServer = async () => {
 	);
 
 	setTimeout(() => {
-		reconnectProbes().catch(error => logger.error(error));
+		reconnectProbes(fetchSockets).catch(error => logger.error(error));
 	}, TIME_UNTIL_VM_BECOMES_HEALTHY);
 };
 
@@ -67,3 +67,5 @@ export const fetchSockets = async () => {
 
 	return sockets;
 };
+
+export type ThrottledFetchSockets = typeof fetchSockets;

--- a/src/measurement/route/create-measurement.ts
+++ b/src/measurement/route/create-measurement.ts
@@ -6,6 +6,7 @@ import type { MeasurementRequest } from '../types.js';
 import { bodyParser } from '../../lib/http/middleware/body-parser.js';
 import { validate } from '../../lib/http/middleware/validate.js';
 import { schema } from '../schema/global-schema.js';
+import { rateLimitHandler } from '../../lib/http/middleware/ratelimit.js';
 
 const hostConfig = config.get<string>('server.host');
 const runner = getMeasurementRunner();
@@ -24,5 +25,5 @@ const handle = async (ctx: Context): Promise<void> => {
 };
 
 export const registerCreateMeasurementRoute = (router: Router): void => {
-	router.post('/measurements', bodyParser(), validate(schema), handle);
+	router.post('/measurements', bodyParser(), validate(schema), rateLimitHandler(), handle);
 };

--- a/src/measurement/schema/location-schema.ts
+++ b/src/measurement/schema/location-schema.ts
@@ -29,5 +29,6 @@ export const schema = Joi.array().items(Joi.object().keys({
 	limit: Joi.number().min(1).max(measurementConfig.limits.location).when(Joi.ref('/limit'), {
 		is: Joi.exist(),
 		then: Joi.forbidden().messages({ 'any.unknown': 'limit per location is not allowed when a global limit is set' }),
+		otherwise: Joi.number().default(1),
 	}),
 }).or('continent', 'region', 'country', 'state', 'city', 'network', 'asn', 'magic', 'tags')).default(GLOBAL_DEFAULTS.locations);

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -163,7 +163,7 @@ type TestProgress = {
 export type RequestType = 'ping' | 'traceroute' | 'dns' | 'http' | 'mtr';
 
 export type MeasurementOptions = PingTest | TracerouteTest | MtrTest | DnsTest | HttpTest;
-export type LocationWithLimit = Location & {limit?: number};
+export type LocationWithLimit = Location & {limit: number};
 
 /**
  * Measurement Objects

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -163,7 +163,7 @@ type TestProgress = {
 export type RequestType = 'ping' | 'traceroute' | 'dns' | 'http' | 'mtr';
 
 export type MeasurementOptions = PingTest | TracerouteTest | MtrTest | DnsTest | HttpTest;
-export type LocationWithLimit = Location & {limit: number};
+export type LocationWithLimit = Location & {limit?: number};
 
 /**
  * Measurement Objects

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -18,18 +18,26 @@ import getProbeIp from '../lib/get-probe-ip.js';
 import { getRegion } from '../lib/ip-ranges.js';
 import type { Probe, ProbeLocation, Tag } from './types.js';
 
-const fakeIpForDebug = () => _.sample([
-	'18.200.0.1', // aws-eu-west-1
-	'34.140.0.10', // gcp-europe-west1
-	'95.155.94.127',
-	'65.49.22.66',
-	'185.229.226.83',
-	'51.158.22.211',
-	'131.255.7.26',
-	'213.136.174.80',
-	'94.214.253.78',
-	'79.205.97.254',
-]);
+const fakeIpForDebug = () => {
+	/**
+	 * Ips for test and dev should be separated so redis will not return dev data during the tests
+	 */
+	if (process.env['NODE_ENV'] === 'test') {
+		return '95.155.94.127';
+	}
+
+	return _.sample([
+		'18.200.0.1', // aws-eu-west-1
+		'34.140.0.10', // gcp-europe-west1
+		'65.49.22.66',
+		'185.229.226.83',
+		'51.158.22.211',
+		'131.255.7.26',
+		'213.136.174.80',
+		'94.214.253.78',
+		'79.205.97.254',
+	]);
+};
 
 const geoipClient = createGeoipClient();
 

--- a/src/probe/handler/dns.ts
+++ b/src/probe/handler/dns.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { Probe } from '../types.js';
 
 export const handleDnsUpdate = (probe: Probe) => (list: string[]): void => {
 	probe.resolvers = list;

--- a/src/probe/handler/stats.ts
+++ b/src/probe/handler/stats.ts
@@ -1,7 +1,4 @@
-import type {
-	Probe,
-	ProbeStats,
-} from '../../probe/types.js';
+import type { Probe, ProbeStats } from '../types.js';
 
 export const handleStatsReport = (probe: Probe) => (report: ProbeStats): void => {
 	probe.stats = report;

--- a/src/probe/handler/status.ts
+++ b/src/probe/handler/status.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { Probe } from '../types.js';
 
 export const handleStatusUpdate = (probe: Probe) => (status: Probe['status']): void => {
 	probe.status = status;

--- a/test/mocks/redis-cache.ts
+++ b/test/mocks/redis-cache.ts
@@ -1,5 +1,0 @@
-export default class RedisCacheMock {
-	set = () => Promise.resolve();
-	get = () => Promise.resolve();
-	delete = () => Promise.resolve();
-}

--- a/test/tests/integration/measurement/create-measurement.test.ts
+++ b/test/tests/integration/measurement/create-measurement.test.ts
@@ -5,7 +5,6 @@ import request, { type SuperTest, type Test } from 'supertest';
 import * as td from 'testdouble';
 import nock from 'nock';
 import type { Socket } from 'socket.io-client';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
@@ -16,7 +15,6 @@ describe('Create measurement', () => {
 	let requestAgent: SuperTest<Test>;
 
 	before(async () => {
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: () => 'gcp-us-west4', populateMemList: () => Promise.resolve() });
 		({ getTestServer, addFakeProbe, deleteFakeProbe } = await import('../../../utils/server.js'));
 		const app = await getTestServer();

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -5,7 +5,6 @@ import nock from 'nock';
 import type { Socket } from 'socket.io-client';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
@@ -22,7 +21,6 @@ describe('Create measurement request', () => {
 
 	before(async () => {
 		await td.replaceEsm('crypto-random-string', {}, cryptoRandomString);
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: () => 'gcp-us-west4', populateMemList: () => Promise.resolve() });
 		({ getTestServer, addFakeProbe, deleteFakeProbe } = await import('../../../utils/server.js'));
 		const app = await getTestServer();

--- a/test/tests/integration/measurement/timeout-result.test.ts
+++ b/test/tests/integration/measurement/timeout-result.test.ts
@@ -5,7 +5,6 @@ import nock from 'nock';
 import type { Socket } from 'socket.io-client';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
@@ -23,7 +22,6 @@ describe('Timeout results', () => {
 		sandbox = sinon.createSandbox({ useFakeTimers: true });
 		await td.replaceEsm('@jcoreio/async-throttle', null, (f: any) => f);
 		await td.replaceEsm('crypto-random-string', {}, cryptoRandomString);
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: () => 'gcp-us-west4', populateMemList: () => Promise.resolve() });
 		({ getTestServer, addFakeProbe, deleteFakeProbe } = await import('../../../utils/server.js'));
 		const app = await getTestServer();

--- a/test/tests/integration/middleware/compress.test.ts
+++ b/test/tests/integration/middleware/compress.test.ts
@@ -1,26 +1,19 @@
 import fs from 'node:fs';
 import request, { type Response } from 'supertest';
 import { expect } from 'chai';
-import * as td from 'testdouble';
 import nock from 'nock';
 import type { Socket } from 'socket.io-client';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
+import { getTestServer, addFakeProbe, deleteFakeProbe } from '../../../utils/server.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
 describe('compression', () => {
-	let addFakeProbe: () => Promise<Socket>;
-	let deleteFakeProbe: (socket: Socket) => Promise<void>;
 	let requestAgent: any;
 	let probes: Socket[] = [];
 
 	describe('headers', () => {
 		before(async () => {
-			await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
-			const http = await import('../../../utils/server.js');
-			addFakeProbe = http.addFakeProbe;
-			deleteFakeProbe = http.deleteFakeProbe;
-			const app = await http.getTestServer();
+			const app = await getTestServer();
 			requestAgent = request(app);
 		});
 

--- a/test/tests/integration/middleware/compress.test.ts
+++ b/test/tests/integration/middleware/compress.test.ts
@@ -39,7 +39,6 @@ describe('compression', () => {
 				probe.emit('probe:status:update', 'ready');
 			}
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			const response = await requestAgent
 				.get('/v1/probes')
 				.set('accept-encoding', '*')

--- a/test/tests/integration/middleware/cors.test.ts
+++ b/test/tests/integration/middleware/cors.test.ts
@@ -15,14 +15,12 @@ describe('cors', () => {
 
 	describe('Access-Control-Allow-Origin header', () => {
 		it('should include the header with value of *', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			const response = await requestAgent.get('/v1/').set('Origin', 'elocast.com').send() as Response;
 
 			expect(response.headers['access-control-allow-origin']).to.equal('*');
 		});
 
 		it('should include the header at root', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			const response = await requestAgent.get('/').send() as Response;
 
 			expect(response.headers['access-control-allow-origin']).to.equal('*');

--- a/test/tests/integration/middleware/domain-redirect.test.ts
+++ b/test/tests/integration/middleware/domain-redirect.test.ts
@@ -15,7 +15,6 @@ describe('domain redirect', () => {
 
 	describe('http requests', () => {
 		it('should be redirected to "https://jsdelivr.com/globalping" if Host is "globalping.io"', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			await requestAgent
 				.get('/v1/probes')
 				.send()
@@ -27,7 +26,6 @@ describe('domain redirect', () => {
 		});
 
 		it('should not be redirected to if Host is not "globalping.io"', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			await requestAgent
 				.get('/v1/probes')
 				.send()

--- a/test/tests/integration/middleware/etag.test.ts
+++ b/test/tests/integration/middleware/etag.test.ts
@@ -15,7 +15,6 @@ describe('etag', () => {
 
 	describe('ETag header', () => {
 		it('should include the header', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			const response = await requestAgent.get('/v1/probes').send() as Response;
 
 			expect(response.headers.etag).to.exist;
@@ -24,7 +23,6 @@ describe('etag', () => {
 
 	describe('conditional get', () => {
 		it('should redirect to cache', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			const response = await requestAgent
 				.get('/v1/probes')
 				.set('if-none-match', 'W/"2-l9Fw4VUO7kr8CvBlt4zaMCqXZ0w"')

--- a/test/tests/integration/middleware/ratelimit.test.ts
+++ b/test/tests/integration/middleware/ratelimit.test.ts
@@ -3,19 +3,20 @@ import request, { type Response } from 'supertest';
 import requestIp from 'request-ip';
 import type { RateLimiterRedis } from 'rate-limiter-flexible';
 import { expect } from 'chai';
-import { getTestServer } from '../../../utils/server.js';
+import { Socket } from 'socket.io-client';
+import { getTestServer, addFakeProbe, deleteFakeProbe } from '../../../utils/server.js';
 
 describe('rate limiter', () => {
 	let app: Server;
 	let requestAgent: any;
 	let clientIpv6: string;
 	let rateLimiterInstance: RateLimiterRedis;
+	let probe: Socket;
 
 	before(async () => {
 		app = await getTestServer();
 		requestAgent = request(app);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		const httpResponse = await requestAgent.post('/v1/').send() as Response & {req: any};
 		// Supertest renders request as ipv4
 		const clientIp = requestIp.getClientIp(httpResponse.req);
@@ -24,6 +25,12 @@ describe('rate limiter', () => {
 
 		const rateLimiter = await import('../../../../src/lib/ratelimiter.js');
 		rateLimiterInstance = rateLimiter.default;
+		probe = await addFakeProbe();
+		probe.emit('probe:status:update', 'ready');
+	});
+
+	after(async () => {
+		await deleteFakeProbe(probe);
 	});
 
 	afterEach(async () => {
@@ -32,7 +39,6 @@ describe('rate limiter', () => {
 
 	describe('headers', () => {
 		it('should NOT include headers (GET)', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			const response = await requestAgent.get('/v1/').send() as Response;
 
 			expect(response.headers['x-ratelimit-limit']).to.not.exist;
@@ -40,25 +46,43 @@ describe('rate limiter', () => {
 			expect(response.headers['x-ratelimit-reset']).to.not.exist;
 		});
 
-		it('should include headers (POST)', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		it('should NOT include headers if body is not valid (POST)', async () => {
 			const response = await requestAgent.post('/v1/measurements').send() as Response;
+
+			expect(response.headers['x-ratelimit-limit']).to.not.exist;
+			expect(response.headers['x-ratelimit-remaining']).to.not.exist;
+			expect(response.headers['x-ratelimit-reset']).to.not.exist;
+		});
+
+		it('should include headers (POST)', async () => {
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+			}) as Response;
 
 			expect(response.headers['x-ratelimit-limit']).to.exist;
 			expect(response.headers['x-ratelimit-remaining']).to.exist;
 			expect(response.headers['x-ratelimit-reset']).to.exist;
 		});
 
-		it('should change values on next request (5) (POST)', async () => {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			const requestPromise = () => requestAgent.post('/v1/measurements').send() as Response;
-			const responseList = await Promise.all(Array.from({ length: 5 }).map(() => requestPromise()));
+		it('should change values on multiple requests (POST)', async () => {
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+			}) as Response;
 
-			const firstResponse = responseList[0];
-			const lastResponse = responseList[4];
+			expect(response.headers['x-ratelimit-limit']).to.equal('100000');
+			expect(response.headers['x-ratelimit-remaining']).to.equal('99999');
+			expect(response.headers['x-ratelimit-reset']).to.equal('3600');
 
-			expect(responseList).to.have.lengthOf(5);
-			expect(firstResponse?.headers?.['x-ratelimit-remaining']).to.not.equal(lastResponse?.headers?.['x-ratelimit-remaining']);
+			const response2 = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+			}) as Response;
+
+			expect(response2.headers['x-ratelimit-limit']).to.equal('100000');
+			expect(response2.headers['x-ratelimit-remaining']).to.equal('99998');
+			expect(response2.headers['x-ratelimit-reset']).to.equal('3600');
 		});
 	});
 
@@ -66,17 +90,21 @@ describe('rate limiter', () => {
 		it('should succeed (limit not reached)', async () => {
 			await rateLimiterInstance.set(clientIpv6, 0, 0);
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			const response = await requestAgent.post('/v1/measurements').send() as Response;
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+			}) as Response;
 
-			expect(Number(response.headers['x-ratelimit-remaining'])).to.equal(299);
+			expect(Number(response.headers['x-ratelimit-remaining'])).to.equal(99999);
 		});
 
 		it('should fail (limit reached) (start at 100)', async () => {
-			await rateLimiterInstance.set(clientIpv6, 300, 0);
+			await rateLimiterInstance.set(clientIpv6, 100000, 0);
 
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			const response = await requestAgent.post('/v1/measurements').send() as Response;
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+			}) as Response;
 
 			expect(Number(response.headers['x-ratelimit-remaining'])).to.equal(0);
 			expect(response.statusCode).to.equal(429);

--- a/test/tests/integration/middleware/ratelimit.test.ts
+++ b/test/tests/integration/middleware/ratelimit.test.ts
@@ -3,7 +3,7 @@ import request, { type Response } from 'supertest';
 import requestIp from 'request-ip';
 import type { RateLimiterRedis } from 'rate-limiter-flexible';
 import { expect } from 'chai';
-import { Socket } from 'socket.io-client';
+import type { Socket } from 'socket.io-client';
 import { getTestServer, addFakeProbe, deleteFakeProbe } from '../../../utils/server.js';
 
 describe('rate limiter', () => {

--- a/test/tests/integration/middleware/responsetime.test.ts
+++ b/test/tests/integration/middleware/responsetime.test.ts
@@ -16,7 +16,6 @@ describe('response time', () => {
 	describe('X-Response-Time header', () => {
 		describe('should include the header', (): void => {
 			it('should succeed', async () => {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 				const response = await requestAgent.get('/v1/').send() as Response;
 
 				expect(response.headers['x-response-time']).to.exist;

--- a/test/tests/integration/probes/get-probes.test.ts
+++ b/test/tests/integration/probes/get-probes.test.ts
@@ -5,28 +5,23 @@ import { expect } from 'chai';
 import request, { type SuperTest, type Test } from 'supertest';
 import * as td from 'testdouble';
 import type { Socket } from 'socket.io-client';
-import RedisCacheMock from '../../../mocks/redis-cache.js';
+import { getTestServer, addFakeProbe as addProbe, deleteFakeProbe } from '../../../utils/server.js';
 
 const nockMocks = JSON.parse(fs.readFileSync('./test/mocks/nock-geoip.json').toString()) as Record<string, any>;
 
 describe('Get Probes', () => {
-	let addFakeProbe: () => Promise<Socket>;
-	let deleteFakeProbe: (socket: Socket) => Promise<void>;
 	let requestAgent: SuperTest<Test>;
+	let addFakeProbe: () => Promise<Socket>;
 	const probes: Socket[] = [];
 
 	before(async () => {
-		await td.replaceEsm('../../../../src/lib/cache/redis-cache.ts', {}, RedisCacheMock);
-		const http = await import('../../../utils/server.js');
-		deleteFakeProbe = http.deleteFakeProbe;
-
 		addFakeProbe = async () => {
-			const probe = await http.addFakeProbe();
+			const probe = await addProbe();
 			probes.push(probe);
 			return probe;
 		};
 
-		const app = await http.getTestServer();
+		const app = await getTestServer();
 		requestAgent = request(app);
 	});
 

--- a/test/tests/unit/middleware/ratelimit.test.ts
+++ b/test/tests/unit/middleware/ratelimit.test.ts
@@ -1,0 +1,159 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import rateLimiter from '../../../../src/lib/ratelimiter.js';
+import { rateLimitHandler } from '../../../../src/lib/http/middleware/ratelimit.js';
+import createHttpError from 'http-errors';
+
+describe('rate limit middleware', () => {
+	const defaultCtx: any = {
+		set: sinon.stub(),
+		req: {},
+		request: {
+			body: {},
+		},
+		response: {},
+	};
+	let ctx = { ...defaultCtx };
+
+	beforeEach(async () => {
+		defaultCtx.set.reset();
+		ctx = { ...defaultCtx };
+		await rateLimiter.delete('');
+	});
+
+	it('should set rate limit headers based on the "probesCount" field value', async () => {
+		ctx.request.body = {
+			limit: 10,
+			locations: [],
+		};
+
+		const next: any = () => {
+			ctx.response.body = {
+				id: 'id',
+				probesCount: 5,
+			};
+		};
+
+		await rateLimitHandler()(ctx, next);
+
+		expect(ctx.set.callCount).to.equal(3);
+		expect(ctx.set.firstCall.args[0]).to.equal('X-RateLimit-Reset');
+		expect(ctx.set.secondCall.args).to.deep.equal([ 'X-RateLimit-Limit', '100000' ]);
+		expect(ctx.set.thirdCall.args).to.deep.equal([ 'X-RateLimit-Remaining', '99995' ]);
+	});
+
+	it('should throw an error if response body doesn\'t have "probesCount" field', async () => {
+		ctx.request.body = {
+			limit: 10,
+			locations: [],
+		};
+
+		const next: any = () => {
+			ctx.response.body = {};
+		};
+
+		const err = await rateLimitHandler()(ctx, next).catch(err => err);
+		expect(err).to.deep.equal(new Error('Missing probesCount field in response object'));
+	});
+
+	it('should NOT set rate limit headers for admin', async () => {
+		ctx.request.body = {
+			limit: 10,
+			locations: [],
+		};
+
+		ctx.isAdmin = true;
+
+		const next: any = () => {
+			ctx.response.body = {
+				id: 'id',
+				probesCount: 10,
+			};
+		};
+
+		await rateLimitHandler()(ctx, next);
+		expect(ctx.set.callCount).to.equal(0);
+	});
+
+	it('should validate request based on the "limit" field value', async () => {
+		ctx.request.body = {
+			limit: 60000,
+			locations: [],
+		};
+
+		const next: any = () => {
+			ctx.response.body = {
+				id: 'id',
+				probesCount: 60000,
+			};
+		};
+
+		await rateLimitHandler()(ctx, next);
+		expect(ctx.set.args[2]).to.deep.equal([ 'X-RateLimit-Remaining', '40000' ]);
+
+		const err = await rateLimitHandler()(ctx, next).catch(err => err); // 60000 > 40000 so another request with the same body fails
+		expect(err).to.deep.equal(createHttpError(429, 'Too Many Probes Requested', { type: 'too_many_probes' }));
+		expect(ctx.set.args[5]).to.deep.equal([ 'X-RateLimit-Remaining', '40000' ]);
+
+		ctx.request.body = {
+			limit: 40000,
+			locations: [],
+		};
+
+		const next2: any = () => {
+			ctx.response.body = {
+				id: 'id',
+				probesCount: 40000,
+			};
+		};
+
+		await rateLimitHandler()(ctx, next2); // 40000 === 40000 so request with the updated body works
+		expect(ctx.set.args[8]).to.deep.equal([ 'X-RateLimit-Remaining', '0' ]);
+	});
+
+	it('should validate request based on the "location.limit" field value', async () => {
+		ctx.request.body = {
+			locations: [{
+				continent: 'EU',
+				limit: 45000,
+			}, {
+				continent: 'NA',
+				limit: 45000,
+			}],
+		};
+
+		const next: any = () => {
+			ctx.response.body = {
+				id: 'id',
+				probesCount: 90000,
+			};
+		};
+
+		await rateLimitHandler()(ctx, next);
+		expect(ctx.set.args[2]).to.deep.equal([ 'X-RateLimit-Remaining', '10000' ]);
+
+		const err = await rateLimitHandler()(ctx, next).catch(err => err); // only 10000 points remaining so another request with the same body fails
+		expect(err).to.deep.equal(createHttpError(429, 'Too Many Probes Requested', { type: 'too_many_probes' }));
+		expect(ctx.set.args[5]).to.deep.equal([ 'X-RateLimit-Remaining', '10000' ]);
+
+		ctx.request.body = {
+			locations: [{
+				continent: 'EU',
+				limit: 5000,
+			}, {
+				continent: 'NA',
+				limit: 5000,
+			}],
+		};
+
+		const next2: any = () => {
+			ctx.response.body = {
+				id: 'id',
+				probesCount: 10000,
+			};
+		};
+
+		await rateLimitHandler()(ctx, next2); // request with 10000 probes will work fine
+		expect(ctx.set.args[8]).to.deep.equal([ 'X-RateLimit-Remaining', '0' ]);
+	});
+});


### PR DESCRIPTION
V2 PR to trigger CI build.

Fixes https://github.com/jsdelivr/globalping/issues/372

Nock module throws errors as expected. Our source code catches 3rd party ip geo errors and that handling was wrong (explained in further comment). That was the real reason we were not able to see an explicit error.
Additionally redis cached some of the geo ip values during tests, which made them pass locally and fail on CI.