### PR TITLE
refactor: rename dash DB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 13306:3306
         env:
-          MARIADB_DATABASE: directus-test
+          MARIADB_DATABASE: dashboard-globalping-test
           MARIADB_USER: directus
           MARIADB_PASSWORD: password
           MARIADB_RANDOM_ROOT_PASSWORD: 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
         ports:
           - 13306:3306
         env:
-          MARIADB_DATABASE: directus-test
+          MARIADB_DATABASE: dashboard-globalping-test
           MARIADB_USER: directus
           MARIADB_PASSWORD: password
           MARIADB_RANDOM_ROOT_PASSWORD: 1

--- a/config/create-dbs.sql
+++ b/config/create-dbs.sql
@@ -1,5 +1,9 @@
-CREATE DATABASE IF NOT EXISTS directus;
-GRANT ALL PRIVILEGES ON directus.* to 'directus'@'%';
+CREATE DATABASE IF NOT EXISTS `dashboard-globalping`;
+GRANT ALL PRIVILEGES ON `dashboard-globalping`.* to 'directus'@'%';
 
-CREATE DATABASE IF NOT EXISTS `directus-test`;
-GRANT ALL PRIVILEGES ON `directus-test`.* to 'directus'@'%';
+CREATE DATABASE IF NOT EXISTS `dashboard-globalping-test`;
+GRANT ALL PRIVILEGES ON `dashboard-globalping-test`.* to 'directus'@'%';
+
+-- Directus issue https://github.com/directus/directus/discussions/11786
+ALTER DATABASE `dashboard-globalping` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER DATABASE `dashboard-globalping-test` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -17,7 +17,7 @@ module.exports = {
 			host: 'localhost',
 			user: 'directus',
 			password: 'password',
-			database: 'directus',
+			database: 'dashboard-globalping',
 			port: 3306,
 		},
 	},

--- a/config/test.cjs
+++ b/config/test.cjs
@@ -8,7 +8,7 @@ module.exports = {
 	db: {
 		connection: {
 			port: 13306,
-			database: 'directus-test',
+			database: 'dashboard-globalping-test',
 			multipleStatements: true,
 		},
 	},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   mariadb:
     image: mariadb:10.11.5
     environment:
-      - MARIADB_DATABASE=directus
+      - MARIADB_DATABASE=dashboard-globalping
       - MARIADB_USER=directus
       - MARIADB_PASSWORD=password
       - MARIADB_ROOT_PASSWORD=root

--- a/test/e2e/cases/dns.test.ts
+++ b/test/e2e/cases/dns.test.ts
@@ -61,7 +61,7 @@ describe('dns mesurement', () => {
 				type: 'dns',
 				target: 'www.jsdelivr.com',
 				measurementOptions: {
-					resolver: '113.24.166.134',
+					resolver: '101.109.234.248',
 				},
 			},
 			throwHttpErrors: false,

--- a/test/e2e/cases/http.test.ts
+++ b/test/e2e/cases/http.test.ts
@@ -64,7 +64,7 @@ describe('http mesurement', () => {
 			target: 'www.jsdelivr.com',
 			type: 'http',
 			measurementOptions: {
-				resolver: '113.24.166.134',
+				resolver: '101.109.234.248',
 			},
 		}, throwHttpErrors: false });
 


### PR DESCRIPTION
To avoid conflicts with the other DB that will be used for the jsDelivr part.