### PR TITLE
perf: separate measurement data for fast key counting

### DIFF
--- a/src/lib/geoip/city-approximation.ts
+++ b/src/lib/geoip/city-approximation.ts
@@ -4,7 +4,7 @@ import got from 'got';
 import AdmZip from 'adm-zip';
 import csvParser from 'csv-parser';
 import _ from 'lodash';
-import { getRedisClient, RedisClient } from '../redis/client.js';
+import { getRedisClient, type RedisClient } from '../redis/client.js';
 import { throttle } from '../ws/helper/throttle.js';
 import { scopedLogger } from '../logger.js';
 import { getIsDcCity } from './dc-cities.js';

--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -1,17 +1,7 @@
-import config from 'config';
-import {
-	createClient,
-	type RedisClientType,
-	type RedisDefaultModules,
-	type RedisClientOptions,
-	type RedisFunctions,
-} from 'redis';
-import { scopedLogger } from '../logger.js';
-import { scripts, type RedisScripts } from './scripts.js';
+import type { RedisClientOptions } from 'redis';
+import { createRedisClientInternal, type RedisClient } from './shared.js';
 
-const logger = scopedLogger('redis-client');
-
-export type RedisClient = RedisClientType<RedisDefaultModules, RedisFunctions, RedisScripts>;
+export type { RedisClient } from './shared.js';
 
 let redis: RedisClient;
 
@@ -21,22 +11,11 @@ export const initRedisClient = async () => {
 };
 
 const createRedisClient = async (options?: RedisClientOptions): Promise<RedisClient> => {
-	const client = createClient({
-		...config.util.toObject(config.get('redis')) as RedisClientOptions,
+	return createRedisClientInternal({
 		...options,
-		database: 1,
+		database: 2,
 		name: 'non-persistent',
-		scripts,
 	});
-
-	client
-		.on('error', (error: Error) => logger.error('connection error', error))
-		.on('ready', () => logger.info('connection ready'))
-		.on('reconnecting', () => logger.info('reconnecting'));
-
-	await client.connect();
-
-	return client;
 };
 
 export const getRedisClient = (): RedisClient => {

--- a/src/lib/redis/measurement-client.ts
+++ b/src/lib/redis/measurement-client.ts
@@ -1,0 +1,27 @@
+import type { RedisClientOptions } from 'redis';
+import { createRedisClientInternal, type RedisClient } from './shared.js';
+
+export type { RedisClient } from './shared.js';
+
+let redis: RedisClient;
+
+export const initMeasurementRedisClient = async () => {
+	redis = await createMeasurementRedisClient();
+	return redis;
+};
+
+export const createMeasurementRedisClient = async (options?: RedisClientOptions): Promise<RedisClient> => {
+	return createRedisClientInternal({
+		...options,
+		database: 0,
+		name: 'measurement',
+	});
+};
+
+export const getMeasurementRedisClient = (): RedisClient => {
+	if (!redis) {
+		throw new Error('redis connection to measurement db is not initialized yet');
+	}
+
+	return redis;
+};

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -31,8 +31,8 @@ const recordResult: RecordResultScript = defineScript({
 	local testId = KEYS[2]
 	local data = KEYS[3]
 	local date = KEYS[4]
-	local key = 'gp:measurement:'..measurementId
-	local awaitingKey = key..':probes_awaiting'
+	local key = 'gp:m:'..measurementId..':results'
+	local awaitingKey = 'gp:m:'..measurementId..':probes_awaiting'
 
 	local probesAwaiting = redis.call('GET', awaitingKey)
 	if not probesAwaiting then
@@ -61,8 +61,8 @@ const markFinished: MarkFinishedScript = defineScript({
 	NUMBER_OF_KEYS: 1,
 	SCRIPT: `
 	local measurementId = KEYS[1]
-	local key = 'gp:measurement:'..measurementId
-	local awaitingKey = key..':probes_awaiting'
+	local key = 'gp:m:'..measurementId..':results'
+	local awaitingKey = 'gp:m:'..measurementId..':probes_awaiting'
 
 	redis.call('HDEL', 'gp:in-progress', measurementId)
 	redis.call('DEL', awaitingKey)

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -1,15 +1,6 @@
 import { defineScript } from 'redis';
 import type { MeasurementRecord, MeasurementResultMessage } from '../../measurement/types.js';
 
-type CountScript = {
-	NUMBER_OF_KEYS: number;
-	SCRIPT: string;
-	transformArguments (key: string): string[];
-	transformReply (reply: number): number;
-} & {
-	SHA1: string;
-};
-
 type RecordResultScript = {
 	NUMBER_OF_KEYS: number;
 	SCRIPT: string;
@@ -29,31 +20,9 @@ type MarkFinishedScript = {
 };
 
 export type RedisScripts = {
-	count: CountScript;
 	recordResult: RecordResultScript;
 	markFinished: MarkFinishedScript;
 };
-
-const count: CountScript = defineScript({
-	NUMBER_OF_KEYS: 1,
-	SCRIPT: `
-	local cursor = 0
-	local count = 0
-	repeat
-		local result = redis.call('SCAN', cursor, 'MATCH', KEYS[1], 'COUNT', 1000)
-		cursor = tonumber(result[1])
-		local keys = result[2]
-		count = count + #keys
-	until cursor == 0
-	return count
-	`,
-	transformArguments (key: string) {
-		return [ key ];
-	},
-	transformReply (reply: number) {
-		return reply;
-	},
-});
 
 const recordResult: RecordResultScript = defineScript({
 	NUMBER_OF_KEYS: 4,
@@ -107,4 +76,4 @@ const markFinished: MarkFinishedScript = defineScript({
 	},
 });
 
-export const scripts: RedisScripts = { count, recordResult, markFinished };
+export const scripts: RedisScripts = { recordResult, markFinished };

--- a/src/lib/redis/shared.ts
+++ b/src/lib/redis/shared.ts
@@ -1,0 +1,31 @@
+import config from 'config';
+import {
+	createClient,
+	type RedisClientOptions,
+	type RedisClientType,
+	type RedisDefaultModules,
+	type RedisFunctions,
+} from 'redis';
+import { type RedisScripts, scripts } from './scripts.js';
+import { scopedLogger } from '../logger.js';
+
+const logger = scopedLogger('redis-client');
+
+export type RedisClient = RedisClientType<RedisDefaultModules, RedisFunctions, RedisScripts>;
+
+export const createRedisClientInternal = async (options?: RedisClientOptions): Promise<RedisClient> => {
+	const client = createClient({
+		...config.util.toObject(config.get('redis')) as RedisClientOptions,
+		...options,
+		scripts,
+	});
+
+	client
+		.on('error', (error: Error) => logger.error('connection error', error))
+		.on('ready', () => logger.info('connection ready'))
+		.on('reconnecting', () => logger.info('reconnecting'));
+
+	await client.connect();
+
+	return client;
+};

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -9,11 +9,13 @@ import { populateCitiesList } from './geoip/city-approximation.js';
 import { adoptedProbes } from './adopted-probes.js';
 import { reconnectProbes } from './ws/helper/reconnect-probes.js';
 import { initPersistentRedisClient } from './redis/persistent-client.js';
+import { initMeasurementRedisClient } from './redis/measurement-client.js';
 import { auth } from './http/auth.js';
 
 export const createServer = async (): Promise<Server> => {
 	await initRedisClient();
 	await initPersistentRedisClient();
+	await initMeasurementRedisClient();
 
 	// Populate memory malware list
 	await populateMemMalwareList();

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -5,7 +5,7 @@ import type { OfflineProbe, Probe } from '../probe/types.js';
 import { scopedLogger } from '../lib/logger.js';
 import type { MeasurementRecord, MeasurementResult, MeasurementRequest, MeasurementProgressMessage, RequestType, MeasurementResultMessage } from './types.js';
 import { getDefaults } from './schema/utils.js';
-import { getPersistentRedisClient, PersistentRedisClient } from '../lib/redis/persistent-client.js';
+import { getMeasurementRedisClient, type RedisClient } from '../lib/redis/measurement-client.js';
 
 const logger = scopedLogger('store');
 
@@ -41,7 +41,7 @@ const substractObjects = (obj1: Record<string, unknown>, obj2: Record<string, un
 };
 
 export class MeasurementStore {
-	constructor (private readonly redis: PersistentRedisClient) {}
+	constructor (private readonly redis: RedisClient) {}
 
 	async getMeasurementString (id: string): Promise<string> {
 		return this.redis.sendCommand([ 'JSON.GET', getMeasurementKey(id) ]);
@@ -238,7 +238,7 @@ let store: MeasurementStore;
 
 export const getMeasurementStore = () => {
 	if (!store) {
-		store = new MeasurementStore(getPersistentRedisClient());
+		store = new MeasurementStore(getMeasurementRedisClient());
 		store.scheduleCleanup();
 	}
 

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -9,14 +9,8 @@ import { getMeasurementRedisClient, type RedisClient } from '../lib/redis/measur
 
 const logger = scopedLogger('store');
 
-export const getMeasurementKey = (id: string, suffix: string | undefined = undefined): string => {
-	let key = `gp:measurement:${id}`;
-
-	if (suffix) {
-		key += `:${suffix}`;
-	}
-
-	return key;
+export const getMeasurementKey = (id: string, suffix: string = 'results'): string => {
+	return `gp:m:${id}:${suffix}`;
 };
 
 const substractObjects = (obj1: Record<string, unknown>, obj2: Record<string, unknown> = {}) => {

--- a/test/tests/unit/index.test.ts
+++ b/test/tests/unit/index.test.ts
@@ -3,15 +3,15 @@ import { EventEmitter } from 'node:events';
 import { expect } from 'chai';
 import * as td from 'testdouble';
 import * as sinon from 'sinon';
-import { getRedisClient, RedisClient } from '../../../src/lib/redis/client.js';
-import { getPersistentRedisClient, PersistentRedisClient } from '../../../src/lib/redis/persistent-client.js';
+import { getRedisClient, type RedisClient } from '../../../src/lib/redis/client.js';
+import { getPersistentRedisClient } from '../../../src/lib/redis/persistent-client.js';
 
 describe('index file', () => {
 	const cluster: any = new EventEmitter();
 	cluster.isPrimary = true;
 	cluster.fork = sinon.stub();
 	let redis: RedisClient;
-	let persistentRedis: PersistentRedisClient;
+	let persistentRedis: RedisClient;
 
 	const readFile = sinon.stub().resolves('commitHash');
 

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -48,7 +48,7 @@ describe('measurement store', () => {
 
 	before(async () => {
 		td.replaceEsm('crypto-random-string', null, () => 'measurementid');
-		await td.replaceEsm('../../../../src/lib/redis/persistent-client.ts', { getPersistentRedisClient: () => redisMock });
+		await td.replaceEsm('../../../../src/lib/redis/measurement-client.ts', { getMeasurementRedisClient: () => redisMock });
 		getMeasurementStore = (await import('../../../../src/measurement/store.js')).getMeasurementStore;
 	});
 

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -97,12 +97,12 @@ describe('measurement store', () => {
 		expect(redisMock.hScan.callCount).to.equal(1);
 		expect(redisMock.hScan.firstCall.args).to.deep.equal([ 'gp:in-progress', 0, { COUNT: 5000 }]);
 		expect(redisMock.json.mGet.callCount).to.equal(1);
-		expect(redisMock.json.mGet.firstCall.args).to.deep.equal([ [ 'gp:measurement:id1', 'gp:measurement:id2' ], '.' ]);
+		expect(redisMock.json.mGet.firstCall.args).to.deep.equal([ [ 'gp:m:id1:results', 'gp:m:id2:results' ], '.' ]);
 		expect(redisMock.hDel.callCount).to.equal(1);
 		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ 'id1', 'id2' ] ]);
 		expect(redisMock.json.set.callCount).to.equal(1);
 
-		expect(redisMock.json.set.firstCall.args).to.deep.equal([ 'gp:measurement:id1', '$', {
+		expect(redisMock.json.set.firstCall.args).to.deep.equal([ 'gp:m:id1:results', '$', {
 			id: 'id1',
 			type: 'ping',
 			status: 'finished',
@@ -137,10 +137,10 @@ describe('measurement store', () => {
 		expect(redisMock.hSet.callCount).to.equal(1);
 		expect(redisMock.hSet.args[0]).to.deep.equal([ 'gp:in-progress', 'measurementid', 1678000000000 ]);
 		expect(redisMock.set.callCount).to.equal(1);
-		expect(redisMock.set.args[0]).to.deep.equal([ 'gp:measurement:measurementid:probes_awaiting', 4, { EX: 35 }]);
+		expect(redisMock.set.args[0]).to.deep.equal([ 'gp:m:measurementid:probes_awaiting', 4, { EX: 35 }]);
 		expect(redisMock.json.set.callCount).to.equal(2);
 
-		expect(redisMock.json.set.args[0]).to.deep.equal([ 'gp:measurement:measurementid', '$', {
+		expect(redisMock.json.set.args[0]).to.deep.equal([ 'gp:m:measurementid:results', '$', {
 			id: 'measurementid',
 			type: 'ping',
 			status: 'in-progress',
@@ -215,11 +215,11 @@ describe('measurement store', () => {
 			}],
 		}]);
 
-		expect(redisMock.expire.args[0]).to.deep.equal([ 'gp:measurement:measurementid', 604800 ]);
+		expect(redisMock.expire.args[0]).to.deep.equal([ 'gp:m:measurementid:results', 604800 ]);
 
-		expect(redisMock.json.set.args[1]).to.deep.equal([ 'gp:measurement:measurementid:ips', '$', [ '1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4' ] ]);
+		expect(redisMock.json.set.args[1]).to.deep.equal([ 'gp:m:measurementid:ips', '$', [ '1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4' ] ]);
 
-		expect(redisMock.expire.args[1]).to.deep.equal([ 'gp:measurement:measurementid:ips', 604800 ]);
+		expect(redisMock.expire.args[1]).to.deep.equal([ 'gp:m:measurementid:ips', 604800 ]);
 	});
 
 	it('should initialize measurement object with the proper default values', async () => {
@@ -238,7 +238,7 @@ describe('measurement store', () => {
 		);
 
 		expect(redisMock.json.set.firstCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$',
 			{
 				id: 'measurementid',
@@ -294,7 +294,7 @@ describe('measurement store', () => {
 		);
 
 		expect(redisMock.json.set.firstCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$',
 			{
 				id: 'measurementid',
@@ -347,7 +347,7 @@ describe('measurement store', () => {
 		);
 
 		expect(redisMock.json.set.firstCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$',
 			{
 				id: 'measurementid',
@@ -381,7 +381,7 @@ describe('measurement store', () => {
 			},
 		]);
 
-		expect(redisMock.set.args[0]).to.deep.equal([ 'gp:measurement:measurementid:probes_awaiting', 0, { EX: 35 }]);
+		expect(redisMock.set.args[0]).to.deep.equal([ 'gp:m:measurementid:probes_awaiting', 0, { EX: 35 }]);
 	});
 
 	it('should store non-default fields of the measurement request', async () => {
@@ -415,7 +415,7 @@ describe('measurement store', () => {
 			[ getProbe('id', '1.1.1.1') ],
 		);
 
-		expect(redisMock.json.set.args[0]).to.deep.equal([ 'gp:measurement:measurementid', '$', {
+		expect(redisMock.json.set.args[0]).to.deep.equal([ 'gp:m:measurementid:results', '$', {
 			id: 'measurementid',
 			type: 'http',
 			status: 'in-progress',
@@ -480,7 +480,7 @@ describe('measurement store', () => {
 			[ getProbe('id', '1.1.1.1') ],
 		);
 
-		expect(redisMock.json.set.args[0]).to.deep.equal([ 'gp:measurement:measurementid', '$', {
+		expect(redisMock.json.set.args[0]).to.deep.equal([ 'gp:m:measurementid:results', '$', {
 			id: 'measurementid',
 			type: 'http',
 			status: 'in-progress',
@@ -527,19 +527,19 @@ describe('measurement store', () => {
 		expect(redisMock.json.strAppend.callCount).to.equal(3);
 
 		expect(redisMock.json.strAppend.firstCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$.results[testid].result.rawHeaders',
 			'headers',
 		]);
 
 		expect(redisMock.json.strAppend.secondCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$.results[testid].result.rawBody',
 			'body',
 		]);
 
 		expect(redisMock.json.strAppend.thirdCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$.results[testid].result.rawOutput',
 			'output',
 		]);
@@ -547,7 +547,7 @@ describe('measurement store', () => {
 		expect(redisMock.json.set.callCount).to.equal(1);
 
 		expect(redisMock.json.set.firstCall.args).to.deep.equal([
-			'gp:measurement:measurementid',
+			'gp:m:measurementid:results',
 			'$.updatedAt',
 			'2023-03-05T07:06:40.000Z',
 		]);


### PR DESCRIPTION
1. Moves the measurement data to their own DB to take advantage of the fact that redis [maintains key count separately for each DB](https://redis.io/commands/dbsize/). This allows us to drop the slower SCAN iteration approach.
2. Updates the measurement count calculation to account for the fact that one measurement uses 2 (when finished) or 3 (when running) keys.