### PR TITLE
feat: filter incoming alt IPs

### DIFF
--- a/probes-stats/known.ts
+++ b/probes-stats/known.ts
@@ -7,13 +7,13 @@
 
 import fs from 'node:fs';
 import { getRedisClient, initRedisClient } from '../src/lib/redis/client.js';
-import { LocationInfo, createGeoipClient } from '../src/lib/geoip/client.js';
+import { LocationInfo, getGeoIpClient } from '../src/lib/geoip/client.js';
 import { normalizeCityName } from '../src/lib/geoip/utils.js';
 import { fastlyLookup } from '../src/lib/geoip/providers/fastly.js';
 import { ipinfoLookup } from '../src/lib/geoip/providers/ipinfo.js';
 import { maxmindLookup } from '../src/lib/geoip/providers/maxmind.js';
 import { populateMemList as populateIpWhiteList } from '../src/lib/geoip/whitelist.js';
-import { Ip2LocationBundledResponse, ip2LocationLookup } from '../src/lib/geoip/providers/ip2location.js';
+import { ip2LocationLookup } from '../src/lib/geoip/providers/ip2location.js';
 import { ipmapLookup } from '../src/lib/geoip/providers/ipmap.js';
 import sheet from './known-probes.json' assert { type: 'json' };
 import { populateCitiesList } from '../src/lib/geoip/city-approximation.js';
@@ -21,14 +21,14 @@ import { populateCitiesList } from '../src/lib/geoip/city-approximation.js';
 await populateIpWhiteList();
 await initRedisClient();
 await populateCitiesList();
-const geoIpClient = createGeoipClient();
+const geoIpClient = getGeoIpClient();
 
 const input: [string, (string) => Promise<LocationInfo>][] = [
-	[ 'ip2location', async ip => (await geoIpClient.lookupWithCache<Ip2LocationBundledResponse>(`geoip:ip2location:${ip}`, async () => ip2LocationLookup(ip))).location ],
-	[ 'ipmap', ip => geoIpClient.lookupWithCache<LocationInfo>(`geoip:ipmap:${ip}`, async () => ipmapLookup(ip)) ],
-	[ 'ipinfo', ip => geoIpClient.lookupWithCache<LocationInfo>(`geoip:ipinfo:${ip}`, async () => ipinfoLookup(ip)) ],
-	[ 'maxmind', ip => geoIpClient.lookupWithCache<LocationInfo>(`geoip:maxmind:${ip}`, async () => maxmindLookup(ip)) ],
-	[ 'fastly', ip => geoIpClient.lookupWithCache<LocationInfo>(`geoip:fastly:${ip}`, async () => fastlyLookup(ip)) ],
+	[ 'ip2location', ip => geoIpClient.lookupWithCache(`geoip:ip2location:${ip}`, async () => ip2LocationLookup(ip)) ],
+	[ 'ipmap', ip => geoIpClient.lookupWithCache(`geoip:ipmap:${ip}`, async () => ipmapLookup(ip)) ],
+	[ 'ipinfo', ip => geoIpClient.lookupWithCache(`geoip:ipinfo:${ip}`, async () => ipinfoLookup(ip)) ],
+	[ 'maxmind', ip => geoIpClient.lookupWithCache(`geoip:maxmind:${ip}`, async () => maxmindLookup(ip)) ],
+	[ 'fastly', ip => geoIpClient.lookupWithCache(`geoip:fastly:${ip}`, async () => fastlyLookup(ip)) ],
 	[ 'algorithm', ip => geoIpClient.lookup(ip) ],
 ];
 

--- a/src/lib/alt-ips.ts
+++ b/src/lib/alt-ips.ts
@@ -102,7 +102,7 @@ export class AltIps {
 			setTimeout(() => {
 				this.pendingRequests.delete(messageId);
 				reject(createHttpError(504, 'Node owning the probe failed to handle alt ip in specified timeout.', { type: 'node_response_timeout' }));
-			}, 15000);
+			}, 20000);
 		}).catch((err) => {
 			logger.error(`Node failed to handle alt ip message ${messageId} in specified timeout.`);
 			throw err;

--- a/src/lib/geoip/client.ts
+++ b/src/lib/geoip/client.ts
@@ -26,11 +26,17 @@ export type NetworkInfo = {
 
 const logger = scopedLogger('geoip');
 
-export const createGeoipClient = (): GeoipClient => {
-	return new GeoipClient(config.get('geoip.cache.enabled') ? new RedisCache(getRedisClient()) : new NullCache());
+let geoIpClient: GeoIpClient;
+
+export const getGeoIpClient = (): GeoIpClient => {
+	if (!geoIpClient) {
+		geoIpClient = new GeoIpClient(config.get('geoip.cache.enabled') ? new RedisCache(getRedisClient()) : new NullCache());
+	}
+
+	return geoIpClient;
 };
 
-export default class GeoipClient {
+export default class GeoIpClient {
 	constructor (private readonly cache: CacheInterface) {}
 
 	async lookup (addr: string): Promise<LocationInfo> {

--- a/src/lib/geoip/fake-client.ts
+++ b/src/lib/geoip/fake-client.ts
@@ -13,6 +13,8 @@ export const fakeLookup = (): LocationInfo => {
 		longitude: -58.3772,
 		network: 'InterBS S.R.L. (BAEHOST)',
 		normalizedNetwork: 'interbs s.r.l. (baehost)',
+		isProxy: false,
 		isHosting: null,
+		isAnycast: false,
 	};
 };

--- a/src/lib/geoip/providers/fastly.ts
+++ b/src/lib/geoip/providers/fastly.ts
@@ -49,6 +49,8 @@ export const fastlyLookup = async (addr: string): Promise<LocationInfo> => {
 		longitude: data.longitude,
 		network: result.as.name,
 		normalizedNetwork: normalizeNetworkName(result.as.name),
+		isProxy: null,
 		isHosting: null,
+		isAnycast: null,
 	};
 };

--- a/src/lib/geoip/providers/ipinfo.ts
+++ b/src/lib/geoip/providers/ipinfo.ts
@@ -17,7 +17,8 @@ type IpinfoResponse = {
 	loc: string | undefined;
 	privacy?: {
 		hosting: boolean;
-	}
+	},
+	anycast?: boolean;
 };
 
 export const ipinfoLookup = async (addr: string): Promise<LocationInfo> => {
@@ -44,6 +45,8 @@ export const ipinfoLookup = async (addr: string): Promise<LocationInfo> => {
 		longitude: Number(lon),
 		network,
 		normalizedNetwork: normalizeNetworkName(network),
+		isProxy: null,
 		isHosting: result.privacy?.hosting ?? null,
+		isAnycast: result.anycast ?? null,
 	};
 };

--- a/src/lib/geoip/providers/ipmap.ts
+++ b/src/lib/geoip/providers/ipmap.ts
@@ -34,6 +34,8 @@ export const ipmapLookup = async (addr: string): Promise<LocationInfo> => {
 		longitude: Number(location.longitude) ?? 0,
 		network: '',
 		normalizedNetwork: '',
+		isProxy: null,
 		isHosting: null,
+		isAnycast: null,
 	};
 };

--- a/src/lib/geoip/providers/maxmind.ts
+++ b/src/lib/geoip/providers/maxmind.ts
@@ -50,6 +50,8 @@ export const maxmindLookup = async (addr: string): Promise<LocationInfo> => {
 		longitude: data.location?.longitude ?? 0,
 		network: data.traits?.isp ?? '',
 		normalizedNetwork: normalizeNetworkName(data.traits?.isp ?? ''),
+		isProxy: null,
 		isHosting: null,
+		isAnycast: data.traits?.isAnycast ?? null,
 	};
 };

--- a/src/lib/get-probe-ip.ts
+++ b/src/lib/get-probe-ip.ts
@@ -13,16 +13,16 @@ const getProbeIp = (socket: Socket) => {
 	// Use random ip assigned by the API
 	if (process.env['FAKE_PROBE_IP']) {
 		const samples = [
-			'213.136.174.80',
-			'18.200.0.1',
-			'34.140.0.10',
-			'95.155.94.127',
+			'213.136.174.80', // Naples
+			'18.200.0.1', // Dublin, AWS
+			'34.140.0.10', // Brussels, GCP
+			'95.155.94.127', // Krakow
 			'65.49.22.66',
 			'185.229.226.83',
 			'131.255.7.26',
 			'94.214.253.78',
 			'79.205.97.254',
-			'2a04:4e42:200::485',
+			'2a04:4e42:200::485', // San Francisco
 		];
 		// Choosing ip based on the probe uuid to always return the same ip for the same probe.
 		const lastGroup = (socket.handshake.query['uuid'] as string).split('-').pop() || '0';

--- a/test/mocks/nock-geoip.json
+++ b/test/mocks/nock-geoip.json
@@ -398,6 +398,17 @@
 			"region": "Texas",
 			"country": "US",
 			"loc": "32.7831,-96.8067"
+		},
+		"anycast": {
+			"city": "Dallas",
+			"region": "Texas",
+			"country": "US",
+			"loc": "32.7831,-96.8067",
+			"org": "AS20004 The Constant Company LLC",
+			"privacy": {
+				"hosting": true
+			},
+			"anycast": true
 		}
 	},
 	"fastly": {

--- a/test/tests/integration/alternative-ip.test.ts
+++ b/test/tests/integration/alternative-ip.test.ts
@@ -42,6 +42,8 @@ describe('Adoption code', () => {
 
 		probe.emit('probe:status:update', 'ready');
 
+		nockGeoIpProviders();
+
 		await requestAgent.post('/v1/alternative-ip')
 			.send({ socketId, token })
 			.expect(200);
@@ -70,6 +72,8 @@ describe('Adoption code', () => {
 		});
 
 		probe.emit('probe:status:update', 'ready');
+
+		nockGeoIpProviders();
 
 		await requestAgent.post('/v1/alternative-ip')
 			.send({ socketId, token })

--- a/test/tests/integration/alternative-ip.test.ts
+++ b/test/tests/integration/alternative-ip.test.ts
@@ -6,7 +6,7 @@ import { getTestServer, addFakeProbe, deleteFakeProbes, waitForProbesUpdate } fr
 import nockGeoIpProviders from '../../utils/nock-geo-ip.js';
 import { expect } from 'chai';
 
-describe('Adoption code', () => {
+describe('Alternative IPs', () => {
 	let app: Server;
 	let requestAgent: Agent;
 
@@ -46,6 +46,7 @@ describe('Adoption code', () => {
 
 		await requestAgent.post('/v1/alternative-ip')
 			.send({ socketId, token })
+			.set('x-client-ip', '89.64.80.78')
 			.expect(200);
 
 		await waitForProbesUpdate();
@@ -77,10 +78,12 @@ describe('Adoption code', () => {
 
 		await requestAgent.post('/v1/alternative-ip')
 			.send({ socketId, token })
+			.set('x-client-ip', '89.64.80.78')
 			.expect(200);
 
 		await requestAgent.post('/v1/alternative-ip')
 			.send({ socketId, token })
+			.set('x-client-ip', '89.64.80.78')
 			.expect(200);
 
 		await waitForProbesUpdate();
@@ -127,6 +130,7 @@ describe('Adoption code', () => {
 
 		await requestAgent.post('/v1/alternative-ip')
 			.send({ socketId, token })
+			.set('x-client-ip', '89.64.80.78')
 			.expect(400)
 			.expect((response) => {
 				expect(response.body.error.type).to.equal('probe_not_found');

--- a/test/tests/unit/alt-ips.test.ts
+++ b/test/tests/unit/alt-ips.test.ts
@@ -9,6 +9,7 @@ describe('AltIps', () => {
 
 	let socket: ServerSocket;
 	let syncedProbeList: any;
+	let geoIpClient: any;
 	let altIps: AltIps;
 
 	beforeEach(() => {
@@ -25,7 +26,9 @@ describe('AltIps', () => {
 			}),
 		};
 
-		altIps = new AltIps(syncedProbeList);
+		geoIpClient = { lookup: sandbox.stub().resolves() };
+
+		altIps = new AltIps(syncedProbeList, geoIpClient);
 	});
 
 	afterEach(async () => {

--- a/test/tests/unit/alt-ips.test.ts
+++ b/test/tests/unit/alt-ips.test.ts
@@ -13,7 +13,14 @@ describe('AltIps', () => {
 	let altIps: AltIps;
 
 	beforeEach(() => {
-		socket = { id: 'socketId1', data: { probe: { client: 'socketId1', ipAddress: '1.1.1.1', altIpAddresses: [] } } } as unknown as ServerSocket;
+		socket = { id: 'socketId1', data: { probe: {
+			client: 'socketId1',
+			ipAddress: '1.1.1.1',
+			altIpAddresses: [],
+			location: {
+				country: 'IT',
+			},
+		} } } as unknown as ServerSocket;
 
 		syncedProbeList = {
 			subscribeToNodeMessages: sandbox.stub(),
@@ -26,13 +33,15 @@ describe('AltIps', () => {
 			}),
 		};
 
-		geoIpClient = { lookup: sandbox.stub().resolves() };
+		geoIpClient = {
+			lookup: sandbox.stub().resolves({ country: 'IT', isAnycast: false }),
+		};
 
 		altIps = new AltIps(syncedProbeList, geoIpClient);
 	});
 
 	afterEach(async () => {
-		sandbox.resetHistory();
+		sandbox.reset();
 	});
 
 	it('should add alt ip for local probe', async () => {
@@ -69,7 +78,7 @@ describe('AltIps', () => {
 			socketId: 'socketId1',
 			ip: '2.2.2.2',
 			token,
-		}).catch(err => err);
+		});
 
 		expect(socket.data.probe.altIpAddresses).to.deep.equal([]);
 	});
@@ -177,6 +186,8 @@ describe('AltIps', () => {
 
 	it('should add alt ip from pub/sub', async () => {
 		const token = await altIps.generateToken(socket);
+		geoIpClient.lookup.resolves({ country: 'IT', isAnycast: false });
+
 		await altIps.validateTokenFromPubSub({
 			id: 'message1',
 			reqNodeId: 'node1',
@@ -213,6 +224,54 @@ describe('AltIps', () => {
 			'node1',
 			'alt-ip:res',
 			{ result: 'probe-not-found', reqMessageId: 'message1' },
+		]);
+	});
+
+	it('should throw if alt ip is anycast', async () => {
+		const token = await altIps.generateToken(socket);
+		geoIpClient.lookup.resolves({ country: 'IT', isAnycast: true });
+
+		await altIps.validateTokenFromPubSub({
+			id: 'message1',
+			reqNodeId: 'node1',
+			type: ALT_IP_REQ_MESSAGE_TYPE,
+			body: {
+				socketId: 'socketId2',
+				ip: '2.2.2.2',
+				token,
+			},
+		});
+
+		expect(socket.data.probe.altIpAddresses).to.deep.equal([]);
+
+		expect(syncedProbeList.publishToNode.args[0]).to.deep.equal([
+			'node1',
+			'alt-ip:res',
+			{ result: 'invalid-alt-ip', reqMessageId: 'message1' },
+		]);
+	});
+
+	it('should throw if alt ip is not in the same country', async () => {
+		const token = await altIps.generateToken(socket);
+		geoIpClient.lookup.resolves({ country: 'FR', isAnycast: false });
+
+		await altIps.validateTokenFromPubSub({
+			id: 'message1',
+			reqNodeId: 'node1',
+			type: ALT_IP_REQ_MESSAGE_TYPE,
+			body: {
+				socketId: 'socketId2',
+				ip: '2.2.2.2',
+				token,
+			},
+		});
+
+		expect(socket.data.probe.altIpAddresses).to.deep.equal([]);
+
+		expect(syncedProbeList.publishToNode.args[0]).to.deep.equal([
+			'node1',
+			'alt-ip:res',
+			{ result: 'invalid-alt-ip', reqMessageId: 'message1' },
 		]);
 	});
 });

--- a/test/tests/unit/geoip/client.test.ts
+++ b/test/tests/unit/geoip/client.test.ts
@@ -33,7 +33,9 @@ describe('geoip service', () => {
 			longitude: -58.38,
 			network: 'InterBS S.R.L. (BAEHOST)',
 			normalizedNetwork: 'interbs s.r.l. (baehost)',
+			isProxy: false,
 			isHosting: true,
+			isAnycast: null,
 		});
 	});
 
@@ -58,7 +60,9 @@ describe('geoip service', () => {
 			longitude: -58.38,
 			network: 'InterBS S.R.L. (BAEHOST)',
 			normalizedNetwork: 'interbs s.r.l. (baehost)',
+			isProxy: null,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -79,7 +83,9 @@ describe('geoip service', () => {
 			longitude: -96.81,
 			network: 'The Constant Company LLC',
 			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -100,7 +106,9 @@ describe('geoip service', () => {
 			longitude: -96.81,
 			network: 'The Constant Company LLC',
 			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -121,7 +129,9 @@ describe('geoip service', () => {
 			longitude: -58.38,
 			network: 'InterBS S.R.L. (BAEHOST)',
 			normalizedNetwork: 'interbs s.r.l. (baehost)',
+			isProxy: false,
 			isHosting: true,
+			isAnycast: null,
 		});
 	});
 
@@ -142,7 +152,9 @@ describe('geoip service', () => {
 			longitude: -58.38,
 			network: 'InterBS S.R.L. (BAEHOST)',
 			normalizedNetwork: 'interbs s.r.l. (baehost)',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -176,7 +188,9 @@ describe('geoip service', () => {
 			longitude: 26.49,
 			network: 'The Constant Company LLC',
 			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -197,7 +211,9 @@ describe('geoip service', () => {
 			longitude: 12.37,
 			network: 'Hetzner Online GmbH',
 			normalizedNetwork: 'hetzner online gmbh',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -218,7 +234,9 @@ describe('geoip service', () => {
 			longitude: 12.37,
 			network: 'Hetzner Online GmbH',
 			normalizedNetwork: 'hetzner online gmbh',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -239,7 +257,9 @@ describe('geoip service', () => {
 			longitude: -96.81,
 			network: 'The Constant Company LLC',
 			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
 			isHosting: true,
+			isAnycast: null,
 		});
 	});
 
@@ -260,7 +280,9 @@ describe('geoip service', () => {
 			longitude: -58.38,
 			network: 'InterBS S.R.L. (BAEHOST)',
 			normalizedNetwork: 'interbs s.r.l. (baehost)',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
 		});
 	});
 
@@ -281,7 +303,9 @@ describe('geoip service', () => {
 			longitude: -74.01,
 			network: 'The Constant Company LLC',
 			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
 			isHosting: true,
+			isAnycast: null,
 		});
 	});
 
@@ -302,7 +326,32 @@ describe('geoip service', () => {
 			longitude: -96.81,
 			network: 'The Constant Company LLC',
 			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
 			isHosting: null,
+			isAnycast: null,
+		});
+	});
+
+	it.only(`should set 'isAnycast: true' if ipinfo returned that it is anycast ip`, async () => {
+		nockGeoIpProviders({ ipinfo: 'anycast' });
+
+		const info = await client.lookup(MOCK_IP);
+
+		expect(info).to.deep.equal({
+			continent: 'NA',
+			country: 'US',
+			state: 'TX',
+			city: 'Dallas',
+			region: 'Northern America',
+			normalizedCity: 'dallas',
+			asn: 20004,
+			latitude: 32.78,
+			longitude: -96.81,
+			network: 'The Constant Company LLC',
+			normalizedNetwork: 'the constant company llc',
+			isProxy: false,
+			isHosting: true,
+			isAnycast: true,
 		});
 	});
 
@@ -324,7 +373,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: null,
+				isAnycast: null,
 			});
 		});
 
@@ -345,7 +396,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: null,
+				isAnycast: null,
 			});
 		});
 
@@ -366,7 +419,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: null,
+				isAnycast: null,
 			});
 		});
 
@@ -387,7 +442,9 @@ describe('geoip service', () => {
 				longitude: -77.04,
 				network: 'Psychz Networks',
 				normalizedNetwork: 'psychz networks',
+				isProxy: false,
 				isHosting: true,
+				isAnycast: null,
 			});
 
 			nockGeoIpProviders({ ip2location: 'empty', ipmap: 'empty', maxmind: 'empty', ipinfo: 'washington', fastly: 'empty' });
@@ -406,7 +463,9 @@ describe('geoip service', () => {
 				longitude: -77.04,
 				network: 'Verizon Business',
 				normalizedNetwork: 'verizon business',
+				isProxy: false,
 				isHosting: null,
+				isAnycast: null,
 			});
 		});
 
@@ -441,7 +500,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: true,
+				isAnycast: null,
 			});
 		});
 
@@ -462,7 +523,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: true,
+				isAnycast: null,
 			});
 		});
 
@@ -491,7 +554,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: true,
+				isAnycast: null,
 			});
 		});
 
@@ -520,7 +585,9 @@ describe('geoip service', () => {
 				longitude: -96.81,
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
+				isProxy: false,
 				isHosting: true,
+				isAnycast: null,
 			});
 		});
 

--- a/test/tests/unit/geoip/client.test.ts
+++ b/test/tests/unit/geoip/client.test.ts
@@ -332,7 +332,7 @@ describe('geoip service', () => {
 		});
 	});
 
-	it.only(`should set 'isAnycast: true' if ipinfo returned that it is anycast ip`, async () => {
+	it(`should set 'isAnycast: true' if ipinfo returned that it is anycast ip`, async () => {
 		nockGeoIpProviders({ ipinfo: 'anycast' });
 
 		const info = await client.lookup(MOCK_IP);

--- a/test/tests/unit/geoip/client.test.ts
+++ b/test/tests/unit/geoip/client.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import mockFs from 'mock-fs';
 import { expect } from 'chai';
-import GeoipClient, { type LocationInfo } from '../../../../src/lib/geoip/client.js';
+import GeoIpClient, { type LocationInfo } from '../../../../src/lib/geoip/client.js';
 import NullCache from '../../../../src/lib/cache/null-cache.js';
 import nockGeoIpProviders from '../../../utils/nock-geo-ip.js';
 import geoIpMocks from '../../../mocks/nock-geoip.json' assert { type: 'json' };
@@ -10,7 +10,7 @@ import { populateMemList } from '../../../../src/lib/geoip/whitelist.js';
 const MOCK_IP = '131.255.7.26';
 
 describe('geoip service', () => {
-	const client = new GeoipClient(new NullCache());
+	const client = new GeoIpClient(new NullCache());
 
 	afterEach(() => {
 		nock.cleanAll();

--- a/test/tests/unit/probe/router.test.ts
+++ b/test/tests/unit/probe/router.test.ts
@@ -67,7 +67,7 @@ describe('probe router', () => {
 	};
 
 	before(async () => {
-		await td.replaceEsm('../../../../src/lib/geoip/client.ts', { createGeoipClient: () => ({ lookup: geoLookupMock }) });
+		await td.replaceEsm('../../../../src/lib/geoip/client.ts', { getGeoIpClient: () => ({ lookup: geoLookupMock }) });
 		await td.replaceEsm('../../../../src/lib/ip-ranges.ts', { getRegion: getRegionMock });
 		buildProbeInternal = (await import('../../../../src/probe/builder.js')).buildProbe as unknown as (socket: RemoteProbeSocket) => Promise<Probe>;
 	});


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/576

Notes:
- During deploys number of geoip requests will double (we have 1300 primary ips + ~1300 alt ips). Need to check our limits.