### PR TITLE
feat: add OPTIONS as an allowed HTTP Method

### DIFF
--- a/public/demo/globals.js
+++ b/public/demo/globals.js
@@ -19,4 +19,4 @@ const ALLOWED_MTR_PROTOCOLS = [ 'TCP', 'UDP', 'ICMP' ];
 
 // http
 const ALLOWED_HTTP_PROTOCOLS = [ 'HTTP', 'HTTPS', 'HTTP2' ];
-const ALLOWED_HTTP_METHODS = [ 'GET', 'HEAD' ];
+const ALLOWED_HTTP_METHODS = [ 'GET', 'HEAD', 'OPTIONS' ];

--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -449,6 +449,7 @@ components:
               enum:
                 - HEAD
                 - GET
+                - OPTIONS
               default: HEAD
             headers:
               type: object

--- a/src/measurement/schema/command-schema.ts
+++ b/src/measurement/schema/command-schema.ts
@@ -49,7 +49,7 @@ export const ipVersionDnsSchema = Joi.number().when(Joi.ref('resolver'), {
 export const validCmdTypes = [ 'ping', 'dns', 'traceroute', 'mtr', 'http' ];
 
 const allowedHttpProtocols = [ 'HTTP', 'HTTPS', 'HTTP2' ];
-const allowedHttpMethods = [ 'GET', 'HEAD' ];
+const allowedHttpMethods = [ 'GET', 'HEAD', 'OPTIONS' ];
 
 // Http
 const httpTargetSchema = Joi.alternatives()

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -126,7 +126,7 @@ type DnsResult = TestResult & (DnsRegularResult | DnsTraceResult);
 
 type HttpTest = {
 	request: {
-		method: 'HEAD' | 'GET';
+		method: 'HEAD' | 'GET' | 'OPTIONS';
 		host?: string;
 		path: string;
 		query: string;

--- a/test/e2e/cases/http.test.ts
+++ b/test/e2e/cases/http.test.ts
@@ -51,7 +51,7 @@ describe('http measurement', () => {
 
 		expect(response.body.status).to.equal('finished');
 		expect(response.body.results[0].result.status).to.equal('finished');
-		expect(response.body.results[0].result.rawBody.length).to.be.above(0);
+		expect(response.body.results[0].result.rawBody).to.equal(null);
 		expect(response).to.matchApiSchema();
 	});
 

--- a/test/e2e/cases/http.test.ts
+++ b/test/e2e/cases/http.test.ts
@@ -36,6 +36,25 @@ describe('http measurement', () => {
 		expect(response).to.matchApiSchema();
 	});
 
+	it('should finish successfully in case of OPTIONS request', async () => {
+		const { id } = await got.post('http://localhost:80/v1/measurements', { json: {
+			target: 'www.jsdelivr.com',
+			type: 'http',
+			measurementOptions: {
+				request: {
+					method: 'OPTIONS',
+				},
+			},
+		} }).json<any>();
+
+		const response = await waitMeasurementFinish(id);
+
+		expect(response.body.status).to.equal('finished');
+		expect(response.body.results[0].result.status).to.equal('finished');
+		expect(response.body.results[0].result.rawBody.length).to.be.above(0);
+		expect(response).to.matchApiSchema();
+	});
+
 	it('should finish successfully in case of IPv6 domain target', async () => {
 		const { id } = await got.post('http://localhost:80/v1/measurements', { json: {
 			target: 'www.jsdelivr.com',

--- a/test/tests/unit/measurement/schema/schema.test.ts
+++ b/test/tests/unit/measurement/schema/schema.test.ts
@@ -2109,7 +2109,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.exist;
-			expect(valid.error!.message).to.equal('"measurementOptions.request.method" must be one of [GET, HEAD]');
+			expect(valid.error!.message).to.equal('"measurementOptions.request.method" must be one of [GET, HEAD, OPTIONS]');
 		});
 
 		it('should fail (unsupported protocol)', () => {

--- a/wallaby.e2e.js
+++ b/wallaby.e2e.js
@@ -1,4 +1,4 @@
-export default function wallaby () {
+export default function w (wallaby) {
 	return {
 		testFramework: 'mocha',
 		files: [
@@ -30,6 +30,11 @@ export default function wallaby () {
 			params: {
 				env: 'NODE_ENV=test',
 			},
+		},
+		compilers: {
+			'**/*.ts?(x)': wallaby.compilers.typeScript({
+				module: 'ESNext',
+			}),
 		},
 		workers: { restart: true, initial: 1, regular: 1 },
 		runMode: 'onsave',

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as url from 'node:url';
 
-export default function wallaby (wallaby) {
+export default function w (wallaby) {
 	const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 	return {
@@ -44,7 +44,7 @@ export default function wallaby (wallaby) {
 			params: {
 				runner: '--experimental-specifier-resolution=node --loader '
 					+ url.pathToFileURL(path.join(__dirname, 'node_modules/testdouble/lib/index.mjs')),
-				env: 'NODE_ENV=test;NEW_RELIC_ENABLED=false;NEW_RELIC_LOG_ENABLED=false;TEST_MODE=unit',
+				env: 'NODE_ENV=test;TEST_MODE=unit',
 			},
 		},
 		compilers: {


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-probe/issues/261

E2E should pass after the merge of https://github.com/jsdelivr/globalping-probe/pull/265