### PR TITLE
feat: add option to force refresh fetchSockets value

### DIFF
--- a/src/lib/ws/helper/probe-ip-limit.ts
+++ b/src/lib/ws/helper/probe-ip-limit.ts
@@ -10,7 +10,7 @@ export const verifyIpLimit = async (ip: string, socketId: string): Promise<void>
 		return;
 	}
 
-	const socketList = await fetchSockets();
+	const socketList = await fetchSockets({ forceRefresh: true });
 	const previousSocket = socketList.find(s => s.data.probe.ipAddress === ip && s.id !== socketId);
 
 	if (previousSocket) {

--- a/src/lib/ws/helper/throttle.ts
+++ b/src/lib/ws/helper/throttle.ts
@@ -6,7 +6,7 @@ const throttle = <Value>(func: () => Promise<Value>, time: number) => {
 		ttl: time,
 		fetchMethod: func,
 	});
-	return () => cache.fetch('') as Promise<Value>;
+	return (options?: {forceRefresh: true}) => cache.fetch('', options) as Promise<Value>;
 };
 
 export default throttle;

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -19,7 +19,7 @@ const TIME_UNTIL_VM_BECOMES_HEALTHY = 8000;
 const logger = scopedLogger('ws-server');
 
 let io: WsServer;
-let throttledFetchSockets: () => Promise<RemoteSocket<DefaultEventsMap, SocketData>[]>;
+let throttledFetchSockets: (options?: {forceRefresh: true}) => Promise<RemoteSocket<DefaultEventsMap, SocketData>[]>;
 
 export const initWsServer = async () => {
 	const pubClient = getRedisClient().duplicate();
@@ -54,12 +54,12 @@ export const getWsServer = (): WsServer => {
 	return io;
 };
 
-export const fetchSockets = async () => {
+export const fetchSockets = async (options?: {forceRefresh: true}) => {
 	if (!io || !throttledFetchSockets) {
 		throw new Error('WS server not initialized yet');
 	}
 
-	const sockets = await throttledFetchSockets();
+	const sockets = await throttledFetchSockets(options);
 
 	return sockets;
 };


### PR DESCRIPTION
Fixes: https://github.com/jsdelivr/globalping/issues/404

Note: Multiple calls with `forceRefresh` result in one real request so no extra calls performed.