### PR TITLE
fix: update UUID only if it changed

### DIFF
--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -245,7 +245,7 @@ export class AdoptedProbes {
 		}
 
 		if (connectedProbeByIp) { // probe was found by ip, but data is outdated
-			return this.updateIds(ip, connectedProbeByIp);
+			return this.updateIds(ip, uuid, connectedProbeByIp);
 		}
 
 		let connectedProbeByAltIp: Probe | undefined;
@@ -261,7 +261,7 @@ export class AdoptedProbes {
 
 		if (connectedProbeByAltIp) { // probe was found by alt ip, need to update the adopted data
 			logger.info('Found by alt IP.', { old: { ip, uuid }, new: { ip: connectedProbeByAltIp.ipAddress, altIps: connectedProbeByAltIp.altIpAddresses, uuid: connectedProbeByAltIp.uuid } });
-			await this.updateIds(ip, connectedProbeByAltIp);
+			await this.updateIds(ip, uuid, connectedProbeByAltIp);
 		}
 
 		if (!uuid) { // uuid is null, so no searching by uuid is required
@@ -272,7 +272,7 @@ export class AdoptedProbes {
 
 		if (connectedProbeByUuid) { // probe was found by uuid, need to update the adopted data
 			logger.info('Found by UUID.', { old: { ip, uuid }, new: { ip: connectedProbeByUuid.ipAddress, altIps: connectedProbeByUuid.altIpAddresses, uuid: connectedProbeByUuid.uuid } });
-			await this.updateIds(ip, connectedProbeByUuid);
+			await this.updateIds(ip, uuid, connectedProbeByUuid);
 		}
 	}
 
@@ -338,11 +338,11 @@ export class AdoptedProbes {
 		}
 	}
 
-	private async updateIds (currentAdoptedIp: string, connectedProbe: Probe) {
+	private async updateIds (currentAdoptedIp: string, uuid: string | null, connectedProbe: Probe) {
 		await this.sql(ADOPTED_PROBES_TABLE).where({ ip: currentAdoptedIp }).update({
 			ip: connectedProbe.ipAddress,
 			altIps: JSON.stringify(connectedProbe.altIpAddresses),
-			uuid: connectedProbe.uuid,
+			...connectedProbe.uuid !== uuid ? { uuid: connectedProbe.uuid } : {},
 		});
 
 		const adoptedProbe = this.getByIp(currentAdoptedIp);

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -134,7 +134,7 @@ describe('AdoptedProbes', () => {
 		expect(whereStub.callCount).to.equal(1);
 		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
 		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.args[0]).to.deep.equal([{ ip: '2.2.2.2', altIps: '[]', uuid: '1-1-1-1-1' }]);
+		expect(updateStub.args[0]).to.deep.equal([{ ip: '2.2.2.2', altIps: '[]' }]);
 	});
 
 	it('class should update alt ips if it is wrong', async () => {
@@ -146,7 +146,7 @@ describe('AdoptedProbes', () => {
 		expect(whereStub.callCount).to.equal(1);
 		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
 		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.args[0]).to.deep.equal([{ ip: '1.1.1.1', altIps: JSON.stringify([ '2.2.2.2' ]), uuid: '1-1-1-1-1' }]);
+		expect(updateStub.args[0]).to.deep.equal([{ ip: '1.1.1.1', altIps: JSON.stringify([ '2.2.2.2' ]) }]);
 	});
 
 	it('class should update status to "offline" if adopted probe was not found', async () => {


### PR DESCRIPTION
Most likely as a result of https://github.com/jsdelivr/globalping-dash-directus/commit/ce54f8e61bec9faf5fb988ee49a329f05eacc47b, the sync is now failing with this error:

```
update `gp_adopted_probes` set `ip` = 'xxx', `altIps` = '[\"yyy\"]', `uuid` = 'zzz' where `ip` = 'xxx' - ER_DUP_ENTRY: Duplicate entry 'zzz' for key 'gp_adopted_probes_uuid_unique'
```

To avoid it, we must either not try to update the UUID without changing its value, or include the value in the WHERE part as well.