### PR TITLE
Refactor: replace `private-ip` with Node.js native API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
 				"maxmind": "^4.3.10",
 				"newrelic": "^10.4.1",
 				"physical-cpu-count": "^2.0.0",
-				"private-ip": "^3.0.0",
 				"rate-limiter-flexible": "^2.4.1",
 				"redis": "^4.6.5",
 				"request-ip": "^3.3.0",
@@ -2337,11 +2336,6 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
-		},
-		"node_modules/@chainsafe/is-ip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
-			"integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
 			"version": "10.5.0",
@@ -10591,17 +10585,6 @@
 			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
 			"dev": true
 		},
-		"node_modules/ip-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-			"integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ip6addr": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/ip6addr/-/ip6addr-0.2.5.tgz",
@@ -12722,6 +12705,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
 			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 0.4.0"
 			}
@@ -14607,20 +14591,6 @@
 			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
 			"dev": true
-		},
-		"node_modules/private-ip": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
-			"integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
-			"dependencies": {
-				"@chainsafe/is-ip": "^2.0.1",
-				"ip-regex": "^5.0.0",
-				"ipaddr.js": "^2.0.1",
-				"netmask": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=14.16"
-			}
 		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
@@ -19502,11 +19472,6 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
-		},
-		"@chainsafe/is-ip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
-			"integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
 		},
 		"@chevrotain/cst-dts-gen": {
 			"version": "10.5.0",
@@ -25929,11 +25894,6 @@
 			"integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
 			"dev": true
 		},
-		"ip-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-			"integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-		},
 		"ip6addr": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/ip6addr/-/ip6addr-0.2.5.tgz",
@@ -27549,7 +27509,8 @@
 		"netmask": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"dev": true
 		},
 		"newman": {
 			"version": "5.3.2",
@@ -29009,17 +28970,6 @@
 			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
 			"dev": true
-		},
-		"private-ip": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/private-ip/-/private-ip-3.0.0.tgz",
-			"integrity": "sha512-HkMBs4nMtrP+cvcw0bDi2BAZIGgiKI4Zq8Oc+dMqNBpHS8iGL4+WO/pRtc8Bwnv9rjnV0QwMDwEBymFtqv7Kww==",
-			"requires": {
-				"@chainsafe/is-ip": "^2.0.1",
-				"ip-regex": "^5.0.0",
-				"ipaddr.js": "^2.0.1",
-				"netmask": "^2.0.2"
-			}
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"maxmind": "^4.3.10",
 		"newrelic": "^10.4.1",
 		"physical-cpu-count": "^2.0.0",
-		"private-ip": "^3.0.0",
 		"rate-limiter-flexible": "^2.4.1",
 		"redis": "^4.6.5",
 		"request-ip": "^3.3.0",

--- a/src/lib/private-ip.ts
+++ b/src/lib/private-ip.ts
@@ -1,0 +1,50 @@
+import { isIP, BlockList } from 'net';
+
+const privateBlockList = new BlockList();
+// https://en.wikipedia.org/wiki/Reserved_IP_addresses
+// IPv4
+privateBlockList.addSubnet('0.0.0.0', 8, 'ipv4');
+privateBlockList.addSubnet('10.0.0.0', 8, 'ipv4');
+privateBlockList.addSubnet('100.64.0.0', 10, 'ipv4');
+privateBlockList.addSubnet('127.0.0.0', 8, 'ipv4');
+privateBlockList.addSubnet('169.254.0.0', 16, 'ipv4');
+privateBlockList.addSubnet('172.16.0.0', 12, 'ipv4');
+privateBlockList.addSubnet('192.0.0.0', 24, 'ipv4');
+privateBlockList.addSubnet('192.0.2.0', 24, 'ipv4');
+privateBlockList.addSubnet('192.88.99.0', 24, 'ipv4');
+privateBlockList.addSubnet('192.168.0.0', 16, 'ipv4');
+privateBlockList.addSubnet('198.18.0.0', 15, 'ipv4');
+privateBlockList.addSubnet('198.51.100.0', 24, 'ipv4');
+privateBlockList.addSubnet('203.0.113.0', 24, 'ipv4');
+privateBlockList.addSubnet('224.0.0.0', 4, 'ipv4');
+privateBlockList.addSubnet('240.0.0.0', 4, 'ipv4');
+privateBlockList.addAddress('255.255.255.255', 'ipv4');
+// IPv6
+privateBlockList.addSubnet('::', 128, 'ipv6');
+privateBlockList.addSubnet('::1', 128, 'ipv6');
+privateBlockList.addSubnet('::ffff:0:0', 96, 'ipv6');
+privateBlockList.addSubnet('64:ff9b::', 96, 'ipv6');
+privateBlockList.addSubnet('64:ff9b:1::', 48, 'ipv6');
+privateBlockList.addSubnet('100::', 64, 'ipv6');
+privateBlockList.addSubnet('2001::', 32, 'ipv6');
+privateBlockList.addSubnet('2001:20::', 28, 'ipv6');
+privateBlockList.addSubnet('2001:db8::', 32, 'ipv6');
+privateBlockList.addSubnet('2002::', 16, 'ipv6');
+privateBlockList.addSubnet('fc00::', 7, 'ipv6');
+privateBlockList.addSubnet('fe80::', 10, 'ipv6');
+privateBlockList.addSubnet('ff00::', 8, 'ipv6');
+
+export const isIpPrivate = (ip: string) => {
+	const ipVersion = isIP(ip);
+
+	if (ipVersion === 4) {
+		return privateBlockList.check(ip, 'ipv4');
+	}
+
+	if (ipVersion === 6) {
+		return privateBlockList.check(ip, 'ipv6');
+	}
+
+	// Not a valid IP
+	return false;
+};

--- a/src/lib/private-ip.ts
+++ b/src/lib/private-ip.ts
@@ -1,6 +1,7 @@
 import { isIP, BlockList } from 'net';
 
 const privateBlockList = new BlockList();
+
 // https://en.wikipedia.org/wiki/Reserved_IP_addresses
 // IPv4
 privateBlockList.addSubnet('0.0.0.0', 8, 'ipv4');
@@ -19,20 +20,6 @@ privateBlockList.addSubnet('203.0.113.0', 24, 'ipv4');
 privateBlockList.addSubnet('224.0.0.0', 4, 'ipv4');
 privateBlockList.addSubnet('240.0.0.0', 4, 'ipv4');
 privateBlockList.addAddress('255.255.255.255', 'ipv4');
-// IPv6
-privateBlockList.addSubnet('::', 128, 'ipv6');
-privateBlockList.addSubnet('::1', 128, 'ipv6');
-privateBlockList.addSubnet('::ffff:0:0', 96, 'ipv6');
-privateBlockList.addSubnet('64:ff9b::', 96, 'ipv6');
-privateBlockList.addSubnet('64:ff9b:1::', 48, 'ipv6');
-privateBlockList.addSubnet('100::', 64, 'ipv6');
-privateBlockList.addSubnet('2001::', 32, 'ipv6');
-privateBlockList.addSubnet('2001:20::', 28, 'ipv6');
-privateBlockList.addSubnet('2001:db8::', 32, 'ipv6');
-privateBlockList.addSubnet('2002::', 16, 'ipv6');
-privateBlockList.addSubnet('fc00::', 7, 'ipv6');
-privateBlockList.addSubnet('fe80::', 10, 'ipv6');
-privateBlockList.addSubnet('ff00::', 8, 'ipv6');
 
 export const isIpPrivate = (ip: string) => {
 	const ipVersion = isIP(ip);

--- a/src/lib/private-ip.ts
+++ b/src/lib/private-ip.ts
@@ -29,7 +29,7 @@ export const isIpPrivate = (ip: string) => {
 	}
 
 	if (ipVersion === 6) {
-		return privateBlockList.check(ip, 'ipv6');
+		throw new Error('IPv6 not supported');
 	}
 
 	// Not a valid IP

--- a/src/measurement/schema/utils.ts
+++ b/src/measurement/schema/utils.ts
@@ -5,7 +5,6 @@ import Joi, {
 	type PresenceMode,
 } from 'joi';
 import validator from 'validator';
-import isIpPrivate from 'private-ip';
 import _ from 'lodash';
 import {
 	joiValidate as joiMalwareValidate,
@@ -13,6 +12,7 @@ import {
 import { joiValidate as joiMalwareValidateIp } from '../../lib/malware/ip.js';
 import { joiValidate as joiMalwareValidateDomain } from '../../lib/malware/domain.js';
 import type { MeasurementRecord, MeasurementRequest } from '../types.js';
+import { isIpPrivate } from '../../lib/private-ip.js';
 
 export const joiValidateDomain = () => (value: string, helpers: CustomHelpers): string | ErrorReport => {
 	const options = {

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -1,7 +1,7 @@
 import * as process from 'node:process';
 import _ from 'lodash';
 import type { Socket } from 'socket.io';
-import isIpPrivate from 'private-ip';
+import { isIpPrivate } from '../lib/private-ip.js';
 import semver from 'semver';
 import {
 	getStateNameByIso,


### PR DESCRIPTION
The PR replaces the `private-ip` npm package with Node.js built-in native API.

The `net.BlockList` API is first introduced in Node.js 14.18.0 and 15.0.0, 
and its API doc can be found here: https://nodejs.org/dist/latest-v18.x/docs/api/net.html#class-netblocklist.

The `net.BlockList` API is originally designed for the purpose of disabling inbound or outbound access to specific IP addresses, IP ranges, or IP subnets. However, it is also a high-performance IP List and can check whether an IP address is included in the list.

The PR creates a `net.BlockList` instance and adds every known private IP range to the list.