### PR TITLE
fix: add Great Britain as GB alias

### DIFF
--- a/src/lib/location/countries.ts
+++ b/src/lib/location/countries.ts
@@ -5,7 +5,7 @@
  * ]
  * */
 export const aliases = [
-	[ 'gb', 'uk', 'united kingdom', 'england', 'northern ireland', 'wales', 'scotland' ],
+	[ 'gb', 'uk', 'great britain', 'england', 'northern ireland', 'wales', 'scotland' ],
 ];
 
 /* eslint @typescript-eslint/naming-convention: 0 */


### PR DESCRIPTION
United Kingdom is the official name, so we already have that in the index. On the other hand, we were missing Great Britain.