### PR TITLE
feat: improve credits-related headers

### DIFF
--- a/public/v1/components/headers.yaml
+++ b/public/v1/components/headers.yaml
@@ -1,12 +1,7 @@
 components:
   headers:
     CreditsConsumed:
-      description: The number of credits consumed by the request. Returned only when credits were successfully consumed.
-      required: false
-      schema:
-        type: integer
-    CreditsRequired:
-      description: The number of credits required to process the request. Returned only when the credits in your account were not sufficient, and the request was rejected.
+      description: The number of credits consumed by the request. Returned only when an attempt to use credits was made (requests with a valid token exceeding the hourly rate limit).
       required: false
       schema:
         type: integer
@@ -22,17 +17,27 @@ components:
         type: string
         format: uri
     RateLimitLimit:
-      description: The number of requests available in a given time window.
+      description: The number of rate limit points available in a given time window.
+      required: true
+      schema:
+        type: integer
+    RateLimitConsumed:
+      description: The number of rate limit points consumed by the request.
       required: true
       schema:
         type: integer
     RateLimitRemaining:
-      description: The number of requests remaining in the current time window.
+      description: The number of rate limit points remaining in the current time window.
       required: true
       schema:
         type: integer
     RateLimitReset:
       description: The number of seconds until the limit resets.
       required: true
+      schema:
+        type: integer
+    RequestCost:
+      description: The number of rate limit points or credits required to accept the request.
+      required: false
       schema:
         type: integer

--- a/public/v1/components/responses.yaml
+++ b/public/v1/components/responses.yaml
@@ -127,16 +127,18 @@ components:
           $ref: 'headers.yaml#/components/headers/MeasurementLocation'
         X-RateLimit-Limit:
           $ref: 'headers.yaml#/components/headers/RateLimitLimit'
+        X-RateLimit-Consumed:
+          $ref: 'headers.yaml#/components/headers/RateLimitConsumed'
         X-RateLimit-Remaining:
           $ref: 'headers.yaml#/components/headers/RateLimitRemaining'
         X-RateLimit-Reset:
           $ref: 'headers.yaml#/components/headers/RateLimitReset'
         X-Credits-Consumed:
           $ref: 'headers.yaml#/components/headers/CreditsConsumed'
-        X-Credits-Required:
-          $ref: 'headers.yaml#/components/headers/CreditsRequired'
         X-Credits-Remaining:
           $ref: 'headers.yaml#/components/headers/CreditsRemaining'
+        X-Request-Cost:
+          $ref: 'headers.yaml#/components/headers/RequestCost'
       content:
         application/json:
           schema:


### PR DESCRIPTION
Removes `X-Credits-Required`, which was confusing because it didn't cover the whole request cost (depending on the hourly rate limit status). Instead, there are now two headers:
 - `X-Request-Cost` - the total cost of the request, always present,
 - `X-RateLimit-Consumed` - part of the request cost that was paid by rate limit points (mirrors the existing `X-Credits-Consumed`).