### PR TITLE
feat: OAuth support

### DIFF
--- a/.mocharc.e2e.cjs
+++ b/.mocharc.e2e.cjs
@@ -11,6 +11,7 @@ module.exports = {
 		path.join(__dirname, 'test/e2e/cases/**/*.test.ts'),
 	],
 	'node-option': [
+		'enable-source-maps',
 		'experimental-specifier-resolution=node',
 		'loader=ts-node/esm',
 	],

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -10,6 +10,7 @@
 		"test/tests/unit/**/*.test.ts"
 	],
 	"node-option": [
+		"enable-source-maps",
 		"experimental-specifier-resolution=node",
 		"loader=ts-node/esm"
 	],

--- a/migrations/create-tables.js.sql
+++ b/migrations/create-tables.js.sql
@@ -1,58 +1,70 @@
 CREATE TABLE IF NOT EXISTS directus_users (
-  id CHAR(36),
-  github_username VARCHAR(255)
-);
+	id CHAR(36) PRIMARY KEY,
+	github_username VARCHAR(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS gp_adopted_probes (
-  id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  user_created CHAR(36),
-  date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  user_updated CHAR(36),
-  date_updated TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  userId VARCHAR(255) NOT NULL,
-  ip VARCHAR(255) NOT NULL,
+	id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	user_created CHAR(36),
+	date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	user_updated CHAR(36),
+	date_updated TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	userId VARCHAR(255) NOT NULL,
+	ip VARCHAR(255) NOT NULL,
 	altIps LONGTEXT COLLATE utf8mb4_bin DEFAULT '[]' NOT NULL,
-  uuid VARCHAR(255),
-  lastSyncDate DATE NOT NULL,
-  isCustomCity TINYINT(1) DEFAULT 0,
-  tags LONGTEXT COLLATE utf8mb4_bin DEFAULT '[]' NOT NULL,
-  status VARCHAR(255) NOT NULL,
-  isIPv4Supported BOOLEAN,
-  isIPv6Supported BOOLEAN,
-  version VARCHAR(255) NOT NULL,
-  nodeVersion VARCHAR(255) NOT NULL,
-  hardwareDevice VARCHAR(255) NULL,
-  country VARCHAR(255) NOT NULL,
-  city VARCHAR(255),
-  state VARCHAR(255),
-  latitude FLOAT(10, 5),
-  longitude FLOAT(10, 5),
-  asn INTEGER NOT NULL,
-  network VARCHAR(255) NOT NULL,
-  countryOfCustomCity VARCHAR(255)
+	uuid VARCHAR(255),
+	lastSyncDate DATE NOT NULL,
+	isCustomCity TINYINT(1) DEFAULT 0,
+	tags LONGTEXT COLLATE utf8mb4_bin DEFAULT '[]' NOT NULL,
+	status VARCHAR(255) NOT NULL,
+	isIPv4Supported BOOLEAN,
+	isIPv6Supported BOOLEAN,
+	version VARCHAR(255) NOT NULL,
+	nodeVersion VARCHAR(255) NOT NULL,
+	hardwareDevice VARCHAR(255) NULL,
+	country VARCHAR(255) NOT NULL,
+	city VARCHAR(255),
+	state VARCHAR(255),
+	latitude FLOAT(10, 5),
+	longitude FLOAT(10, 5),
+	asn INTEGER NOT NULL,
+	network VARCHAR(255) NOT NULL,
+	countryOfCustomCity VARCHAR(255)
 );
 
 CREATE TABLE IF NOT EXISTS directus_notifications (
-  id CHAR(10),
-  recipient CHAR(36),
-  timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  subject VARCHAR(255),
-  message TEXT
+	id CHAR(10),
+	recipient CHAR(36),
+	timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	subject VARCHAR(255),
+	message TEXT
 );
 
-CREATE TABLE IF NOT EXISTS gp_tokens (
-  id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-	user_created CHAR(36),
-	name VARCHAR(255),
-	value VARCHAR(255),
-	origins LONGTEXT,
-	expire DATE,
-	date_last_used DATE
-);
+CREATE TABLE `gp_tokens` (
+	`date_created` timestamp NULL DEFAULT NULL,
+	`date_last_used` date DEFAULT NULL,
+	`date_updated` timestamp NULL DEFAULT NULL,
+	`expire` date DEFAULT NULL,
+	`id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+	`name` varchar(255) NOT NULL,
+	`origins` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '[]' CHECK (json_valid(`origins`)),
+	`user_created` char(36) DEFAULT NULL,
+	`user_updated` char(36) DEFAULT NULL,
+	`value` varchar(255) DEFAULT NULL,
+	`scopes` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '[]' CHECK (json_valid(`scopes`)),
+	`type` varchar(255) DEFAULT 'access_token',
+	`parent` int(10) unsigned DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `gp_tokens_value_unique` (`value`),
+	KEY `gp_tokens_user_created_foreign` (`user_created`),
+	KEY `gp_tokens_user_updated_foreign` (`user_updated`),
+	KEY `value_index` (`value`),
+	KEY `gp_tokens_parent_foreign` (`parent`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS gp_credits (
-  id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	AMOUNT INT,
 	user_id VARCHAR(36) NOT NULL,
 	CONSTRAINT gp_credits_user_id_unique UNIQUE (user_id),
@@ -60,15 +72,15 @@ CREATE TABLE IF NOT EXISTS gp_credits (
 );
 
 CREATE TABLE IF NOT EXISTS gp_location_overrides (
-  id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  user_created CHAR(36),
-  date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  user_updated CHAR(36),
-  date_updated TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  ip_range VARCHAR(255) NOT NULL,
-  city VARCHAR(255) NOT NULL,
-  state VARCHAR(255),
-  country VARCHAR(255),
+	id INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	user_created CHAR(36),
+	date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	user_updated CHAR(36),
+	date_updated TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	ip_range VARCHAR(255) NOT NULL,
+	city VARCHAR(255) NOT NULL,
+	state VARCHAR(255),
+	country VARCHAR(255),
 	latitude FLOAT(10, 5),
 	longitude FLOAT(10, 5)
 );

--- a/src/lib/http/middleware/authenticate.ts
+++ b/src/lib/http/middleware/authenticate.ts
@@ -1,7 +1,10 @@
+import config from 'config';
 import { jwtVerify } from 'jose';
 
 import { auth } from '../auth.js';
 import type { ExtendedMiddleware } from '../../../types.js';
+
+const sessionConfig = config.get<AuthenticateOptions['session']>('server.session');
 
 type SessionCookiePayload = {
 	id?: string;
@@ -10,12 +13,12 @@ type SessionCookiePayload = {
 	admin_access?: number;
 };
 
-export const authenticate = (options: AuthenticateOptions): ExtendedMiddleware => {
-	const sessionKey = Buffer.from(options.session.cookieSecret);
+export const authenticate = (): ExtendedMiddleware => {
+	const sessionKey = Buffer.from(sessionConfig.cookieSecret);
 
 	return async (ctx, next) => {
 		const authorization = ctx.headers.authorization;
-		const sessionCookie = ctx.cookies.get(options.session.cookieName);
+		const sessionCookie = ctx.cookies.get(sessionConfig.cookieName);
 
 		if (authorization) {
 			const parts = authorization.split(' ');

--- a/src/lib/http/middleware/authenticate.ts
+++ b/src/lib/http/middleware/authenticate.ts
@@ -30,14 +30,14 @@ export const authenticate = (): ExtendedMiddleware => {
 
 			const token = parts[1]!;
 			const origin = ctx.get('Origin');
-			const userId = await auth.validate(token, origin);
+			const result = await auth.validate(token, origin);
 
-			if (!userId) {
+			if (!result) {
 				ctx.status = 401;
 				return;
 			}
 
-			ctx.state.user = { id: userId, authMode: 'token' };
+			ctx.state.user = { id: result.userId, scopes: result.scopes, authMode: 'token' };
 		} else if (sessionCookie) {
 			try {
 				const result = await jwtVerify<SessionCookiePayload>(sessionCookie, sessionKey);
@@ -53,5 +53,4 @@ export const authenticate = (): ExtendedMiddleware => {
 };
 
 export type AuthenticateOptions = { session: { cookieName: string, cookieSecret: string } };
-export type AuthenticateState = { user?: { id: string, authMode: 'cookie' | 'token' } };
-
+export type AuthenticateState = { user?: { id: string, scopes?: string[], authMode: 'cookie' | 'token' } };

--- a/src/lib/http/middleware/cors.ts
+++ b/src/lib/http/middleware/cors.ts
@@ -1,4 +1,8 @@
 import type { Context, Next } from 'koa';
+import config from 'config';
+
+const corsConfig = config.get<CorsOptions>('server.cors');
+const trustedOrigins = corsConfig.trustedOrigins || [];
 
 export const corsHandler = () => async (ctx: Context, next: Next) => {
 	ctx.set('Access-Control-Allow-Origin', '*');
@@ -12,7 +16,7 @@ export const corsHandler = () => async (ctx: Context, next: Next) => {
 	return next();
 };
 
-export const corsAuthHandler = ({ trustedOrigins = [] }: CorsOptions) => {
+export const corsAuthHandler = () => {
 	const exposeHeaders = [
 		'ETag',
 		'Link',

--- a/src/lib/http/middleware/default-json.ts
+++ b/src/lib/http/middleware/default-json.ts
@@ -8,6 +8,11 @@ export const defaultJson = (): ExtendedMiddleware => async (ctx, next) => {
 	if (ctx.status >= 400 && !ctx.body) {
 		const error = createHttpError(ctx.status);
 
+		// Fix a bit of koa's magic: setting the body below resets the status
+		// to 200 if it wasn't explicitly set before.
+		// eslint-disable-next-line no-self-assign
+		ctx.status = ctx.status;
+
 		ctx.body = {
 			error: {
 				type: _.snakeCase(error.message),

--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -19,6 +19,9 @@ const createRedisClient = (options?: RedisClientOptions): RedisClient => {
 };
 
 export const getRedisClient = (): RedisClient => {
-	redis = createRedisClient();
+	if (!redis) {
+		redis = createRedisClient();
+	}
+
 	return redis;
 };

--- a/src/lib/redis/measurement-client.ts
+++ b/src/lib/redis/measurement-client.ts
@@ -19,6 +19,9 @@ export const createMeasurementRedisClient = (options?: RedisClientOptions): Redi
 };
 
 export const getMeasurementRedisClient = (): RedisClient => {
-	redis = createMeasurementRedisClient();
+	if (!redis) {
+		redis = createMeasurementRedisClient();
+	}
+
 	return redis;
 };

--- a/src/lib/redis/persistent-client.ts
+++ b/src/lib/redis/persistent-client.ts
@@ -19,6 +19,9 @@ export const createPersistentRedisClient = (options?: RedisClientOptions): Redis
 };
 
 export const getPersistentRedisClient = (): RedisClient => {
-	redis = createPersistentRedisClient();
+	if (!redis) {
+		redis = createPersistentRedisClient();
+	}
+
 	return redis;
 };

--- a/src/lib/redis/subscription-client.ts
+++ b/src/lib/redis/subscription-client.ts
@@ -18,6 +18,9 @@ export const createSubscriptionRedisClient = (options?: RedisClientOptions): Red
 };
 
 export const getSubscriptionRedisClient = (): RedisClient => {
-	redis = createSubscriptionRedisClient();
+	if (!redis) {
+		redis = createSubscriptionRedisClient();
+	}
+
 	return redis;
 };

--- a/src/measurement/route/create-measurement.ts
+++ b/src/measurement/route/create-measurement.ts
@@ -2,14 +2,12 @@ import config from 'config';
 import type Router from '@koa/router';
 import { getMeasurementRunner } from '../runner.js';
 import { bodyParser } from '../../lib/http/middleware/body-parser.js';
-import { corsAuthHandler, CorsOptions } from '../../lib/http/middleware/cors.js';
+import { corsAuthHandler } from '../../lib/http/middleware/cors.js';
 import { validate } from '../../lib/http/middleware/validate.js';
-import { authenticate, AuthenticateOptions } from '../../lib/http/middleware/authenticate.js';
+import { authenticate } from '../../lib/http/middleware/authenticate.js';
 import { schema } from '../schema/global-schema.js';
 import type { ExtendedContext } from '../../types.js';
 
-const corsConfig = config.get<CorsOptions>('server.cors');
-const sessionConfig = config.get<AuthenticateOptions['session']>('server.session');
 const hostConfig = config.get<string>('server.host');
 const runner = getMeasurementRunner();
 
@@ -27,6 +25,6 @@ const handle = async (ctx: ExtendedContext): Promise<void> => {
 
 export const registerCreateMeasurementRoute = (router: Router): void => {
 	router
-		.options('/measurements', '/measurements', corsAuthHandler(corsConfig))
-		.post('/measurements', '/measurements', corsAuthHandler(corsConfig), authenticate({ session: sessionConfig }), bodyParser(), validate(schema), handle);
+		.post('/measurements', '/measurements', corsAuthHandler(), authenticate(), bodyParser(), validate(schema), handle)
+		.options('/measurements', '/measurements', corsAuthHandler());
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,7 +4,7 @@ import type { DocsLinkContext } from './lib/http/middleware/docs-link.js';
 import type { AuthenticateState } from './lib/http/middleware/authenticate.js';
 
 export type CustomState = Koa.DefaultState & AuthenticateState;
-export type CustomContext = Koa.DefaultContext & DocsLinkContext;
+export type CustomContext = Koa.DefaultContext & Router.RouterParamContext & DocsLinkContext;
 
 export type ExtendedContext = Router.RouterContext<CustomState, CustomContext>;
 export type ExtendedMiddleware = Router.Middleware<CustomState, CustomContext>;

--- a/test/tests/integration/middleware/authenticate.test.ts
+++ b/test/tests/integration/middleware/authenticate.test.ts
@@ -48,6 +48,7 @@ describe('authenticate', () => {
 
 		it('should accept if valid token was passed', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 			});
@@ -65,6 +66,7 @@ describe('authenticate', () => {
 
 		it('should accept if origin is correct', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 				origins: JSON.stringify([ 'https://jsdelivr.com' ]),
@@ -84,6 +86,7 @@ describe('authenticate', () => {
 
 		it('should update "date_last_used" field', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 			});
@@ -109,6 +112,7 @@ describe('authenticate', () => {
 
 		it('should get token from db if it is not synced yet', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 			});
@@ -134,6 +138,7 @@ describe('authenticate', () => {
 
 		it('should reject if token is expired', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 				expire: new Date('01-01-2024'),
@@ -152,6 +157,7 @@ describe('authenticate', () => {
 
 		it('should reject if previously not synced token is expired', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 				expire: new Date('01-01-2024'),
@@ -168,6 +174,7 @@ describe('authenticate', () => {
 
 		it('should reject if origin is wrong', async () => {
 			await client(GP_TOKENS_TABLE).insert({
+				name: 'test token',
 				user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				value: '/bSluuDrAPX9zIiZZ/hxEKARwOg+e//EdJgCFpmApbg=',
 				origins: JSON.stringify([ 'https://jsdelivr.com' ]),

--- a/test/tests/integration/ratelimit.test.ts
+++ b/test/tests/integration/ratelimit.test.ts
@@ -38,6 +38,7 @@ describe('rate limiter', () => {
 		await waitForProbesUpdate();
 
 		await client(GP_TOKENS_TABLE).insert({
+			name: 'test token',
 			user_created: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 			value: 'Xj6kuKFEQ6zI60mr+ckHG7yQcIFGMJFzvtK9PBQ69y8=', // token: qz5kdukfcr3vggv3xbujvjwvirkpkkpx
 		});
@@ -56,7 +57,7 @@ describe('rate limiter', () => {
 
 	describe('headers', () => {
 		it('should NOT include headers (GET)', async () => {
-			const response = await requestAgent.get('/v1/').send().expect(200) as Response;
+			const response = await requestAgent.get('/v1/').send().expect(404) as Response;
 
 			expect(response.headers['x-ratelimit-limit']).to.not.exist;
 			expect(response.headers['x-ratelimit-consumed']).to.not.exist;

--- a/test/tests/unit/auth.test.ts
+++ b/test/tests/unit/auth.test.ts
@@ -37,7 +37,7 @@ describe('Auth', () => {
 		await clock.tickAsync(60_000);
 
 		const user1 = await auth.validate('hf2fnprguymlgliirdk7qv23664c2xcr', 'https://jsdelivr.com');
-		expect(user1).to.equal('user1');
+		expect(user1).to.deep.equal({ userId: 'user1', scopes: [] });
 		const user2 = await auth.validate('vumzijbzihrskmc2hj34yw22batpibmt', 'https://jsdelivr.com');
 		expect(user2).to.equal(null);
 
@@ -53,7 +53,7 @@ describe('Auth', () => {
 		const user1afterSync = await auth.validate('hf2fnprguymlgliirdk7qv23664c2xcr', 'https://jsdelivr.com');
 		expect(user1afterSync).to.equal(null);
 		const user2afterSync = await auth.validate('vumzijbzihrskmc2hj34yw22batpibmt', 'https://jsdelivr.com');
-		expect(user2afterSync).to.equal('user2');
+		expect(user2afterSync).to.deep.equal({ userId: 'user2', scopes: [] });
 		auth.unscheduleSync();
 	});
 
@@ -72,7 +72,7 @@ describe('Auth', () => {
 		await auth.validate('hf2fnprguymlgliirdk7qv23664c2xcr', 'https://jsdelivr.com');
 		await auth.validate('hf2fnprguymlgliirdk7qv23664c2xcr', 'https://jsdelivr.com');
 
-		expect(user).to.equal('user1');
+		expect(user).to.deep.equal({ userId: 'user1', scopes: [] });
 		expect(selectStub.callCount).to.equal(1);
 	});
 
@@ -89,7 +89,7 @@ describe('Auth', () => {
 		await auth.validate('hf2fnprguymlgliirdk7qv23664c2xcr', 'https://jsdelivr.com');
 		await auth.validate('hf2fnprguymlgliirdk7qv23664c2xcr', 'https://jsdelivr.com');
 
-		expect(user).to.equal('user1');
+		expect(user).to.deep.equal({ userId: 'user1', scopes: [] });
 		expect(selectStub.callCount).to.equal(1);
 	});
 


### PR DESCRIPTION
Part of https://github.com/jsdelivr/globalping-auth/pull/1

Minimal changes here, the first 4 commits are unrelated fixes. The auth changes are:
 - check for `type: 'access_token'`,
 - loading scopes, though these are not used anywhere, as all tokens get exactly the same scope.