### PR TITLE
ci: disable deepsource for JS

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,7 +7,3 @@ exclude_patterns = ["public/**"]
 [[analyzers]]
 name = "shell"
 enabled = true
-
-[[analyzers]]
-name = "javascript"
-enabled = true


### PR DESCRIPTION
Our own linter works better and deepsource doesn't bring anything extra, it's just annoying.