### PR TITLE
feat: only consider cities from the most likely country

### DIFF
--- a/docs/geoip.md
+++ b/docs/geoip.md
@@ -109,7 +109,8 @@ New data state:
 
 Sort accoriding to the priority. All providers are prioritized so we are able to make a decision in draw situations. Current priority is: `["ipinfo", "ip2location", "maxmind", "ipmap", "fastly"]`, where `"ipinfo"` is the top prioritized.
 Sorting rules are:
-- providers with the same "city" are grouped and go first
+- providers with the same "country" are grouped and go first
+- providers with the same "city" within the top "country" are grouped and go first
 - if there are several groups of the same size, group with the most prioritized provider goes first
 - groups are sorted internally by the priority of providers
 

--- a/test/tests/unit/geoip/client.test.ts
+++ b/test/tests/unit/geoip/client.test.ts
@@ -136,7 +136,7 @@ describe('geoip service', () => {
 	});
 
 	it('should choose top prioritized provider when all providers returned different cities', async () => {
-		nockGeoIpProviders({ ipmap: 'default', ip2location: 'argentina', maxmind: 'newYork', ipinfo: 'empty', fastly: 'bangkok' });
+		nockGeoIpProviders({ ipmap: 'default', ip2location: 'argentina', maxmind: 'empty', ipinfo: 'empty', fastly: 'bangkok' });
 
 		const info = await client.lookup(MOCK_IP);
 
@@ -155,6 +155,29 @@ describe('geoip service', () => {
 			isProxy: false,
 			isHosting: null,
 			isAnycast: null,
+		});
+	});
+
+	it('should consider only results in the most popular country', async () => {
+		nockGeoIpProviders({ ipmap: 'default', ip2location: 'newYork', maxmind: 'newYork', ipinfo: 'argentina', fastly: 'argentina' });
+
+		const info = await client.lookup(MOCK_IP);
+
+		expect(info).to.deep.equal({
+			asn: 80001,
+			city: 'New York',
+			continent: 'NA',
+			country: 'US',
+			isAnycast: null,
+			isHosting: true,
+			isProxy: false,
+			latitude: 40.71,
+			longitude: -74.01,
+			network: 'The Constant Company LLC',
+			normalizedCity: 'new york',
+			normalizedNetwork: 'the constant company llc',
+			region: 'Northern America',
+			state: 'NY',
 		});
 	});
 


### PR DESCRIPTION
Sometimes, we run into a case where we get multiple cities that are different but close to each other, and then one somewhere far, reported by two providers, e.g.:

```
lisbon, PT
san francisco, US
san jose, US
new york, US
lisbon, PT
```

```
johannesburg, ZA
amsterdam, NL
lelystad, NL (almost amsterdam)
amsterdam, NL
johannesburg, ZA
```

Sometimes each provider returns a different city, but multiple agree on the country:

```
calais, FR
Paris, FR
brugge, BE
roubaix, FR
```

We currently don't consider at all how close or far the cities are, and doing so makes sense and does improve the results a little.   I initially considered clustering the cities by distance based on coordinates, but this is easier and seems to work just as well.