### PR TITLE
feat: support svcb records for dns requests

### DIFF
--- a/public/demo/globals.js
+++ b/public/demo/globals.js
@@ -11,7 +11,7 @@ const ALLOWED_IP_VERSIONS = [ 4, 6 ];
 const ALLOWED_TRACE_PROTOCOLS = [ 'TCP', 'UDP', 'ICMP' ];
 
 // dns
-const ALLOWED_DNS_TYPES = [ 'A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'HTTPS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV' ];
+const ALLOWED_DNS_TYPES = [ 'A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'HTTPS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV', 'SVCB' ];
 const ALLOWED_DNS_PROTOCOLS = [ 'UDP', 'TCP' ];
 
 // mtr

--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -363,6 +363,7 @@ components:
                 - SOA
                 - TXT
                 - SRV
+                - SVCB
               default: A
         resolver:
           $ref: 'schemas.yaml#/components/schemas/MeasurementResolver'

--- a/src/measurement/schema/command-schema.ts
+++ b/src/measurement/schema/command-schema.ts
@@ -113,7 +113,7 @@ export const tracerouteSchema = Joi.object({
 	ipVersion: ipVersionSchema,
 }).default().messages(schemaErrorMessages);
 
-const allowedDnsTypes = [ 'A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'HTTPS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV' ];
+const allowedDnsTypes = [ 'A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'HTTPS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV', 'SVCB' ];
 const allowedDnsProtocols = [ 'UDP', 'TCP' ];
 
 // Dns

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -93,7 +93,7 @@ export type MtrResult = TestResult & {
 	hops?: MtrResultHop[];
 };
 
-type DnsQueryTypes = 'A' | 'AAAA' | 'ANY' | 'CNAME' | 'DNSKEY' | 'DS' | 'HTTPS' | 'MX' | 'NS' | 'NSEC' | 'PTR' | 'RRSIG' | 'SOA' | 'TXT' | 'SRV';
+type DnsQueryTypes = 'A' | 'AAAA' | 'ANY' | 'CNAME' | 'DNSKEY' | 'DS' | 'HTTPS' | 'MX' | 'NS' | 'NSEC' | 'PTR' | 'RRSIG' | 'SOA' | 'TXT' | 'SRV' | 'SVCB';
 
 type DnsTest = {
 	query: {


### PR DESCRIPTION
Fixes #615

See https://github.com/jsdelivr/globalping-probe/pull/287 for changes to probe.

I tested this with the local dev setup.