### PR TITLE
fix: make geoip client work even if redis is broken

### DIFF
--- a/src/lib/geoip/client.ts
+++ b/src/lib/geoip/client.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import config from 'config';
-import type { Logger } from 'winston';
 import newrelic from 'newrelic';
 import type { CacheInterface } from '../cache/cache-interface.js';
 import { InternalError } from '../internal-error.js';
@@ -27,16 +26,12 @@ export type NetworkInfo = {
 	asn: number;
 };
 
-export const createGeoipClient = (): GeoipClient => new GeoipClient(
-	new RedisCache(getRedisClient()),
-	scopedLogger('geoip'),
-);
+const logger = scopedLogger('geoip');
+
+export const createGeoipClient = (): GeoipClient => new GeoipClient(new RedisCache(getRedisClient()));
 
 export default class GeoipClient {
-	constructor (
-		private readonly cache: CacheInterface,
-		private readonly logger: Logger,
-	) {}
+	constructor (private readonly cache: CacheInterface) {}
 
 	async lookup (addr: string): Promise<ProbeLocation> {
 		const results = await Promise
@@ -155,7 +150,7 @@ export default class GeoipClient {
 		}
 
 		if (!best || best.provider === 'fastly') {
-			this.logger.error(`failed to find a correct value for a field "${field}"`, { field, sources });
+			logger.error(`failed to find a correct value for a field "${field}"`, { field, sources });
 			throw new Error(`failed to find a correct value for a field "${field}"`);
 		}
 
@@ -163,7 +158,10 @@ export default class GeoipClient {
 	}
 
 	public async lookupWithCache<T> (key: string, fn: () => Promise<T>): Promise<T> {
-		const cached = await this.cache.get<T>(key);
+		const cached = await this.cache.get<T>(key).catch((error: Error) => {
+			logger.error('Failed to get cached geoip info for probe.', error);
+			newrelic.noticeError(error, { key });
+		});
 
 		if (cached) {
 			return cached;
@@ -173,7 +171,7 @@ export default class GeoipClient {
 		const ttl = Number(config.get('geoip.cache.ttl'));
 
 		await this.cache.set(key, info, ttl).catch((error: Error) => {
-			this.logger.error('Failed to cache geoip info for probe.', error);
+			logger.error('Failed to cache geoip info for probe.', error);
 			newrelic.noticeError(error, { key, ttl });
 		});
 


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/388

At the time of the issue redis was in a strange state, it was rejecting all the queries (GET, SET, etc.). Our geo ip logic uses redis to get cached value before making real requests to the 3rd party geo APIs. Since get command was throwing errors the whole geo ip function was throwing and API were unable to get the geo ips of probes and sent `unresolvable geoip` to them.

Probes were constantly reconnecting when API was down. But they stopped reconnecting after getting `unresolvable geoip` error from the API, which is valid behaviour from the perspective of the probe.

In that fix we are catching any geo ip redis errors and making request to the 3rd party geo APIs not only if there is no value in the cache but also if the cache itself is buggy/unavailable.