### PR TITLE
feat: adopt user's offline probe by asn+city if possible

### DIFF
--- a/src/adoption/adoption-token.ts
+++ b/src/adoption/adoption-token.ts
@@ -78,7 +78,7 @@ export class AdoptionToken {
 		const tokenValue = socket.handshake.query['adoptionToken'];
 		const token = !tokenValue ? null : String(tokenValue);
 		const probe = socket.data.probe;
-		const isAdopted = !!adoptedProbes.getByIp(probe.ipAddress);
+		const isAdopted = !!this.adoptedProbes.getByIp(probe.ipAddress);
 
 		if (!token) {
 			!isAdopted && socket.emit('api:connect:adoption', { message: 'You can register this probe at https://dash.globalping.io to earn extra measurement credits.' });
@@ -92,12 +92,18 @@ export class AdoptionToken {
 		}
 	}
 
-	async validateToken (token: string, probe: Probe): Promise<{ message: string | null, level?: 'info' | 'warn' }> {
+	async getUserByToken (token: string) {
 		let user = this.tokensToUsers.get(token);
 
 		if (!user) {
 			user = await this.fetchSpecificUser(token);
 		}
+
+		return user;
+	}
+
+	async validateToken (token: string, probe: Probe): Promise<{ message: string | null, level?: 'info' | 'warn' }> {
+		const user = await this.getUserByToken(token);
 
 		if (!user) {
 			logger.info('User not found for the provided adoption token.', { token });

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -379,8 +379,7 @@ export class AdoptedProbes {
 		// Searching probe for the dProbe by: offline dProbe token+asn+city -> probe token+asn+city.
 		dProbesToCheck = [ ...dProbesWithoutProbe ];
 		dProbesWithoutProbe = [];
-
-		const adoptionTokenToProbes = _.groupBy(probes.filter(probe => !!probe.adoptionToken), probe => `${probe.adoptionToken}-${probe.location.asn}-${probe.location.city}`);
+		const adoptionTokenToProbes = _.groupBy(([ ...uuidToProbe.values() ]).filter(probe => !!probe.adoptionToken), probe => `${probe.adoptionToken}-${probe.location.asn}-${probe.location.city}`);
 
 		dProbesToCheck.forEach((dProbe) => {
 			const probes = dProbe.adoptionToken && dProbe.status === 'offline' && adoptionTokenToProbes[`${dProbe.adoptionToken}-${dProbe.asn}-${dProbe.city}`];

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -21,9 +21,11 @@ export const buildProbe = async (socket: Socket): Promise<Probe> => {
 	const uuid = String(socket.handshake.query['uuid']);
 	const isHardware = socket.handshake.query['isHardware'] === 'true' || socket.handshake.query['isHardware'] === '1';
 	const hardwareDeviceValue = socket.handshake.query['hardwareDevice'];
-	const hardwareDeviceFirmwareValue = socket.handshake.query['hardwareDeviceFirmware'];
 	const hardwareDevice = !hardwareDeviceValue ? null : String(hardwareDeviceValue);
+	const hardwareDeviceFirmwareValue = socket.handshake.query['hardwareDeviceFirmware'];
 	const hardwareDeviceFirmware = !hardwareDeviceFirmwareValue ? null : String(hardwareDeviceFirmwareValue);
+	const adoptionTokenValue = socket.handshake.query['adoptionToken'];
+	const adoptionToken = !adoptionTokenValue ? null : String(adoptionTokenValue);
 	const host = process.env['HOSTNAME'] ?? '';
 
 	const ip = getProbeIp(socket);
@@ -87,6 +89,7 @@ export const buildProbe = async (socket: Socket): Promise<Probe> => {
 		status: 'initializing',
 		isIPv4Supported: false,
 		isIPv6Supported: false,
+		adoptionToken,
 	};
 };
 

--- a/src/probe/router.ts
+++ b/src/probe/router.ts
@@ -176,6 +176,7 @@ export class ProbeRouter {
 			},
 			jobs: { count: null },
 		},
+		adoptionToken: null,
 	});
 }
 

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -55,6 +55,7 @@ export type Probe = {
 	stats: ProbeStats;
 	hostInfo: HostInfo;
 	owner?: { id: string };
+	adoptionToken: string | null;
 };
 
 type Modify<T, Fields> = Omit<T, keyof Fields> & Fields;

--- a/test/tests/integration/adoption-code.test.ts
+++ b/test/tests/integration/adoption-code.test.ts
@@ -81,6 +81,7 @@ describe('Adoption code', () => {
 					network: 'The Constant Company LLC',
 					isCustomCity: false,
 					countryOfCustomCity: null,
+					adoptionToken: null,
 				});
 			});
 

--- a/test/tests/integration/adoption-token.test.ts
+++ b/test/tests/integration/adoption-token.test.ts
@@ -61,6 +61,7 @@ describe('Adoption token', () => {
 					network: 'The Constant Company LLC',
 					isCustomCity: false,
 					countryOfCustomCity: null,
+					adoptionToken: 'adoptionTokenValue',
 				},
 				user: { id: 'userIdValue' },
 			});

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -33,6 +33,7 @@ describe('AdoptedProbes', () => {
 		network: 'Amazon.com, Inc.',
 		githubUsername: 'jimaek',
 		publicProbes: 0,
+		adoptionToken: null,
 	};
 
 	const defaultConnectedProbe: Probe = {
@@ -79,6 +80,7 @@ describe('AdoptedProbes', () => {
 			totalDiskSize: 0,
 			availableDiskSpace: 0,
 		},
+		adoptionToken: null,
 	};
 
 	const sandbox = sinon.createSandbox();

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -287,6 +287,22 @@ describe('AdoptedProbes', () => {
 		expect(sql.insert.callCount).to.equal(0);
 	});
 
+	it('class should not use already matched probes in search by: offline dProbe token+asn+city -> probe token+asn+city', async () => {
+		sql.select.resolves([
+			defaultAdoption,
+			{ ...defaultAdoption, status: 'offline', ip: '2.2.2.2', uuid: '2-2-2-2-2', adoptionToken: 'adoptionTokenValue' },
+		]);
+
+		getProbesWithAdminData.returns([{ ...defaultConnectedProbe, adoptionToken: 'adoptionTokenValue' }]);
+
+		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);
+		await adoptedProbes.syncDashboardData();
+
+		expect(sql.update.callCount).to.equal(0);
+		expect(sql.delete.callCount).to.equal(0);
+		expect(sql.insert.callCount).to.equal(0);
+	});
+
 	it('class should update status to "offline" if probe was not found', async () => {
 		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);
 		sql.select.resolves([{ ...defaultAdoption, lastSyncDate: relativeDayUtc(-15) }]);


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/625

Adding logic of matching by token+offline+asn+city here as well to prevent a possible race condition, where sync in `adopted-probes.ts` happens before `/adopt-by-token` is handled, so new probe is created in db instead of updating of the offline probe.