### PR TITLE
perf: reduce data sent in probe sync

### DIFF
--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -6,7 +6,7 @@ import createHttpError from 'http-errors';
 import type { ExtendedContext } from '../types.js';
 import { credits } from './credits.js';
 
-const redisClient = await createPersistentRedisClient({ legacyMode: true });
+const redisClient = createPersistentRedisClient({ legacyMode: true });
 
 export const anonymousRateLimiter = new RateLimiterRedis({
 	storeClient: redisClient,

--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -6,11 +6,11 @@ export type { RedisClient } from './shared.js';
 let redis: RedisClient;
 
 export const initRedisClient = async () => {
-	redis = await createRedisClient();
+	redis = createRedisClient();
 	return redis;
 };
 
-const createRedisClient = async (options?: RedisClientOptions): Promise<RedisClient> => {
+const createRedisClient = (options?: RedisClientOptions): RedisClient => {
 	return createRedisClientInternal({
 		...options,
 		database: 2,
@@ -19,9 +19,6 @@ const createRedisClient = async (options?: RedisClientOptions): Promise<RedisCli
 };
 
 export const getRedisClient = (): RedisClient => {
-	if (!redis) {
-		throw new Error('redis connection is not initialized yet');
-	}
-
+	redis = createRedisClient();
 	return redis;
 };

--- a/src/lib/redis/measurement-client.ts
+++ b/src/lib/redis/measurement-client.ts
@@ -6,11 +6,11 @@ export type { RedisClient } from './shared.js';
 let redis: RedisClient;
 
 export const initMeasurementRedisClient = async () => {
-	redis = await createMeasurementRedisClient();
+	redis = createMeasurementRedisClient();
 	return redis;
 };
 
-export const createMeasurementRedisClient = async (options?: RedisClientOptions): Promise<RedisClient> => {
+export const createMeasurementRedisClient = (options?: RedisClientOptions): RedisClient => {
 	return createRedisClientInternal({
 		...options,
 		database: 0,
@@ -19,9 +19,6 @@ export const createMeasurementRedisClient = async (options?: RedisClientOptions)
 };
 
 export const getMeasurementRedisClient = (): RedisClient => {
-	if (!redis) {
-		throw new Error('redis connection to measurement db is not initialized yet');
-	}
-
+	redis = createMeasurementRedisClient();
 	return redis;
 };

--- a/src/lib/redis/persistent-client.ts
+++ b/src/lib/redis/persistent-client.ts
@@ -6,11 +6,11 @@ export type { RedisClient } from './shared.js';
 let redis: RedisClient;
 
 export const initPersistentRedisClient = async () => {
-	redis = await createPersistentRedisClient();
+	redis = createPersistentRedisClient();
 	return redis;
 };
 
-export const createPersistentRedisClient = async (options?: RedisClientOptions): Promise<RedisClient> => {
+export const createPersistentRedisClient = (options?: RedisClientOptions): RedisClient => {
 	return createRedisClientInternal({
 		...options,
 		database: 1,
@@ -19,9 +19,6 @@ export const createPersistentRedisClient = async (options?: RedisClientOptions):
 };
 
 export const getPersistentRedisClient = (): RedisClient => {
-	if (!redis) {
-		throw new Error('redis connection to persistent db is not initialized yet');
-	}
-
+	redis = createPersistentRedisClient();
 	return redis;
 };

--- a/src/lib/redis/shared.ts
+++ b/src/lib/redis/shared.ts
@@ -13,7 +13,7 @@ const logger = scopedLogger('redis-client');
 
 export type RedisClient = RedisClientType<RedisDefaultModules, RedisFunctions, RedisScripts>;
 
-export const createRedisClientInternal = async (options?: RedisClientOptions): Promise<RedisClient> => {
+export const createRedisClientInternal = (options?: RedisClientOptions): RedisClient => {
 	const client = createClient({
 		...config.util.toObject(config.get('redis')) as RedisClientOptions,
 		...options,
@@ -23,9 +23,8 @@ export const createRedisClientInternal = async (options?: RedisClientOptions): P
 	client
 		.on('error', (error: Error) => logger.error('connection error', error))
 		.on('ready', () => logger.info('connection ready'))
-		.on('reconnecting', () => logger.info('reconnecting'));
-
-	await client.connect();
+		.on('reconnecting', () => logger.info('reconnecting'))
+		.connect().catch((error: Error) => logger.error('connection error', error));
 
 	return client;
 };

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -27,8 +27,9 @@ let io: WsServer;
 let syncedProbeList: SyncedProbeList;
 
 export const initWsServer = async () => {
-	const pubClient = getRedisClient().duplicate();
-	const subClient = pubClient.duplicate();
+	const redis = getRedisClient();
+	const pubClient = redis.duplicate();
+	const subClient = redis.duplicate();
 
 	await Promise.all([ pubClient.connect(), subClient.connect() ]);
 
@@ -44,7 +45,7 @@ export const initWsServer = async () => {
 		dynamicPrivateChannels: true,
 	}));
 
-	syncedProbeList = new SyncedProbeList(io.of(PROBES_NAMESPACE), adoptedProbes);
+	syncedProbeList = new SyncedProbeList(redis, io.of(PROBES_NAMESPACE), adoptedProbes);
 
 	await syncedProbeList.sync();
 	syncedProbeList.scheduleSync();

--- a/src/lib/ws/synced-probe-list.ts
+++ b/src/lib/ws/synced-probe-list.ts
@@ -1,42 +1,68 @@
+import _ from 'lodash';
 import { randomBytes } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import TTLCache from '@isaacs/ttlcache';
 import { scopedLogger } from '../logger.js';
 import type { WsServerNamespace } from './server.js';
-import type { Probe } from '../../probe/types.js';
+import type { Probe, ProbeStats } from '../../probe/types.js';
 import type winston from 'winston';
 import type { AdoptedProbes } from '../adopted-probes.js';
 import { getIndex } from '../../probe/builder.js';
+import type { RedisClient } from '../redis/shared.js';
 
 type NodeData = {
 	nodeId: string;
-	probes: Probe[];
-	timestamp: number;
+	changeTimestamp: number;
+	revalidateTimestamp: number;
+	probesById: Record<string, Probe>;
+};
+
+type NodeChanges = {
+	nodeId: string;
+	reloadNode: boolean;
+	revalidateTimestamp: number | undefined;
+	removeProbes: Set<string>;
+	updateProbes: Set<string>;
+	updateStats: Map<string, ProbeStats>;
+};
+
+const MESSAGE_TYPES = {
+	ALIVE: 'a',
+	META: 'm',
+	NODE: 'n',
+	UPDATE: '+',
+	RELOAD: 'r',
+	REMOVE: '-',
+	STATS: 's',
 };
 
 export class SyncedProbeList extends EventEmitter {
+	remoteDataTtl = 60 * 60 * 1000;
 	syncInterval = 2000;
 	syncTimeout = 5000;
 
-	readonly localUpdateEvent = 'synced-probe-list:local-update';
-	readonly remoteUpdateEvent = 'synced-probe-list:remote-update';
+	readonly localUpdateEvent = 'spl:local-update';
+	readonly remoteEventsStream = 'gp:spl:events';
 
 	private logger: winston.Logger;
 	private rawProbes: Probe[];
 	private probes: Probe[];
 	private oldest: number;
-	private timer: NodeJS.Timeout | undefined;
+	private pushTimer: NodeJS.Timeout | undefined;
+	private pullTimer: NodeJS.Timeout | undefined;
+	private lastReadEventId: string;
 
 	private readonly nodeId: string;
 	private readonly nodeData: TTLCache<string, NodeData>;
 
-	constructor (private readonly ioNamespace: WsServerNamespace, private readonly adoptedProbes: AdoptedProbes) {
+	constructor (private readonly redis: RedisClient, private readonly ioNamespace: WsServerNamespace, private readonly adoptedProbes: AdoptedProbes) {
 		super();
 		this.nodeId = randomBytes(8).toString('hex');
 		this.logger = scopedLogger('synced-probe-list', this.nodeId);
 		this.rawProbes = [];
 		this.probes = [];
 		this.oldest = Infinity;
+		this.lastReadEventId = Date.now().toString();
 
 		this.nodeData = new TTLCache<string, NodeData>({
 			noDisposeOnSet: true,
@@ -45,8 +71,6 @@ export class SyncedProbeList extends EventEmitter {
 				this.updateProbes();
 			},
 		});
-
-		this.ioNamespace.on(this.remoteUpdateEvent, message => this.handleUpdate(message as NodeData));
 	}
 
 	async fetchProbes (): Promise<Probe[]> {
@@ -76,11 +100,11 @@ export class SyncedProbeList extends EventEmitter {
 		const probes = [];
 		let oldest = Infinity;
 
-		for (const [ , entry ] of this.nodeData.entries()) {
-			probes.push(...entry.probes);
+		for (const nodeData of this.nodeData.values()) {
+			probes.push(...Object.values(nodeData.probesById));
 
-			if (entry.timestamp < oldest) {
-				oldest = entry.timestamp;
+			if (nodeData.revalidateTimestamp < oldest) {
+				oldest = nodeData.revalidateTimestamp;
 			}
 		}
 
@@ -100,27 +124,322 @@ export class SyncedProbeList extends EventEmitter {
 		this.updateProbes();
 	}
 
-	async sync () {
-		const sockets = await this.ioNamespace.local.fetchSockets();
+	private getRemoteDataKey (nodeId: string) {
+		return `gp:spl:probes:${nodeId}`;
+	}
 
-		const message = {
+	private getRemoteNodeData (nodeId: string): Promise<NodeData | null> {
+		return this.redis.json.get(this.getRemoteDataKey(nodeId)) as Promise<NodeData | null>;
+	}
+
+	private getRemoteNodeDataAtPath<T> (nodeId: string, path: string): Promise<T | null> {
+		return this.redis.json.get(this.getRemoteDataKey(nodeId), { path }).then((result) => {
+			if (Array.isArray(result)) {
+				return result[0];
+			}
+
+			return result;
+		}) as Promise<T | null>;
+	}
+
+	private getRemoteNodeDataAtPaths<T> (nodeId: string, path: string[]): Promise<Array<T | null>> {
+		return this.redis.json.get(this.getRemoteDataKey(nodeId), { path }).then((result) => {
+			// Normalize redis variable return format.
+			if (result) {
+				return path.length > 1
+					? Object.values(result as unknown as Record<string, T[]>).map(v => v[0])
+					: [ (result as unknown as T[])[0] ];
+			}
+
+			return result;
+		}) as unknown as Promise<Array<T | null>>;
+	}
+
+	private setRemoteNodeData (nodeId: string, nodeData: NodeData): Promise<unknown> {
+		const nodeKey = this.getRemoteDataKey(nodeId);
+
+		return Promise.all([
+			this.redis.json.set(nodeKey, '$', nodeData),
+			this.redis.pExpire(nodeKey, this.remoteDataTtl),
+		]);
+	}
+
+	private publishEvent (message: Record<string, string>): Promise<string> {
+		return this.redis.xAdd(this.remoteEventsStream, '*', {
+			...message,
+			[MESSAGE_TYPES.NODE]: this.nodeId,
+		}, {
+			TRIM: {
+				strategy: 'MAXLEN',
+				strategyModifier: '~',
+				threshold: 100,
+			},
+		});
+	}
+
+	private serializeProbeStats (stats: ProbeStats): string {
+		const loadStats = stats.cpu.load.flatMap(load => [ load.idle, load.usage ]);
+		return [ stats.jobs.count ].concat(loadStats).join();
+	}
+
+	private unserializeProbeStats (statsString: string): ProbeStats {
+		const parts = statsString.split(',').map(Number);
+
+		return {
+			jobs: {
+				count: parts[0] || 0,
+			},
+			cpu: {
+				count: Math.floor(parts.length / 2),
+				load: parts.slice(1).reduce((acc, v, i, a) => {
+					return acc.concat([{ idle: v, usage: a[i + 1] || 0 }]);
+				}, [] as ProbeStats['cpu']['load']),
+			},
+		};
+	}
+
+	async syncPush () {
+		const sockets = await this.ioNamespace.local.fetchSockets();
+		const currentProbes = sockets.map(socket => _.cloneDeep(socket.data.probe));
+		const previousNodeData = this.nodeData.get(this.nodeId);
+
+		const nodeData = {
 			nodeId: this.nodeId,
-			probes: sockets.map(socket => socket.data.probe),
-			timestamp: Date.now(),
+			changeTimestamp: Date.now(),
+			revalidateTimestamp: Date.now(),
+			probesById: Object.fromEntries(currentProbes.map(probe => [ probe.client, probe ])),
 		};
 
-		this.ioNamespace.serverSideEmit(this.remoteUpdateEvent, message);
-		this.handleUpdate(message);
+		const previousTimestamp = previousNodeData?.changeTimestamp;
+		const remoteTimestamp = await this.getRemoteNodeDataAtPath<number>(this.nodeId, '$.changeTimestamp');
+
+		// If timestamps don't match (shouldn't happen unless the DB is flushed/key evicted),
+		// we reset the data and tell all nodes to do a full reload...
+		if (!remoteTimestamp || remoteTimestamp !== previousTimestamp) {
+			this.handleUpdate(nodeData);
+			await this.setRemoteNodeData(this.nodeId, nodeData);
+			await this.publishEvent({ [MESSAGE_TYPES.RELOAD]: '1' });
+			return;
+		}
+
+		const previousProbes = previousNodeData?.probesById || {};
+		const previousProbesMap = new Map(Object.entries(previousProbes));
+		const updatedStatsById: Record<string, string> = {};
+		const updatedProbesIds = [];
+
+		// ...otherwise we compute a diff.
+		for (const currentProbe of currentProbes) {
+			const previousProbe = previousProbesMap.get(currentProbe.client);
+			previousProbesMap.delete(currentProbe.client);
+
+			const probesEqualExceptStats = _.isEqualWith(currentProbe, previousProbe, (a, b, key) => {
+				if (key === 'stats') {
+					if (!_.isEqual(a, b)) {
+						updatedStatsById[currentProbe.client] = this.serializeProbeStats(currentProbe.stats);
+					}
+
+					return true;
+				}
+
+				return undefined;
+			});
+
+			if (!probesEqualExceptStats) {
+				updatedProbesIds.push(currentProbe.client);
+			}
+		}
+
+		// If there are no changes, we just send a keep-alive ping and stats...
+		if (!updatedProbesIds.length && !previousProbesMap.size) {
+			if (previousTimestamp) {
+				nodeData.changeTimestamp = previousTimestamp;
+			}
+
+			// ...and occasionally also refresh the TTL by resetting it.
+			if (nodeData.revalidateTimestamp - remoteTimestamp > this.remoteDataTtl / 2) {
+				await this.setRemoteNodeData(this.nodeId, nodeData);
+			}
+
+			this.handleUpdate(nodeData);
+
+			const message: Record<string, string> = {
+				[MESSAGE_TYPES.ALIVE]: nodeData.revalidateTimestamp.toString(),
+			};
+
+			if (Object.keys(updatedStatsById).length) {
+				message[MESSAGE_TYPES.STATS] = JSON.stringify(updatedStatsById);
+			}
+
+			await this.publishEvent(message);
+			return;
+		}
+
+		// If there are changes, we reset the data and send the diff.
+		const message: Record<string, string> = {
+			[MESSAGE_TYPES.ALIVE]: nodeData.revalidateTimestamp.toString(),
+		};
+
+		if (Object.keys(updatedStatsById).length) {
+			message[MESSAGE_TYPES.STATS] = JSON.stringify(updatedStatsById);
+		}
+
+		if (previousProbesMap.size) {
+			message[MESSAGE_TYPES.REMOVE] = [ ...previousProbesMap.keys() ].join();
+		}
+
+		if (updatedProbesIds.length) {
+			message[MESSAGE_TYPES.UPDATE] = updatedProbesIds.join();
+		}
+
+		this.handleUpdate(nodeData);
+		await this.setRemoteNodeData(this.nodeId, nodeData);
+		await this.publishEvent(message);
+	}
+
+	async syncPull () {
+		// Returns an *inclusive* range starting from this.lastReadEventId
+		const events = await this.redis.xRange(this.remoteEventsStream, this.lastReadEventId, '+');
+		const hasMissedEvents = events[0]?.id !== this.lastReadEventId;
+
+		if (!hasMissedEvents) {
+			events.shift(); // Already processed in the previous batch.
+		}
+
+		const eventsToProcess = events.filter(event => event.message[MESSAGE_TYPES.NODE] !== this.nodeId);
+
+		if (!eventsToProcess.length) {
+			return;
+		}
+
+		const eventsByNode = _.groupBy(eventsToProcess, event => event.message[MESSAGE_TYPES.NODE]);
+
+		await Promise.all(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
+			const changes: NodeChanges = {
+				nodeId,
+				revalidateTimestamp: undefined,
+				reloadNode: hasMissedEvents,
+				removeProbes: new Set(),
+				updateProbes: new Set(),
+				updateStats: new Map(),
+			};
+
+			if (changes.reloadNode) {
+				return changes;
+			}
+
+			for (const event of nodeEvents) {
+				for (const [ key, value ] of Object.entries(event.message)) {
+					switch (key) {
+						case MESSAGE_TYPES.ALIVE:
+							changes.revalidateTimestamp = Number(value);
+							break;
+
+						case MESSAGE_TYPES.RELOAD:
+							changes.reloadNode = true;
+							return changes;
+
+						case MESSAGE_TYPES.REMOVE:
+							value.split(',').forEach(id => changes.removeProbes.add(id));
+							break;
+
+						case MESSAGE_TYPES.UPDATE:
+							value.split(',').forEach(id => changes.updateProbes.add(id));
+							break;
+
+						case MESSAGE_TYPES.STATS:
+							Object.entries(JSON.parse(value) as Record<string, string>).forEach(([ id, statsString ]) => {
+								changes.updateStats.set(id, this.unserializeProbeStats(statsString));
+							});
+
+							break;
+					}
+				}
+			}
+
+			return changes;
+		}).map(async (changes: NodeChanges) => {
+			const nodeData = this.nodeData.get(changes.nodeId);
+
+			if (!nodeData || changes.reloadNode || changes.updateProbes.size > 5) {
+				const newNodeData = await this.getRemoteNodeData(changes.nodeId);
+
+				if (newNodeData) {
+					this.handleUpdate(newNodeData);
+				}
+
+				return;
+			}
+
+			const probesById = _.pickBy(nodeData.probesById, ((probe) => {
+				return !changes.removeProbes.has(probe.client);
+			}));
+
+			changes.updateStats.forEach((stats, id) => {
+				if (probesById[id]) {
+					probesById[id]!.stats = stats;
+				}
+			});
+
+			if (changes.updateProbes.size) {
+				const paths = Array.from(changes.updateProbes).map(probeId => `$.probesById['${probeId}']`);
+				const newProbesByPath = await this.getRemoteNodeDataAtPaths<Probe>(changes.nodeId, paths);
+
+				if (newProbesByPath) {
+					newProbesByPath.forEach((probe) => {
+						if (probe) {
+							probesById[probe.client] = probe;
+						}
+					});
+				}
+			}
+
+			const newNodeData = {
+				...nodeData,
+				...changes.revalidateTimestamp ? { revalidateTimestamp: changes.revalidateTimestamp } : {},
+				probesById,
+			};
+
+			this.handleUpdate(newNodeData);
+		}));
+
+		this.lastReadEventId = events.at(-1)!.id;
+	}
+
+	async sync () {
+		return Promise.all([
+			this.syncPush(),
+			this.syncPull(),
+		]);
+	}
+
+	schedulePush () {
+		clearTimeout(this.pushTimer);
+
+		this.pushTimer = setTimeout(() => {
+			this.syncPush()
+				.finally(() => this.schedulePush())
+				.catch(error => this.logger.error(error));
+		}, this.syncInterval).unref();
+	}
+
+	schedulePull () {
+		clearTimeout(this.pullTimer);
+
+		this.pullTimer = setTimeout(() => {
+			this.syncPull()
+				.finally(() => this.schedulePull())
+				.catch(error => this.logger.error(error));
+		}, this.syncInterval).unref();
 	}
 
 	scheduleSync () {
-		clearTimeout(this.timer);
+		this.schedulePush();
+		this.schedulePull();
+	}
 
-		this.timer = setTimeout(() => {
-			this.sync()
-				.finally(() => this.scheduleSync())
-				.catch(error => this.logger.error(error));
-		}, this.syncInterval).unref();
+	unscheduleSync () {
+		clearTimeout(this.pushTimer);
+		clearTimeout(this.pullTimer);
 	}
 }
 

--- a/test/dist.js
+++ b/test/dist.js
@@ -17,6 +17,10 @@ if (!cluster.isPrimary) {
 			Object.values(cluster.workers).forEach((worker) => {
 				worker.kill();
 			});
+
+			setTimeout(() => {
+				process.exit(process.exitCode);
+			}, 1000).unref();
 		});
 
 		it('loads and doesn\'t crash', async () => {

--- a/test/tests/unit/ws/server.test.ts
+++ b/test/tests/unit/ws/server.test.ts
@@ -9,6 +9,13 @@ describe('ws server', () => {
 	const redisClient = {
 		duplicate: () => redisClient,
 		connect: sandbox.stub(),
+		xAdd: sandbox.stub().resolves(null),
+		xRange: sandbox.stub().resolves([]),
+		pExpire: sandbox.stub().resolves(null),
+		json: {
+			get: sandbox.stub().resolves(null),
+			set: sandbox.stub().resolves(null),
+		},
 	};
 	const disconnect = sandbox.stub();
 	const fetchSocketsSocketIo = sandbox.stub();

--- a/test/tests/unit/ws/synced-probe-list.test.ts
+++ b/test/tests/unit/ws/synced-probe-list.test.ts
@@ -6,12 +6,16 @@ import { SyncedProbeList } from '../../../../src/lib/ws/synced-probe-list.js';
 import { type AdoptedProbe, AdoptedProbes } from '../../../../src/lib/adopted-probes.js';
 import type { Probe } from '../../../../src/probe/types.js';
 import { getRegionByCountry } from '../../../../src/lib/location/location.js';
+import { getRedisClient } from '../../../../src/lib/redis/client.js';
 
 describe('SyncedProbeList', () => {
 	const sandbox = sinon.createSandbox();
-	const onStub = sandbox.stub();
-	const serverSideEmitStub = sandbox.stub();
+	const redisClient = getRedisClient();
 	const localFetchSocketsStub = sandbox.stub();
+	const redisXAdd = sandbox.stub(redisClient, 'xAdd');
+	const redisXRange = sandbox.stub(redisClient, 'xRange');
+	const redisPExpire = sandbox.stub(redisClient, 'pExpire');
+	const redisJsonGet = sandbox.stub(redisClient.json, 'get');
 
 	const location = {
 		continent: 'NA',
@@ -25,8 +29,6 @@ describe('SyncedProbeList', () => {
 	};
 
 	const ioNamespace = {
-		on: onStub,
-		serverSideEmit: serverSideEmitStub,
 		local: {
 			fetchSockets: localFetchSocketsStub,
 		},
@@ -35,18 +37,20 @@ describe('SyncedProbeList', () => {
 	const adoptedProbes = sandbox.createStubInstance(AdoptedProbes);
 
 	let syncedProbeList: SyncedProbeList;
-	let updateHandler: SyncedProbeList['handleUpdate'];
 
 	beforeEach(() => {
+		redisXRange.resolves([]);
+		redisJsonGet.callThrough();
+		redisPExpire.callThrough();
 		localFetchSocketsStub.resolves([]);
-		onStub.callsFake((_e, h) => updateHandler = h);
 		adoptedProbes.getUpdatedLocation.callThrough();
 		adoptedProbes.getUpdatedTags.callThrough();
 
-		syncedProbeList = new SyncedProbeList(ioNamespace, adoptedProbes);
+		syncedProbeList = new SyncedProbeList(redisClient, ioNamespace, adoptedProbes);
 	});
 
 	afterEach(() => {
+		syncedProbeList.unscheduleSync();
 		sandbox.reset();
 	});
 
@@ -57,36 +61,217 @@ describe('SyncedProbeList', () => {
 		];
 
 		localFetchSocketsStub.resolves(sockets);
-
 		await syncedProbeList.sync();
 
 		expect(localFetchSocketsStub.callCount).to.equal(1);
 		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.map(s => s.data.probe));
 
-		localFetchSocketsStub.resolves(sockets.slice(1));
+		expect(redisXAdd.callCount).to.equal(1);
+		expect(redisXAdd.firstCall.args[2]).to.deep.include({ r: '1' });
+		expect(redisXAdd.firstCall.args[2]).to.not.have.property('s');
 
+		localFetchSocketsStub.resolves(sockets.slice(1));
 		await syncedProbeList.sync();
 
 		expect(localFetchSocketsStub.callCount).to.equal(2);
 		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.slice(1).map(s => s.data.probe));
+
+		expect(redisXAdd.callCount).to.equal(2);
+		expect(redisXAdd.secondCall.args[2]).to.deep.include({ '-': 'A' });
+		expect(redisXAdd.secondCall.args[2]).to.not.have.property('+');
+		expect(redisXAdd.secondCall.args[2]).to.not.have.property('s');
+
+		localFetchSocketsStub.resolves(sockets);
+		await syncedProbeList.sync();
+
+		expect(localFetchSocketsStub.callCount).to.equal(3);
+		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.map(s => s.data.probe));
+
+		expect(redisXAdd.callCount).to.equal(3);
+		expect(redisXAdd.thirdCall.args[2]).to.deep.include({ '+': 'A' });
+		expect(redisXAdd.thirdCall.args[2]).to.not.have.property('-');
+		expect(redisXAdd.thirdCall.args[2]).to.not.have.property('s');
+	});
+
+	it('emits stats in the message on change', async () => {
+		const sockets = [
+			{ data: { probe: { client: 'A', stats: { cpu: { count: 1, load: [{ idle: 0, usage: 0 }] }, jobs: { count: 0 } } } } },
+			{ data: { probe: { client: 'B', stats: { cpu: { count: 1, load: [{ idle: 0, usage: 0 }] }, jobs: { count: 0 } } } } },
+			{ data: { probe: { client: 'C', stats: { cpu: { count: 1, load: [{ idle: 0, usage: 0 }] }, jobs: { count: 0 } } } } },
+		];
+
+		localFetchSocketsStub.resolves(sockets);
+		await syncedProbeList.sync();
+
+		expect(localFetchSocketsStub.callCount).to.equal(1);
+		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.map(s => s.data.probe));
+
+		expect(redisXAdd.callCount).to.equal(1);
+
+		sockets.slice(1).forEach(socket => socket.data.probe.stats.jobs.count = 1);
+		localFetchSocketsStub.resolves(sockets);
+		await syncedProbeList.sync();
+
+		expect(localFetchSocketsStub.callCount).to.equal(2);
+		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.map(s => s.data.probe));
+
+		expect(redisXAdd.callCount).to.equal(2);
+
+		// @ts-expect-error the arg must be an object
+		expect(JSON.parse(redisXAdd.secondCall.args[2].s)).to.deep.equal({
+			B: '1,0,0',
+			C: '1,0,0',
+		});
+
+		expect(redisXAdd.secondCall.args[2]).to.not.have.property('r');
+		expect(redisXAdd.secondCall.args[2]).to.not.have.property('+');
+		expect(redisXAdd.secondCall.args[2]).to.not.have.property('-');
+
+		localFetchSocketsStub.resolves(sockets);
+		await syncedProbeList.sync();
+
+		expect(localFetchSocketsStub.callCount).to.equal(3);
+		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.map(s => s.data.probe));
+
+		expect(redisXAdd.callCount).to.equal(3);
+		expect(redisXAdd.thirdCall.args[2]).to.not.have.property('s');
+		expect(redisXAdd.thirdCall.args[2]).to.not.have.property('r');
+		expect(redisXAdd.thirdCall.args[2]).to.not.have.property('+');
+		expect(redisXAdd.thirdCall.args[2]).to.not.have.property('-');
+
+		sockets[1]!.data.probe.client = 'D';
+		sockets.slice(2).forEach(socket => socket.data.probe.stats.jobs.count = 2);
+		localFetchSocketsStub.resolves(sockets);
+		await syncedProbeList.sync();
+
+		expect(localFetchSocketsStub.callCount).to.equal(4);
+		expect(syncedProbeList.getProbes()).to.deep.equal(sockets.map(s => s.data.probe));
+
+		expect(redisXAdd.callCount).to.equal(4);
+
+		// @ts-expect-error the arg must be an object
+		expect(JSON.parse(redisXAdd.args[3][2].s)).to.deep.equal({
+			C: '2,0,0',
+		});
+
+		expect(redisXAdd.args[3]![2]).to.deep.include({ '+': 'D', '-': 'B' });
+		expect(redisXAdd.args[3]![2]).to.not.have.property('r');
+	});
+
+	it('refreshes remote TTL when needed', async () => {
+		syncedProbeList.remoteDataTtl = 20 * 1000;
+
+		const sockets = [
+			{ data: { probe: { client: 'A' } } },
+			{ data: { probe: { client: 'B' } } },
+		];
+
+		localFetchSocketsStub.resolves(sockets);
+		await syncedProbeList.syncPush();
+
+		expect(redisPExpire.callCount).to.equal(1);
+
+		await syncedProbeList.sync();
+		expect(redisPExpire.callCount).to.equal(1);
+
+		let elapsed = 0;
+
+		// Simulate running for the duration of syncedProbeList.remoteDataTtl.
+		while ((elapsed += syncedProbeList.syncInterval) < syncedProbeList.remoteDataTtl / 2) {
+			await clock.tickAsync(syncedProbeList.syncInterval);
+			await syncedProbeList.sync();
+		}
+
+		await clock.tickAsync(2 * syncedProbeList.syncInterval);
+		await syncedProbeList.sync();
+		expect(redisPExpire.callCount).to.equal(2);
+	});
+
+	it('reads remote stats updates', async () => {
+		const probes = {
+			A: { client: 'A', stats: { cpu: { count: 1, load: [{ idle: 0, usage: 0 }] }, jobs: { count: 0 } } },
+			B: { client: 'B', stats: { cpu: { count: 1, load: [{ idle: 0, usage: 0 }] }, jobs: { count: 0 } } },
+			C: { client: 'C', stats: { cpu: { count: 1, load: [{ idle: 0, usage: 0 }] }, jobs: { count: 0 } } },
+		} as unknown as Record<string, Probe>;
+
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote', r: '1' } },
+		]);
+
+		redisJsonGet.resolves({
+			nodeId: 'remote',
+			probesById: probes,
+			changeTimestamp: Date.now(),
+			revalidateTimestamp: Date.now(),
+		});
+
+		await syncedProbeList.sync();
+		expect(syncedProbeList.getProbes()).to.deep.equal(Object.values(probes));
+
+		redisXRange.resolves([
+			{ id: '1-1', message: {} },
+			{ id: '1-2', message: { n: 'remote', s: '{"B":"1,0,0","C":"1,0,0"}' } },
+		]);
+
+		await syncedProbeList.sync();
+		expect(syncedProbeList.getProbes()[0]?.stats).to.deep.include({ jobs: { count: 0 } });
+		expect(syncedProbeList.getProbes()[1]?.stats).to.deep.include({ jobs: { count: 1 } });
+		expect(syncedProbeList.getProbes()[2]?.stats).to.deep.include({ jobs: { count: 1 } });
+	});
+
+	it('should do a full reload if some removed events were missed', async () => {
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote', a: '1' } },
+		]);
+
+		redisJsonGet.resolves({
+			nodeId: 'remote',
+			probesById: {},
+			changeTimestamp: Date.now(),
+			revalidateTimestamp: Date.now(),
+		});
+
+		await syncedProbeList.syncPull();
+		expect(redisJsonGet.callCount).to.equal(1);
+
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote', a: '1' } },
+			{ id: '1-2', message: { n: 'remote', a: '1' } },
+		]);
+
+		await syncedProbeList.syncPull();
+		expect(redisJsonGet.callCount).to.equal(1);
+
+		redisXRange.resolves([
+			{ id: '1-3', message: { n: 'remote', a: '1' } },
+		]);
+
+		await syncedProbeList.syncPull();
+		expect(redisJsonGet.callCount).to.equal(2);
 	});
 
 	it('expires remote probes after the timeout', async () => {
-		const probes = [
-			{ client: 'A' },
-			{ client: 'B' },
-		] as Probe[];
+		const probes = {
+			A: { client: 'A' },
+			B: { client: 'B' },
+		} as unknown as Record<string, Probe>;
 
-		updateHandler({
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote', r: '1' } },
+		]);
+
+		redisJsonGet.resolves({
 			nodeId: 'remote',
-			probes,
-			timestamp: Date.now(),
+			probesById: probes,
+			changeTimestamp: Date.now(),
+			revalidateTimestamp: Date.now(),
 		});
 
-		expect(syncedProbeList.getProbes()).to.deep.equal(probes);
+		await syncedProbeList.sync();
+		expect(syncedProbeList.getProbes()).to.deep.equal(Object.values(probes));
 
 		await syncedProbeList.sync();
-		expect(syncedProbeList.getProbes()).to.deep.equal(probes);
+		expect(syncedProbeList.getProbes()).to.deep.equal(Object.values(probes));
 
 		await clock.tickAsync(syncedProbeList.syncTimeout + 100);
 		expect(syncedProbeList.getProbes()).to.be.empty;


### PR DESCRIPTION
#501 overall improved the performance of the app but resulted in a *higher* redis load than expected. Most likely, it was because the previous pull-based mechanism only exchanged data when the instance was active (there was a request that needed the data), while the new sync runs all the time (as if there was at least one request every second on each instance) - so theoretically, the new approach was more efficient, but only in high-load scenarios.

This PR further improves the sync by storing the data in redis and only notifying other instances when there are changes (detected per-probe; similar idea previously suggested in https://github.com/jsdelivr/globalping/issues/419#issuecomment-1711557404), which reduces the size (not number, because of "keep alive") of exchanged messages. 

I replaced the pub/sub communication with [redis streams](https://redis.io/docs/data-types/streams/), which are essentially used as "pub/sub with history", meaning the sync doesn't break even if some messages get lost occasionally. The mechanism also handles evicted/flushed keys.

There was one issue with the "sync only changed probes" approach, as we have load stats that change often, unlike the rest of the probe data. We don't actually use the stats anywhere, but we might in the future, so I kept them and added a separate mechanism for them - they are exchanged directly via the stream in a very minimalistic form. If we eventually store them elsewhere, we might remove that part later.

The downside here is that the sync code got a lot more complex, but it should be worth the load reduction.