### PR TITLE
feat: flush redis only on deploys but not on regular restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       redis:
-        image: redislabs/redismod:latest
+        image: redislabs/rejson:latest
         ports:
           - 6379:6379
         options: >-

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/IP_BLACKLIST.json
 data/AWS_IP_RANGES.json
 data/GCP_IP_RANGES.json
 data/GEONAMES_CITIES.csv
+data/LAST_API_COMMIT_HASH.txt
 probes-stats/known-result.csv
 probes-stats/known-result.json
 probes-stats/all-result.csv

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,2 +1,0 @@
-maxmemory-policy volatile-ttl
-loadmodule /usr/lib/redis/modules/rejson.so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,9 @@ version: "3.8"
 
 services:
   redis:
-    image: redislabs/redismod:latest
+    image: redis/redis-stack-server
     ports:
       - "6379:6379"
-    volumes:
-      - ./config/redis.conf:/usr/local/etc/redis/redis.conf
-    command: /usr/local/etc/redis/redis.conf
 
   mariadb:
     image: mariadb:10.11.5

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
 		"utf-8-validate": "^6.0.3"
 	},
 	"scripts": {
-		"build": "tsc && npm run download:files && cp -r public dist",
+		"build": "tsc && npm run download:files && npm run commit:hash && cp -r public dist",
+		"commit:hash": "git rev-parse HEAD > data/LAST_API_COMMIT_HASH.txt",
 		"coverage": "npm run clean && NODE_ENV=test FAKE_PROBE_IP=api NEW_RELIC_ENABLED=false NEW_RELIC_LOG_ENABLED=false c8 mocha",
 		"clean": "rimraf coverage",
 		"download:files": "tsx src/lib/download-files.ts",

--- a/src/lib/flush-redis-cache.ts
+++ b/src/lib/flush-redis-cache.ts
@@ -1,0 +1,23 @@
+import fs from 'fs/promises';
+import path from 'node:path';
+import { getRedisClient } from './redis/client.js';
+import { getPersistentRedisClient } from './redis/persistent-client.js';
+
+export async function flushRedisCache () {
+	if (process.env['NODE_ENV'] === 'production' && !process.env['HOSTNAME']) {
+		throw new Error('HOSTNAME env variable is not specified');
+	}
+
+	const redis = getRedisClient();
+	const persistentRedis = getPersistentRedisClient();
+	const hostname = process.env['HOSTNAME'] || 'default';
+	const filePath = path.join(path.resolve(), 'data/LAST_API_COMMIT_HASH.txt');
+
+	const lastCommitHashInRedis = await persistentRedis.get(`LAST_API_COMMIT_HASH_${hostname}`);
+	const currentLastCommitHash = (await fs.readFile(filePath, 'utf8')).trim();
+
+	if (lastCommitHashInRedis !== currentLastCommitHash) {
+		await redis.flushDb();
+		await persistentRedis.set(`LAST_API_COMMIT_HASH_${hostname}`, currentLastCommitHash);
+	}
+}

--- a/src/lib/get-probe-ip.ts
+++ b/src/lib/get-probe-ip.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import requestIp from 'request-ip';
 import type { Socket } from 'socket.io';
 
@@ -9,7 +8,7 @@ const getProbeIp = (socket: Socket) => {
 
 	// Use random ip assigned by the API
 	if (process.env['FAKE_PROBE_IP'] === 'api') {
-		return _.sample([
+		const samples = [
 			'18.200.0.1',
 			'34.140.0.10',
 			'95.155.94.127',
@@ -20,7 +19,11 @@ const getProbeIp = (socket: Socket) => {
 			'213.136.174.80',
 			'94.214.253.78',
 			'79.205.97.254',
-		]);
+		];
+		// Choosing ip based on the probe uuid to always return the same ip for the same probe.
+		const lastGroup = (socket.handshake.query['uuid'] as string).split('-').pop() || '0';
+		const index = parseInt(lastGroup, 16) % samples.length;
+		return samples[index];
 	}
 
 	// Use fake ip provided by the probe

--- a/wallaby.js
+++ b/wallaby.js
@@ -26,6 +26,7 @@ export default function wallaby () {
 			'data/DOMAIN_BLACKLIST.json',
 			'data/IP_BLACKLIST.json',
 			'data/GEONAMES_CITIES.csv',
+			'data/LAST_API_COMMIT_HASH.txt',
 		],
 		tests: [
 			'test/tests/**/*.test.ts',


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/472

Additionally:
- update get-fake-ip logic so it doesn't change ip after probe reconnects;
- change redis image to the one that supports arm64 architecture. Previous was unstable on my new mac;
- change redis image in ci to make sure tests are passing with only reJSON module.