### PR TITLE
fix: disable throttling for probe ip limit fetchSockets

### DIFF
--- a/src/lib/geoip/city-approximation.ts
+++ b/src/lib/geoip/city-approximation.ts
@@ -5,7 +5,7 @@ import AdmZip from 'adm-zip';
 import csvParser from 'csv-parser';
 import _ from 'lodash';
 import { getRedisClient, RedisClient } from '../redis/client.js';
-import throttle from '../ws/helper/throttle.js';
+import { throttle } from '../ws/helper/throttle.js';
 import { scopedLogger } from '../logger.js';
 import { getIsDcCity } from './dc-cities.js';
 

--- a/src/lib/ws/helper/probe-ip-limit.ts
+++ b/src/lib/ws/helper/probe-ip-limit.ts
@@ -14,7 +14,7 @@ export const verifyIpLimit = async (ip: string, socketId: string): Promise<void>
 	const status: LRUOptions['status'] = {};
 	let socketList = await fetchSockets({ forceRefresh: true, status });
 
-	// If another fetchSockets was already 'inflight' during our fetchSockets call, result socketList may be stale, so we need to refetch it
+	// If another fetchSockets was already 'inflight' at the moment of a new fetchSockets call, result socketList may be stale, so we need to refetch it.
 	if (status.fetch === 'inflight') {
 		socketList = await fetchSockets({ forceRefresh: true });
 	}

--- a/src/lib/ws/helper/probe-ip-limit.ts
+++ b/src/lib/ws/helper/probe-ip-limit.ts
@@ -1,5 +1,5 @@
 import * as process from 'node:process';
-import { fetchSockets } from '../server.js';
+import { fetchSocketsUntrottled } from '../server.js';
 import { scopedLogger } from '../../logger.js';
 import { InternalError } from '../../internal-error.js';
 
@@ -10,7 +10,7 @@ export const verifyIpLimit = async (ip: string, socketId: string): Promise<void>
 		return;
 	}
 
-	const socketList = await fetchSockets({ forceRefresh: true });
+	const socketList = await fetchSocketsUntrottled();
 	const previousSocket = socketList.find(s => s.data.probe.ipAddress === ip && s.id !== socketId);
 
 	if (previousSocket) {

--- a/src/lib/ws/helper/reconnect-probes.ts
+++ b/src/lib/ws/helper/reconnect-probes.ts
@@ -1,6 +1,6 @@
 import type { ThrottledFetchSockets } from '../server';
 
-const TIME_TO_RECONNECT_PROBES = 60_000;
+const TIME_TO_RECONNECT_PROBES = 2 * 60 * 1000;
 
 export const reconnectProbes = async (fetchSockets: ThrottledFetchSockets) => { // passing fetchSockets in arguments to avoid cycle dependency
 	const sockets = await fetchSockets();

--- a/src/lib/ws/helper/throttle.ts
+++ b/src/lib/ws/helper/throttle.ts
@@ -1,12 +1,12 @@
 import { LRUCache } from 'lru-cache';
 
-const throttle = <Value>(func: () => Promise<Value>, time: number) => {
+export type LRUOptions = LRUCache.FetchOptions<object, any, unknown>;
+
+export const throttle = <Value>(func: () => Promise<Value>, time: number) => {
 	const cache = new LRUCache({
 		max: 1,
 		ttl: time,
 		fetchMethod: func,
 	});
-	return (options?: {forceRefresh: true}) => cache.fetch('', options) as Promise<Value>;
+	return (options?: LRUOptions) => cache.fetch('', options) as Promise<Value>;
 };
-
-export default throttle;

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -5,7 +5,7 @@ import type { DefaultEventsMap } from 'socket.io/dist/typed-events';
 import type { Probe } from '../../probe/types.js';
 import { getRedisClient } from '../redis/client.js';
 import { reconnectProbes } from './helper/reconnect-probes.js';
-import throttle from './helper/throttle.js';
+import { throttle, LRUOptions } from './helper/throttle.js';
 import { scopedLogger } from '../logger.js';
 
 export type SocketData = {
@@ -19,7 +19,7 @@ const TIME_UNTIL_VM_BECOMES_HEALTHY = 8000;
 const logger = scopedLogger('ws-server');
 
 let io: WsServer;
-let throttledFetchSockets: (options?: {forceRefresh: true}) => Promise<RemoteSocket<DefaultEventsMap, SocketData>[]>;
+let throttledFetchSockets: (options?: LRUOptions) => Promise<RemoteSocket<DefaultEventsMap, SocketData>[]>;
 
 export const initWsServer = async () => {
 	const pubClient = getRedisClient().duplicate();
@@ -54,7 +54,7 @@ export const getWsServer = (): WsServer => {
 	return io;
 };
 
-export const fetchSockets = async (options?: {forceRefresh: true}) => {
+export const fetchSockets = async (options?: LRUOptions) => {
 	if (!io || !throttledFetchSockets) {
 		throw new Error('WS server not initialized yet');
 	}

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -65,3 +65,13 @@ export const fetchSockets = async (options?: {forceRefresh: true}) => {
 };
 
 export type ThrottledFetchSockets = typeof fetchSockets;
+
+export const fetchSocketsUntrottled = async () => {
+	if (!io) {
+		throw new Error('WS server not initialized yet');
+	}
+
+	const sockets = await io.of(PROBES_NAMESPACE).fetchSockets();
+
+	return sockets;
+};

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -65,13 +65,3 @@ export const fetchSockets = async (options?: LRUOptions) => {
 };
 
 export type ThrottledFetchSockets = typeof fetchSockets;
-
-export const fetchSocketsUntrottled = async () => {
-	if (!io) {
-		throw new Error('WS server not initialized yet');
-	}
-
-	const sockets = await io.of(PROBES_NAMESPACE).fetchSockets();
-
-	return sockets;
-};

--- a/test/tests/unit/ws/server.test.ts
+++ b/test/tests/unit/ws/server.test.ts
@@ -43,7 +43,7 @@ describe('ws server', () => {
 
 	it('initWsServer should reconnect the probes on start', async () => {
 		await initWsServer();
-		await sandbox.clock.tickAsync(8000 + 60_000 + 1000);
+		await sandbox.clock.tickAsync(8000 + 2 * 60_000 + 1000);
 
 		expect(io.adapter.callCount).to.equal(1);
 		expect(redisClient.connect.callCount).to.equal(2);


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/404.
I've checked the code on a remote dev env (https://github.com/jsdelivr/globalping/issues/418). Performance is the same as for current master, so PR is not adding extra load.
