### PR TITLE
fix: API build with IPv6 docker daemon config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,19 +45,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - name: Build
+        run: |
+          npm ci
+          npm run build
       - uses: fscarmen/warp-on-actions@v1.3
-        with:
-          mode: client
       - name: Enable IPv6 for Docker containers
         run: |
           sudo cat /etc/docker/daemon.json | jq '. + { "ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64", "experimental": true, "ip6tables": true }' > daemon.json
           sudo mv daemon.json /etc/docker/
           sudo systemctl restart docker
           docker restart $(docker ps -aq)
-      - name: Build
-        run: |
-          npm ci
-          npm run build
       - name: Test E2E
         run: |
           npm run test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           node-version: 20.x
       - uses: fscarmen/warp-on-actions@v1.3
+        with:
+          mode: client
       - name: Enable IPv6 for Docker containers
         run: |
           sudo cat /etc/docker/daemon.json | jq '. + { "ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64", "experimental": true, "ip6tables": true }' > daemon.json


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/586

Switching to `mode: client` didn't help, but looks like we can just run build step earlier.