### PR TITLE
refactor: override koa's IP handling for consistency

### DIFF
--- a/src/alternative-ip/route/alternative-ip.ts
+++ b/src/alternative-ip/route/alternative-ip.ts
@@ -6,12 +6,10 @@ import { bodyParser } from '../../lib/http/middleware/body-parser.js';
 import { validate } from '../../lib/http/middleware/validate.js';
 import { schema } from '../schema.js';
 import { getAltIpsClient } from '../../lib/alt-ips.js';
-import { getIpFromRequest } from '../../lib/client-ip.js';
 
 const handle = async (ctx: Context): Promise<void> => {
 	const request = ctx.request.body as AlternativeIpRequest;
-
-	const ip = getIpFromRequest(ctx.req);
+	const ip = ctx.request.ip;
 
 	if (!ip) {
 		throw createHttpError(400, 'Unable to get requester ip.', { type: 'no_ip' });

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -11,12 +11,12 @@ const trustPredicate = proxyaddr.compile([
 	'linklocal',
 ]);
 
-export const getIpFromRequest = (request: IncomingMessage) => {
-	const ip = proxyaddr(request, trustPredicate);
-
-	if (!ip) {
-		return ip;
-	}
+/**
+ * Returns the real client IP, taking into account the configured trusted proxies.
+ * Normalizes IPv4-mapped IPv6 address into IPv4.
+ */
+export const getIpFromRequest = (req: IncomingMessage) => {
+	const ip = proxyaddr(req, trustPredicate);
 
 	if (ipv4MappedPattern.test(ip)) {
 		return ip.slice(7);

--- a/src/lib/http/middleware/request-ip.ts
+++ b/src/lib/http/middleware/request-ip.ts
@@ -1,0 +1,7 @@
+import type { Context, Next } from 'koa';
+import { getIpFromRequest } from '../../client-ip.js';
+
+export const requestIp = () => async (ctx: Context, next: Next) => {
+	ctx.request.ip = getIpFromRequest(ctx.req);
+	await next();
+};

--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -24,6 +24,7 @@ import { errorHandler } from './error-handler.js';
 import { defaultJson } from './middleware/default-json.js';
 import { errorHandlerMw } from './middleware/error-handler.js';
 import { corsHandler } from './middleware/cors.js';
+import { requestIp } from './middleware/request-ip.js';
 import { isAdminMw } from './middleware/is-admin.js';
 import { isSystemMw } from './middleware/is-system.js';
 import { docsLink } from './middleware/docs-link.js';
@@ -63,7 +64,7 @@ apmAgent.addSpanFilter((payload) => {
 	return false;
 });
 
-const app = new Koa({ proxy: true, maxIpsCount: 1 });
+const app = new Koa();
 const publicPath = url.fileURLToPath(new URL('.', import.meta.url)) + '/../../../public';
 const docsHost = config.get<string>('server.docsHost');
 
@@ -112,6 +113,7 @@ healthRouter.use(koaElasticUtils.middleware(apmAgent));
 registerHealthRoute(healthRouter);
 
 app
+	.use(requestIp())
 	.use(responseTime())
 	.use(koaFavicon(`${publicPath}/favicon.ico`))
 	.use(compress({ br: { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 } }, gzip: { level: 3 }, deflate: false }))

--- a/src/lib/rate-limiter/get-id-from-request.ts
+++ b/src/lib/rate-limiter/get-id-from-request.ts
@@ -1,10 +1,9 @@
-import { IncomingMessage } from 'node:http';
 import { isIPv6 } from 'node:net';
 import ipaddr from 'ipaddr.js';
-import { getIpFromRequest } from '../client-ip.js';
+import koa from 'koa';
 
-export const getIdFromRequest = (req: IncomingMessage) => {
-	const clientIp = getIpFromRequest(req);
+export const getIdFromRequest = (request: koa.Request) => {
+	const clientIp = request.ip;
 
 	if (!clientIp) {
 		return '';

--- a/src/lib/rate-limiter/rate-limiter-get.ts
+++ b/src/lib/rate-limiter/rate-limiter-get.ts
@@ -20,7 +20,7 @@ export const getMeasurementRateLimit = async (ctx: ExtendedContext, next: Unknow
 		return next();
 	}
 
-	const clientId = getIdFromRequest(ctx.req);
+	const clientId = getIdFromRequest(ctx.request);
 	const measurementId = ctx.params['id'] ?? '';
 	const id = `${clientId}:${measurementId}`;
 

--- a/src/lib/rate-limiter/rate-limiter-post.ts
+++ b/src/lib/rate-limiter/rate-limiter-post.ts
@@ -45,7 +45,7 @@ const getRateLimiter = (ctx: ExtendedContext): {
 
 	return {
 		type: 'ip',
-		id: ctx.state.user?.hashedToken ?? getIdFromRequest(ctx.req),
+		id: ctx.state.user?.hashedToken ?? getIdFromRequest(ctx.request),
 		rateLimiter: anonymousRateLimiter,
 	};
 };

--- a/test/tests/integration/limits.test.ts
+++ b/test/tests/integration/limits.test.ts
@@ -1,14 +1,12 @@
 import type { Server } from 'node:http';
-import request, { type Response } from 'supertest';
+import request from 'supertest';
 import { expect } from 'chai';
-import _ from 'lodash';
 import { getTestServer, addFakeProbe, deleteFakeProbes, waitForProbesUpdate } from '../../utils/server.js';
 import nockGeoIpProviders from '../../utils/nock-geo-ip.js';
 import { anonymousRateLimiter, authenticatedRateLimiter } from '../../../src/lib/rate-limiter/rate-limiter-post.js';
 import { client } from '../../../src/lib/sql/client.js';
 import { GP_TOKENS_TABLE } from '../../../src/lib/http/auth.js';
 import { CREDITS_TABLE } from '../../../src/lib/credits.js';
-import { getIdFromRequest } from '../../../src/lib/rate-limiter/get-id-from-request.js';
 
 describe('rate limiter', () => {
 	let app: Server;
@@ -19,9 +17,8 @@ describe('rate limiter', () => {
 		app = await getTestServer();
 		requestAgent = request(app);
 
-		const httpResponse = await requestAgent.post('/v1/').send() as Response & { req: any };
-		_.defaults(httpResponse.req, { headers: {} });
-		clientId = getIdFromRequest(httpResponse.req) || '127.0.0.1';
+		await requestAgent.post('/v1/').send();
+		clientId = '127.0.0.1';
 
 		nockGeoIpProviders();
 

--- a/test/tests/integration/ratelimit.test.ts
+++ b/test/tests/integration/ratelimit.test.ts
@@ -1,7 +1,6 @@
 import type { Server } from 'node:http';
 import request, { type Response } from 'supertest';
 import { expect } from 'chai';
-import _ from 'lodash';
 import { getTestServer, addFakeProbe, deleteFakeProbes, waitForProbesUpdate } from '../../utils/server.js';
 import nockGeoIpProviders from '../../utils/nock-geo-ip.js';
 import { anonymousRateLimiter as anonymousPostRateLimiter, authenticatedRateLimiter as authenticatedPostRateLimiter, failedCreditsAttempts } from '../../../src/lib/rate-limiter/rate-limiter-post.js';
@@ -10,7 +9,6 @@ import { client } from '../../../src/lib/sql/client.js';
 import { GP_TOKENS_TABLE } from '../../../src/lib/http/auth.js';
 import { CREDITS_TABLE } from '../../../src/lib/credits.js';
 import { getPersistentRedisClient } from '../../../src/lib/redis/persistent-client.js';
-import { getIdFromRequest } from '../../../src/lib/rate-limiter/get-id-from-request.js';
 
 describe('rate limiter', () => {
 	let app: Server;
@@ -22,9 +20,8 @@ describe('rate limiter', () => {
 		app = await getTestServer();
 		requestAgent = request(app);
 
-		const httpResponse = await requestAgent.post('/v1/').send() as Response & { req: any };
-		_.defaults(httpResponse.req, { headers: {} });
-		clientId = getIdFromRequest(httpResponse.req) || '127.0.0.1';
+		requestAgent.post('/v1/').send();
+		clientId = '127.0.0.1';
 
 		nockGeoIpProviders();
 		nockGeoIpProviders();


### PR DESCRIPTION
Koa's handling of the proxies is rather poor, and we also need to normalize the mapped addresses. This seems like the best option to do it consistently.