### PR TITLE
misc: add APM annotations and more metrics

### DIFF
--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -186,7 +186,7 @@ export class AdoptedProbes {
 			const hasUserTags = adoption.tags && adoption.tags.length;
 
 			if (!isCustomCity && !hasUserTags) {
-				return probe;
+				return { ...probe, owner: { id: adoption.userId } };
 			}
 
 			const newLocation = this.getUpdatedLocation(probe) || probe.location;
@@ -198,6 +198,7 @@ export class AdoptedProbes {
 				location: newLocation,
 				tags: newTags,
 				index: getIndex(newLocation, newTags),
+				owner: { id: adoption.userId },
 			};
 		});
 	}

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -1,6 +1,7 @@
 import config from 'config';
 import type { Server } from 'socket.io';
 import createHttpError from 'http-errors';
+import apmAgent from 'elastic-apm-node';
 import { getWsServer, PROBES_NAMESPACE } from '../lib/ws/server.js';
 import { getProbeRouter, type ProbeRouter } from '../probe/router.js';
 import type { Probe } from '../probe/types.js';
@@ -32,6 +33,7 @@ export class MeasurementRunner {
 		await this.checkRateLimit(ctx, onlineProbesMap.size);
 
 		const measurementId = await this.store.createMeasurement(request, onlineProbesMap, allProbes);
+		apmAgent.addLabels({ gpMeasurementId: measurementId, gpMeasurementType: request.type, gpMeasurementTarget: request.target });
 
 		if (onlineProbesMap.size) {
 			this.sendToProbes(measurementId, onlineProbesMap, request);

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -53,6 +53,7 @@ export type Probe = {
 	tags: Tag[];
 	stats: ProbeStats;
 	hostInfo: HostInfo;
+	owner?: { id: string };
 };
 
 type Modify<T, Fields> = Omit<T, keyof Fields> & Fields;


### PR DESCRIPTION
Part of #577. Adds:
 - user info when creating measurements,
 - measurement id, type, and target labels,
 - active probes metrics.