### PR TITLE
misc: unify the format of validation error messages

### DIFF
--- a/src/lib/malware/client.ts
+++ b/src/lib/malware/client.ts
@@ -43,7 +43,7 @@ export const joiValidate = (value: string, helpers?: CustomHelpers): string | Er
 };
 
 export const joiSchemaErrorMessages = {
-	'ip.blacklisted': `Provided address is blacklisted.`,
-	'domain.blacklisted': `Provided address is blacklisted.`,
-	'any.blacklisted': `Provided address is blacklisted.`,
+	'ip.blacklisted': `{{#label}} is a blacklisted address`,
+	'domain.blacklisted': `{{#label}} is a blacklisted domain`,
+	'any.blacklisted': `{{#label}} is a blacklisted address or domain`,
 };

--- a/src/measurement/schema/command-schema.ts
+++ b/src/measurement/schema/command-schema.ts
@@ -14,8 +14,8 @@ import {
 
 export const schemaErrorMessages = {
 	...joiMalwareSchemaErrorMessages,
-	'ip.private': 'Private hostnames are not allowed.',
-	'domain.invalid': 'Provided target is not a valid domain name',
+	'ip.private': '{{#label}} must not be a private hostname',
+	'domain.invalid': '{{#label}} must be a valid domain name',
 };
 
 
@@ -30,8 +30,8 @@ export const ipVersionSchema = Joi.number().when(Joi.ref('...target'), {
 		otherwise: Joi.forbidden().default(DEFAULT_IP_VERSION),
 	}),
 }).messages({
-	'any.only': 'ipVersion must be either 4 or 6',
-	'any.unknown': 'ipVersion is not allowed when target is not a domain',
+	'any.only': '{{#label}} must be either 4 or 6',
+	'any.unknown': '{{#label}} is not allowed when target is not a domain',
 });
 export const ipVersionDnsSchema = Joi.number().when(Joi.ref('resolver'), {
 	is: Joi.custom(joiValidateDomain()),
@@ -42,8 +42,8 @@ export const ipVersionDnsSchema = Joi.number().when(Joi.ref('resolver'), {
 		otherwise: Joi.forbidden().default(DEFAULT_IP_VERSION),
 	}),
 }).messages({
-	'any.only': 'ipVersion must be either 4 or 6',
-	'any.unknown': 'ipVersion is not allowed when resolver is not a domain',
+	'any.only': '{{#label}} must be either 4 or 6',
+	'any.unknown': '{{#label}} is not allowed when resolver is not a domain',
 });
 
 export const validCmdTypes = [ 'ping', 'dns', 'traceroute', 'mtr', 'http' ];

--- a/src/measurement/schema/location-schema.ts
+++ b/src/measurement/schema/location-schema.ts
@@ -39,12 +39,12 @@ export const schema = Joi.alternatives().try(
 	Joi.string().max(128),
 	Joi.array().max(128).items(Joi.object().keys({
 		continent: Joi.string().valid(...Object.keys(continents)).insensitive()
-			.messages({ 'any.only': 'The continent must be a valid two-letter continent code' }),
+			.messages({ 'any.only': '{{#label}} must be a valid two-letter continent code' }),
 		region: Joi.string().valid(...regionNames).insensitive(),
 		country: Joi.string().valid(...Object.keys(countries)).insensitive()
-			.messages({ 'any.only': 'The country must be a valid two-letter ISO code' }),
+			.messages({ 'any.only': '{{#label}} must be a valid two-letter ISO code' }),
 		state: Joi.string().valid(...Object.values(states)).insensitive()
-			.messages({ 'any.only': 'The US state must be a valid two-letter code, e.g. CA' }),
+			.messages({ 'any.only': '{{#label}} must be a valid two-letter code, e.g. CA' }),
 		city: Joi.string().min(1).max(128).lowercase().custom(normalizeValue),
 		network: Joi.string().min(1).max(128).lowercase().custom(normalizeValue),
 		asn: Joi.number().integer().positive(),
@@ -56,7 +56,7 @@ export const schema = Joi.alternatives().try(
 			otherwise: Joi.number().max(anonymousTestsPerLocation),
 		}).when(Joi.ref('/limit'), {
 			is: Joi.exist(),
-			then: Joi.forbidden().messages({ 'any.unknown': 'limit per location is not allowed when a global limit is set' }),
+			then: Joi.forbidden().messages({ 'any.unknown': '{{#label}} is not allowed when a global limit is set' }),
 			otherwise: Joi.number().default(1),
 		}),
 	}).or('continent', 'region', 'country', 'state', 'city', 'network', 'asn', 'magic', 'tags'))
@@ -65,8 +65,8 @@ export const schema = Joi.alternatives().try(
 			then: Joi.custom(sumOfLocationsLimits('limits.sum.auth', authenticatedTestsPerMeasurement)),
 			otherwise: Joi.custom(sumOfLocationsLimits('limits.sum.anon', anonymousTestsPerMeasurement)),
 		}).messages({
-			'limits.sum.auth': `Sum of limits must be less than or equal to ${authenticatedTestsPerMeasurement}`,
-			'limits.sum.anon': `Sum of limits must be less than or equal to ${anonymousTestsPerMeasurement}`,
+			'limits.sum.auth': `the sum of limits must be less than or equal to ${authenticatedTestsPerMeasurement}`,
+			'limits.sum.anon': `the sum of limits must be less than or equal to ${anonymousTestsPerMeasurement}`,
 			'magic.max.conditions': `{{#label}} must contain at most ${maxConditionsInMagicField} combined filters`,
 		}),
 ).default(GLOBAL_DEFAULTS.locations);

--- a/test/tests/unit/measurement/schema/schema.test.ts
+++ b/test/tests/unit/measurement/schema/schema.test.ts
@@ -46,7 +46,7 @@ describe('command schema', async () => {
 
 				const valid = globalSchema.validate(input, { convert: true });
 
-				expect(valid?.error?.details?.[0]?.message).to.equal('limit per location is not allowed when a global limit is set');
+				expect(valid?.error?.details?.[0]?.message).to.equal('"locations[0].limit" is not allowed when a global limit is set');
 			});
 
 			it('should pass (2 locations - no limit)', () => {
@@ -145,7 +145,7 @@ describe('command schema', async () => {
 
 				const valid = globalSchema.validate(input, { convert: true });
 
-				expect(valid?.error?.details?.[0]?.message).to.equal('Sum of limits must be less than or equal to 500');
+				expect(valid?.error?.details?.[0]?.message).to.equal('the sum of limits must be less than or equal to 500');
 			});
 
 			it('should return an error (locations authenticated limit sum is bigger than global limit)', () => {
@@ -166,7 +166,7 @@ describe('command schema', async () => {
 
 				const valid = globalSchema.validate(input, { convert: true, context: { userId: '1-1-1-1-1' } });
 
-				expect(valid?.error?.details?.[0]?.message).to.equal('Sum of limits must be less than or equal to 500');
+				expect(valid?.error?.details?.[0]?.message).to.equal('the sum of limits must be less than or equal to 500');
 			});
 		});
 
@@ -549,21 +549,21 @@ describe('command schema', async () => {
 			const input = '.';
 			const valid = schema.validate(input);
 
-			expect(valid.error!.details[0]!.message).to.equal('Provided target is not a valid domain name');
+			expect(valid.error!.details[0]!.message).to.equal('"value" must be a valid domain name');
 		});
 
 		it('should fail (tld)', () => {
 			const input = 'com';
 			const valid = schema.validate(input);
 
-			expect(valid.error!.details[0]!.message).to.equal('Provided target is not a valid domain name');
+			expect(valid.error!.details[0]!.message).to.equal('"value" must be a valid domain name');
 		});
 
 		it('should fail (trailing dot)', () => {
 			const input = 'example.com.';
 			const valid = schema.validate(input);
 
-			expect(valid.error!.details[0]!.message).to.equal('Provided target is not a valid domain name');
+			expect(valid.error!.details[0]!.message).to.equal('"value" must be a valid domain name');
 		});
 	});
 
@@ -621,7 +621,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Private hostnames are not allowed.');
+			expect(valid.error!.message).to.equal('"target" must not be a private hostname');
 		});
 
 		it('should fail (private ipv6)', () => {
@@ -633,7 +633,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Private hostnames are not allowed.');
+			expect(valid.error!.message).to.equal('"target" must not be a private hostname');
 		});
 
 		it('should fail (missing values)', () => {
@@ -725,7 +725,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv4)', () => {
@@ -737,7 +737,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv6)', () => {
@@ -749,7 +749,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (unsupported ipVersion)', () => {
@@ -764,7 +764,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion must be either 4 or 6');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" must be either 4 or 6');
 		});
 
 		it('should pass and correct values (incorrect capitalization)', () => {
@@ -861,7 +861,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion is not allowed when target is not a domain');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" is not allowed when target is not a domain');
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when target ipv4', () => {
@@ -932,7 +932,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv4)', () => {
@@ -944,7 +944,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv6)', () => {
@@ -956,7 +956,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (invalid port)', () => {
@@ -986,7 +986,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion must be either 4 or 6');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" must be either 4 or 6');
 		});
 
 		it('should pass (target domain)', () => {
@@ -1133,7 +1133,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion is not allowed when target is not a domain');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" is not allowed when target is not a domain');
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when target ipv4', () => {
@@ -1206,7 +1206,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided target is not a valid domain name');
+			expect(valid.error!.message).to.equal('"target" must be a valid domain name');
 		});
 
 		it('should fail (blacklisted target domain)', () => {
@@ -1218,7 +1218,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted domain');
 		});
 
 		it('should pass (ipv6 resolver)', () => {
@@ -1247,7 +1247,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"measurementOptions.resolver" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted ipv4 resolver)', () => {
@@ -1262,7 +1262,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"measurementOptions.resolver" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted ipv6 resolver)', () => {
@@ -1277,7 +1277,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"measurementOptions.resolver" is a blacklisted address or domain');
 		});
 
 		it('should fail (invalid port)', () => {
@@ -1322,7 +1322,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion must be either 4 or 6');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" must be either 4 or 6');
 		});
 
 		it('should pass (target domain) (_acme-challenge.abc.com)', () => {
@@ -1565,7 +1565,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion is not allowed when resolver is not a domain');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" is not allowed when resolver is not a domain');
 		});
 
 		it('should pass (root domain)', () => {
@@ -1634,7 +1634,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address');
 		});
 
 		it('should fail (uses blacklisted ipv6 for target)', () => {
@@ -1651,7 +1651,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address');
 		});
 
 		it('should pass (uses ipv4 for target)', () => {
@@ -1741,7 +1741,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv4)', () => {
@@ -1753,7 +1753,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv6)', () => {
@@ -1765,7 +1765,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (invalid port)', () => {
@@ -1795,7 +1795,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion must be either 4 or 6');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" must be either 4 or 6');
 		});
 
 		it('should pass (target domain)', () => {
@@ -1884,7 +1884,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion is not allowed when target is not a domain');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" is not allowed when target is not a domain');
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when target ipv4', () => {
@@ -2067,7 +2067,7 @@ describe('command schema', async () => {
 
 			const valid = globalSchema.validate(input, { convert: true });
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"measurementOptions.resolver" is a blacklisted address');
 		});
 
 		it('should fail (blacklisted ipv6 resolver)', () => {
@@ -2090,7 +2090,7 @@ describe('command schema', async () => {
 
 			const valid = globalSchema.validate(input, { convert: true });
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"measurementOptions.resolver" is a blacklisted address');
 		});
 
 		it('should fail (unsupported method)', () => {
@@ -2161,7 +2161,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion must be either 4 or 6');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" must be either 4 or 6');
 		});
 
 		it('should fail (blacklisted target domain)', () => {
@@ -2173,7 +2173,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv4)', () => {
@@ -2185,7 +2185,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should fail (blacklisted target ipv6)', () => {
@@ -2197,7 +2197,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('Provided address is blacklisted.');
+			expect(valid.error!.message).to.equal('"target" is a blacklisted address or domain');
 		});
 
 		it('should pass (target domain) (_sub.domain.com)', () => {
@@ -2409,7 +2409,7 @@ describe('command schema', async () => {
 
 			const valid = globalSchema.validate(input, { convert: true });
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('ipVersion is not allowed when target is not a domain');
+			expect(valid.error!.message).to.equal('"measurementOptions.ipVersion" is not allowed when target is not a domain');
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when target is ipv4', () => {


### PR DESCRIPTION
To match the format Joi generates for its own errors. 