### PR TITLE
fix: improve rate limit handling when near zero

### DIFF
--- a/test/tests/integration/ratelimit.test.ts
+++ b/test/tests/integration/ratelimit.test.ts
@@ -3,7 +3,6 @@ import request, { type Response } from 'supertest';
 import requestIp from 'request-ip';
 import type { RateLimiterRedis } from 'rate-limiter-flexible';
 import { expect } from 'chai';
-import type { Socket } from 'socket.io-client';
 import { getTestServer, addFakeProbe, deleteFakeProbes } from '../../utils/server.js';
 import nockGeoIpProviders from '../../utils/nock-geo-ip.js';
 
@@ -12,7 +11,6 @@ describe('rate limiter', () => {
 	let requestAgent: any;
 	let clientIpv6: string;
 	let rateLimiterInstance: RateLimiterRedis;
-	let probe: Socket;
 
 	before(async () => {
 		app = await getTestServer();
@@ -28,8 +26,13 @@ describe('rate limiter', () => {
 		rateLimiterInstance = rateLimiter.default;
 
 		nockGeoIpProviders();
-		probe = await addFakeProbe();
-		probe.emit('probe:status:update', 'ready');
+		nockGeoIpProviders();
+
+		const probe1 = await addFakeProbe();
+		const probe2 = await addFakeProbe();
+
+		probe1.emit('probe:status:update', 'ready');
+		probe2.emit('probe:status:update', 'ready');
 	});
 
 
@@ -111,6 +114,18 @@ describe('rate limiter', () => {
 			}).expect(429) as Response;
 
 			expect(Number(response.headers['x-ratelimit-remaining'])).to.equal(0);
+		});
+
+		it('should consume all points successfully or none at all (cost > remaining > 0)', async () => {
+			await rateLimiterInstance.set(clientIpv6, 99999, 0); // 1 remaining
+
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+				limit: 2,
+			}).expect(429) as Response;
+
+			expect(Number(response.headers['x-ratelimit-remaining'])).to.equal(1);
 		});
 	});
 });


### PR DESCRIPTION
Before: 
1. The user has 3 credits remaining and makes a request for 5 locations.
2. The request fails, and **the user has 0 credits remaining.**

After:
1. The user has 3 credits remaining and makes a request for 5 locations.
2. The request fails, and **the user still has 3 credits remaining.**
