### PR TITLE
feat: improve diversification across cities

### DIFF
--- a/src/probe/probes-location-filter.ts
+++ b/src/probe/probes-location-filter.ts
@@ -178,20 +178,12 @@ export class ProbesLocationFilter {
 			.value();
 
 		// For each group, compute the frequency of the same city in earlier groups.
-		const counts: {[k: string]: { values: number[], currentRank: number }} = {};
+		const counts: {[k: string]: number} = {};
 		const shuffledProbes: Probe[] = [];
 
 		for (const group of groupedProbes) {
-			const cityR = counts[group.cityKey] ?? (counts[group.cityKey] = { values: [ 0 ], currentRank: group.rank });
-
-			if (group.rank === cityR.currentRank) {
-				cityR.values[cityR.values.length - 1]++;
-			} else if (group.rank < cityR.currentRank) {
-				cityR.values.push((cityR.values.at(-1) || 0) + 1);
-				cityR.currentRank = group.rank;
-			}
-
-			group.prevSameCity = cityR.values.at(-2) || 0;
+			group.prevSameCity = counts[group.cityKey] ?? (counts[group.cityKey] = 0);
+			counts[group.cityKey]++;
 		}
 
 		// Prioritize less common cities within the same ranking group.


### PR DESCRIPTION
#637 improved the situation significantly for ASNs, but cities still repeat in the results quite a lot. This is expected and not entirely avoidable, but we can improve it somewhat by boosting less common cities within their own ranking group. E.g.:

 - 30 probes in City1, ASN1,
 - 10 probes in City1, ASN2,
 - 5 probes in City1, ASN3,
 - 5 probes in City2, ASN4,
 - 4 probes in City3, ASN5

We boost the last two groups above the third one, as they all rank the same, but the last two increase city diversity while the third one doesn't.

Difference on our real data for Germany (in both cases the results could vary a bit between runs):

```
limit 10 - before
[
  [ 'DE, Frankfurt', 6 ],
  [ 'DE, Nuremberg', 2 ],
  [ 'DE, Berlin', 1 ],
  [ 'DE, Falkenstein', 1 ]
]

limit 10 - after
[
  [ 'DE, Frankfurt', 4 ],
  [ 'DE, Nuremberg', 2 ],
  [ 'DE, Dusseldorf', 1 ],
  [ 'DE, Lubeck', 1 ],
  [ 'DE, Berlin', 1 ],
  [ 'DE, Falkenstein', 1 ]
]
```

```
limit 20 - before
[
  [ 'DE, Frankfurt', 12 ],
  [ 'DE, Dusseldorf', 3 ],
  [ 'DE, Berlin', 2 ],
  [ 'DE, Nuremberg', 2 ],
  [ 'DE, Falkenstein', 1 ]
]

limit 20 - after - no difference here as there are about 20 large City+ASN groups in total
[
  [ 'DE, Frankfurt', 12 ],
  [ 'DE, Dusseldorf', 3 ],
  [ 'DE, Berlin', 2 ],
  [ 'DE, Nuremberg', 2 ],
  [ 'DE, Falkenstein', 1 ]
]
```

```
limit 50 - before
[
  [ 'DE, Frankfurt', 32 ],
  [ 'DE, Dusseldorf', 4 ],
  [ 'DE, Nuremberg', 4 ],
  [ 'DE, Berlin', 3 ],
  [ 'DE, Neuwied', 1 ],
  [ 'DE, Koln', 1 ],
  [ 'DE, Duren', 1 ],
  [ 'DE, Leinfelden-Echterdingen', 1 ],
  [ 'DE, Rheda-Wiedenbruck', 1 ],
  [ 'DE, Koblenz', 1 ],
  [ 'DE, Falkenstein', 1 ]
]

limit 50 - after
[
  [ 'DE, Frankfurt', 12 ],
  [ 'DE, Dusseldorf', 7 ],
  [ 'DE, Berlin', 5 ],
  [ 'DE, Nuremberg', 5 ],
  [ 'DE, Falkenstein', 2 ],
  [ 'DE, Erfurt', 1 ],
  [ 'DE, Stuttgart', 1 ],
  [ 'DE, Mannheim', 1 ],
  [ 'DE, Koln', 1 ],
  [ 'DE, Leinfelden-Echterdingen', 1 ],
  [ 'DE, Wesel', 1 ],
  [ 'DE, Lubeck', 1 ],
  [ 'DE, Kleve', 1 ],
  [ 'DE, Munich', 1 ],
  [ 'DE, Karlsruhe', 1 ],
  [ 'DE, Munster', 1 ],
  [ 'DE, Duren', 1 ],
  [ 'DE, Cologne', 1 ],
  [ 'DE, Rheda-Wiedenbruck', 1 ],
  [ 'DE, Hannover', 1 ],
  [ 'DE, Koblenz', 1 ],
  [ 'DE, Bielefeld', 1 ],
  [ 'DE, Aachen', 1 ],
  [ 'DE, Neuwied', 1 ]
]
```