### PR TITLE
fix: adopted probes sync issue

### DIFF
--- a/migrations/create-tables.js.sql
+++ b/migrations/create-tables.js.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS gp_adopted_probes (
 	tags LONGTEXT COLLATE utf8mb4_bin DEFAULT '[]' NOT NULL,
 	systemTags LONGTEXT COLLATE utf8mb4_bin DEFAULT '[]' NOT NULL,
 	status VARCHAR(255) NOT NULL,
+	onlineTimesToday INT DEFAULT 0 NOT NULL,
 	isIPv4Supported BOOLEAN,
 	isIPv6Supported BOOLEAN,
 	version VARCHAR(255) NOT NULL,

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -15,7 +15,7 @@ const logger = scopedLogger('adopted-probes');
 
 export const ADOPTED_PROBES_TABLE = 'gp_adopted_probes';
 export const NOTIFICATIONS_TABLE = 'directus_notifications';
-const ER_DUP_ENTRY_CODE = 1062;
+export const ER_DUP_ENTRY_CODE = 1062;
 
 export type AdoptedProbe = {
 	id: string;

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -216,11 +216,9 @@ export class AdoptedProbes {
 	}
 
 	private async resolveIfError (pr: Promise<void>): Promise<void> {
-		const result = await Bluebird.resolve(pr).reflect();
-
-		if (result.isRejected()) {
-			logger.error(result.reason());
-		}
+		return pr.catch((e) => {
+			logger.error(e);
+		});
 	}
 
 	private async fetchAdoptedProbes () {
@@ -408,8 +406,8 @@ export class AdoptedProbes {
 			.where({ ip: currentAdoptedIp })
 			.orWhere({ ip: connectedProbe.ipAddress })
 			.orWhere({ uuid: connectedProbe.uuid })
-			// First item will be preserved, so we are prioritizing probes with a custom city and online probes.
-			.orderByRaw(`isCustomCity DESC, lastSyncDate DESC, onlineTimesToday DESC, FIELD(status, 'ready') DESC`)
+			// First item will be preserved, so we are prioritizing online probes.
+			.orderByRaw(`lastSyncDate DESC, onlineTimesToday DESC, FIELD(status, 'ready') DESC`)
 			.select<Row[]>([ 'id', 'ip', 'uuid' ]);
 		logger.warn('Duplicated probes:', duplicates);
 

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -216,9 +216,7 @@ export class AdoptedProbes {
 	}
 
 	private async fetchAdoptedProbes () {
-		const rows = await this.sql(ADOPTED_PROBES_TABLE)
-			.orderByRaw(`lastSyncDate DESC, onlineTimesToday DESC, FIELD(status, 'ready') DESC`)
-			.select<Row[]>();
+		const rows = await this.sql(ADOPTED_PROBES_TABLE).select<Row[]>();
 
 		const adoptedProbes: AdoptedProbe[] = rows.map(row => ({
 			...row,
@@ -402,7 +400,8 @@ export class AdoptedProbes {
 			.where({ ip: currentAdoptedIp })
 			.orWhere({ ip: connectedProbe.ipAddress })
 			.orWhere({ uuid: connectedProbe.uuid })
-			.orderByRaw(`lastSyncDate DESC, onlineTimesToday DESC, FIELD(status, 'ready') DESC`)
+			// First item will be preserved, so we are prioritizing probes with a custom city and online probes.
+			.orderByRaw(`isCustomCity DESC, lastSyncDate DESC, onlineTimesToday DESC, FIELD(status, 'ready') DESC`)
 			.select<Row[]>([ 'id', 'ip', 'uuid' ]);
 		logger.warn('Duplicated probes:', duplicates);
 

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -408,13 +408,13 @@ export class AdoptedProbes {
 			.orWhere({ uuid: connectedProbe.uuid })
 			// First item will be preserved, so we are prioritizing online probes.
 			.orderByRaw(`lastSyncDate DESC, onlineTimesToday DESC, FIELD(status, 'ready') DESC`)
-			.select<Row[]>([ 'id', 'ip', 'uuid' ]);
+			.select<Row[]>([ 'id', 'ip', 'uuid', 'altIps' ]);
 		logger.warn('Duplicated probes:', duplicates);
 
 		if (duplicates.length > 1) {
-			const excessProbesIds = duplicates.slice(1).map(row => row.id);
-			logger.warn('Deleting probes with ids:', excessProbesIds);
-			await this.sql(ADOPTED_PROBES_TABLE).whereIn('id', excessProbesIds).delete();
+			const excessProbes = duplicates.slice(1);
+			logger.warn('Deleting probes:', excessProbes);
+			await this.sql(ADOPTED_PROBES_TABLE).whereIn('id', excessProbes.map(row => row.id)).delete();
 		}
 	}
 

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import type { Knex } from 'knex';
 import * as sinon from 'sinon';
 import relativeDayUtc from 'relative-day-utc';
 import { AdoptedProbes } from '../../../../src/lib/override/adopted-probes.js';
 import type { Probe } from '../../../../src/probe/types.js';
+import { Knex } from 'knex';
 
 describe('AdoptedProbes', () => {
 	const defaultAdoptedProbe = {
@@ -79,24 +79,22 @@ describe('AdoptedProbes', () => {
 	};
 
 	const sandbox = sinon.createSandbox();
-	const selectStub = sandbox.stub();
-	const updateStub = sandbox.stub();
-	const deleteStub = sandbox.stub();
-	const rawStub = sandbox.stub();
-	const whereStub = sandbox.stub().returns({
-		update: updateStub,
-		delete: deleteStub,
-	});
-	const sqlStub = sandbox.stub().returns({
-		select: selectStub,
-		where: whereStub,
-	}) as sinon.SinonStub<any[], any> & {raw: any};
-	sqlStub.raw = rawStub;
+
+	const sql = {} as any;
+	sql.select = sandbox.stub().returns(sql);
+	sql.update = sandbox.stub().returns(sql);
+	sql.delete = sandbox.stub().returns(sql);
+	sql.raw = sandbox.stub().returns(sql);
+	sql.where = sandbox.stub().returns(sql);
+	sql.orderByRaw = sandbox.stub().returns(sql);
+	const sqlStub = sandbox.stub().returns(sql) as any;
+	sqlStub.raw = sql.raw;
+
 	const fetchProbesWithAdminData = sandbox.stub().resolves([]);
 
 	beforeEach(() => {
 		sandbox.resetHistory();
-		selectStub.resolves([ defaultAdoptedProbe ]);
+		sql.select.resolves([ defaultAdoptedProbe ]);
 		fetchProbesWithAdminData.resolves([ defaultConnectedProbe ]);
 	});
 
@@ -104,101 +102,101 @@ describe('AdoptedProbes', () => {
 		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
 
 		expect(sqlStub.callCount).to.equal(0);
-		expect(selectStub.callCount).to.equal(0);
+		expect(sql.select.callCount).to.equal(0);
 
 		await adoptedProbes.syncDashboardData();
 
 		expect(sqlStub.callCount).to.equal(1);
 		expect(sqlStub.args[0]).deep.equal([ 'gp_adopted_probes' ]);
-		expect(selectStub.callCount).to.equal(1);
+		expect(sql.select.callCount).to.equal(1);
 	});
 
 	it('class should update uuid if it is wrong', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 		fetchProbesWithAdminData.resolves([{ ...defaultConnectedProbe, uuid: '2-2-2-2-2' }]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.args[0]).to.deep.equal([{ ip: '1.1.1.1', altIps: '[]', uuid: '2-2-2-2-2' }]);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.update.callCount).to.equal(1);
+		expect(sql.update.args[0]).to.deep.equal([{ ip: '1.1.1.1', altIps: '[]', uuid: '2-2-2-2-2' }]);
 	});
 
 	it('class should update ip if it is wrong', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 		fetchProbesWithAdminData.resolves([{ ...defaultConnectedProbe, ipAddress: '2.2.2.2' }]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.args[0]).to.deep.equal([{ ip: '2.2.2.2', altIps: '[]' }]);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.update.callCount).to.equal(1);
+		expect(sql.update.args[0]).to.deep.equal([{ ip: '2.2.2.2', altIps: '[]', uuid: '1-1-1-1-1' }]);
 	});
 
 	it('class should update alt ips if it is wrong', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 		fetchProbesWithAdminData.resolves([{ ...defaultConnectedProbe, altIpAddresses: [ '2.2.2.2' ] }]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.args[0]).to.deep.equal([{ ip: '1.1.1.1', altIps: JSON.stringify([ '2.2.2.2' ]) }]);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.update.callCount).to.equal(1);
+		expect(sql.update.args[0]).to.deep.equal([{ ip: '1.1.1.1', altIps: JSON.stringify([ '2.2.2.2' ]), uuid: '1-1-1-1-1' }]);
 	});
 
 	it('class should update status to "offline" if adopted probe was not found', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{ ...defaultAdoptedProbe, lastSyncDate: relativeDayUtc(-15) }]);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoptedProbe, lastSyncDate: relativeDayUtc(-15) }]);
 		fetchProbesWithAdminData.resolves([]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.args[0]).to.deep.equal([{ status: 'offline' }]);
-		expect(deleteStub.callCount).to.equal(0);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.update.callCount).to.equal(1);
+		expect(sql.update.args[0]).to.deep.equal([{ status: 'offline' }]);
+		expect(sql.delete.callCount).to.equal(0);
 	});
 
 	it('class should do nothing if adopted probe was not found but it is already "offline"', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{ ...defaultAdoptedProbe, lastSyncDate: relativeDayUtc(-15), status: 'offline' }]);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoptedProbe, lastSyncDate: relativeDayUtc(-15), status: 'offline' }]);
 		fetchProbesWithAdminData.resolves([]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(0);
-		expect(updateStub.callCount).to.equal(0);
-		expect(deleteStub.callCount).to.equal(0);
+		expect(sql.where.callCount).to.equal(0);
+		expect(sql.update.callCount).to.equal(0);
+		expect(sql.delete.callCount).to.equal(0);
 	});
 
 	it('class should update lastSyncDate if probe is connected', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{ ...defaultAdoptedProbe, lastSyncDate: relativeDayUtc(-15) }]);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoptedProbe, lastSyncDate: relativeDayUtc(-15) }]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(updateStub.callCount).to.equal(1);
-		expect(updateStub.firstCall.args[0].lastSyncDate).to.be.greaterThanOrEqual(relativeDayUtc());
-		expect(deleteStub.callCount).to.equal(0);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.update.callCount).to.equal(1);
+		expect(sql.update.firstCall.args[0].lastSyncDate).to.be.greaterThanOrEqual(relativeDayUtc());
+		expect(sql.delete.callCount).to.equal(0);
 	});
 
 	it('class should not update anything if lastSyncDate is today', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(0);
-		expect(updateStub.callCount).to.equal(0);
-		expect(deleteStub.callCount).to.equal(0);
+		expect(sql.where.callCount).to.equal(0);
+		expect(sql.update.callCount).to.equal(0);
+		expect(sql.delete.callCount).to.equal(0);
 	});
 
 	it('class should update probe meta info if it is outdated and "isCustomCity: false"', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 
 		fetchProbesWithAdminData.resolves([
 			{
@@ -231,11 +229,11 @@ describe('AdoptedProbes', () => {
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(updateStub.callCount).to.equal(1);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.update.callCount).to.equal(1);
 
-		expect(updateStub.args[0]).to.deep.equal([{
+		expect(sql.update.args[0]).to.deep.equal([{
 			status: 'initializing',
 			isIPv4Supported: false,
 			isIPv6Supported: false,
@@ -253,7 +251,7 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('class should update country and send notification if country of the probe changes', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 		const defaultAdoptedProbes = [
 			defaultAdoptedProbe,
 			{
@@ -264,7 +262,7 @@ describe('AdoptedProbes', () => {
 				name: 'probe-gb-london-01',
 			}];
 
-		selectStub.resolves(defaultAdoptedProbes.map(probe => ({ ...probe, countryOfCustomCity: 'IE', isCustomCity: 1 })));
+		sql.select.resolves(defaultAdoptedProbes.map(probe => ({ ...probe, countryOfCustomCity: 'IE', isCustomCity: 1 })));
 
 		fetchProbesWithAdminData.resolves([
 			{
@@ -323,26 +321,26 @@ describe('AdoptedProbes', () => {
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(rawStub.callCount).to.equal(2);
+		expect(sql.raw.callCount).to.equal(2);
 
-		expect(rawStub.args[0]![1]).to.deep.equal({
+		expect(sql.raw.args[0]![1]).to.deep.equal({
 			recipient: '3cff97ae-4a0a-4f34-9f1a-155e6def0a45',
 			subject: `Your probe's location has changed`,
 			message: 'Globalping detected that your [probe with IP address **1.1.1.1**](/probes/p-1) has changed its location from Ireland to United Kingdom. The custom city value "Dublin" is not applied anymore.\n\nIf this change is not right, please report it in [this issue](https://github.com/jsdelivr/globalping/issues/268).',
 		});
 
-		expect(rawStub.args[1]![1]).to.deep.equal({
+		expect(sql.raw.args[1]![1]).to.deep.equal({
 			recipient: '3cff97ae-4a0a-4f34-9f1a-155e6def0a45',
 			subject: `Your probe's location has changed`,
 			message: 'Globalping detected that your probe [**probe-gb-london-01**](/probes/p-9) with IP address **9.9.9.9** has changed its location from Ireland to United Kingdom. The custom city value "Dublin" is not applied anymore.\n\nIf this change is not right, please report it in [this issue](https://github.com/jsdelivr/globalping/issues/268).',
 		});
 
-		expect(whereStub.callCount).to.equal(2);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(whereStub.args[1]).to.deep.equal([{ ip: '9.9.9.9' }]);
-		expect(updateStub.callCount).to.equal(2);
+		expect(sql.where.callCount).to.equal(2);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.where.args[1]).to.deep.equal([{ ip: '9.9.9.9' }]);
+		expect(sql.update.callCount).to.equal(2);
 
-		expect(updateStub.args[0]).to.deep.equal([
+		expect(sql.update.args[0]).to.deep.equal([
 			{
 				status: 'initializing',
 				isIPv4Supported: false,
@@ -354,7 +352,7 @@ describe('AdoptedProbes', () => {
 			},
 		]);
 
-		expect(updateStub.args[1]).to.deep.equal([
+		expect(sql.update.args[1]).to.deep.equal([
 			{
 				status: 'initializing',
 				isIPv4Supported: false,
@@ -366,7 +364,7 @@ describe('AdoptedProbes', () => {
 			},
 		]);
 
-		selectStub.resolves(defaultAdoptedProbes.map(probe => ({ ...probe, country: 'GB', countryOfCustomCity: 'IE', isCustomCity: 1 })));
+		sql.select.resolves(defaultAdoptedProbes.map(probe => ({ ...probe, country: 'GB', countryOfCustomCity: 'IE', isCustomCity: 1 })));
 
 		fetchProbesWithAdminData.resolves([
 			{
@@ -425,26 +423,26 @@ describe('AdoptedProbes', () => {
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(rawStub.callCount).to.equal(4);
+		expect(sql.raw.callCount).to.equal(4);
 
-		expect(rawStub.args[2]![1]).to.deep.equal({
+		expect(sql.raw.args[2]![1]).to.deep.equal({
 			recipient: '3cff97ae-4a0a-4f34-9f1a-155e6def0a45',
 			subject: `Your probe's location has changed back`,
 			message: 'Globalping detected that your [probe with IP address **1.1.1.1**](/probes/p-1) has changed its location back from United Kingdom to Ireland. The custom city value "Dublin" is now applied again.',
 		});
 
-		expect(rawStub.args[3]![1]).to.deep.equal({
+		expect(sql.raw.args[3]![1]).to.deep.equal({
 			recipient: '3cff97ae-4a0a-4f34-9f1a-155e6def0a45',
 			subject: `Your probe's location has changed back`,
 			message: 'Globalping detected that your probe [**probe-gb-london-01**](/probes/p-9) with IP address **9.9.9.9** has changed its location back from United Kingdom to Ireland. The custom city value "Dublin" is now applied again.',
 		});
 
-		expect(whereStub.callCount).to.equal(4);
-		expect(whereStub.args[2]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(whereStub.args[3]).to.deep.equal([{ ip: '9.9.9.9' }]);
-		expect(updateStub.callCount).to.equal(4);
+		expect(sql.where.callCount).to.equal(4);
+		expect(sql.where.args[2]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.where.args[3]).to.deep.equal([{ ip: '9.9.9.9' }]);
+		expect(sql.update.callCount).to.equal(4);
 
-		expect(updateStub.args[2]).to.deep.equal([
+		expect(sql.update.args[2]).to.deep.equal([
 			{
 				status: 'initializing',
 				isIPv4Supported: false,
@@ -456,7 +454,7 @@ describe('AdoptedProbes', () => {
 			},
 		]);
 
-		expect(updateStub.args[3]).to.deep.equal([
+		expect(sql.update.args[3]).to.deep.equal([
 			{
 				status: 'initializing',
 				isIPv4Supported: false,
@@ -470,8 +468,8 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('class should partially update probe meta info if it is outdated and "isCustomCity: true"', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{ ...defaultAdoptedProbe, countryOfCustomCity: 'IE', isCustomCity: 1 }]);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoptedProbe, countryOfCustomCity: 'IE', isCustomCity: 1 }]);
 
 		fetchProbesWithAdminData.resolves([
 			{
@@ -504,11 +502,11 @@ describe('AdoptedProbes', () => {
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(1);
-		expect(whereStub.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
-		expect(updateStub.callCount).to.equal(1);
+		expect(sql.where.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ ip: '1.1.1.1' }]);
+		expect(sql.update.callCount).to.equal(1);
 
-		expect(updateStub.args[0]).to.deep.equal([{
+		expect(sql.update.args[0]).to.deep.equal([{
 			status: 'initializing',
 			isIPv4Supported: false,
 			isIPv6Supported: false,
@@ -520,28 +518,28 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('class should not update probe meta info if it is actual', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(0);
-		expect(updateStub.callCount).to.equal(0);
-		expect(deleteStub.callCount).to.equal(0);
+		expect(sql.where.callCount).to.equal(0);
+		expect(sql.update.callCount).to.equal(0);
+		expect(sql.delete.callCount).to.equal(0);
 	});
 
 	it('class should treat null and undefined values as equal', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{ ...defaultAdoptedProbe, state: null }]);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoptedProbe, state: null }]);
 
 		await adoptedProbes.syncDashboardData();
 
-		expect(whereStub.callCount).to.equal(0);
-		expect(updateStub.callCount).to.equal(0);
-		expect(deleteStub.callCount).to.equal(0);
+		expect(sql.where.callCount).to.equal(0);
+		expect(sql.update.callCount).to.equal(0);
+		expect(sql.delete.callCount).to.equal(0);
 	});
 
 	it('getByIp method should return adopted probe data', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 
 		await adoptedProbes.syncDashboardData();
 
@@ -558,8 +556,8 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('getUpdatedLocation method should return updated location', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{
 			...defaultAdoptedProbe,
 			city: 'Dundalk',
 			countryOfCustomCity: 'IE',
@@ -586,8 +584,8 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('getUpdatedLocation method should return null if connected.country !== adopted.countryOfCustomCity', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{
 			...defaultAdoptedProbe,
 			country: 'IE',
 			countryOfCustomCity: 'GB',
@@ -603,8 +601,8 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('getUpdatedLocation method should return null if "isCustomCity: false"', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{
 			...defaultAdoptedProbe,
 			city: 'Dundalk',
 			isCustomCity: 0,
@@ -618,7 +616,7 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('getUpdatedTags method should return updated tags', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
 
 		await adoptedProbes.syncDashboardData();
 		const updatedTags = adoptedProbes.getUpdatedTags(defaultConnectedProbe);
@@ -629,8 +627,8 @@ describe('AdoptedProbes', () => {
 	});
 
 	it('getUpdatedTags method should return same tags array if user tags are empty', async () => {
-		const adoptedProbes = new AdoptedProbes(sqlStub as unknown as Knex, fetchProbesWithAdminData);
-		selectStub.resolves([{ ...defaultAdoptedProbe, tags: '[]' }]);
+		const adoptedProbes = new AdoptedProbes(sqlStub, fetchProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoptedProbe, tags: '[]' }]);
 
 		await adoptedProbes.syncDashboardData();
 		const updatedTags = adoptedProbes.getUpdatedTags(defaultConnectedProbe);


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/572

What it does:
- in case of duplication error, extra adoptions are deleted, then update repeats;
- individual sync errors are logged and resolved, not to break syncing of others;
- uuid equality check is removed as not required.