### PR TITLE
perf: optimize magic sort and diversified shuffle

### DIFF
--- a/src/lib/geoip/utils.ts
+++ b/src/lib/geoip/utils.ts
@@ -14,3 +14,5 @@ export const normalizeFromPublicName = (name: string): string => name.toLowerCas
 export const normalizeNetworkName = (name: string): string => name.toLowerCase();
 
 export const normalizeCoordinate = (coordinate: number) => Math.round(coordinate * 100) / 100;
+
+export const getGroupingKey = (country: string, state: string | null, normalizedCity: string, asn: number) => `${country}-${state}-${normalizedCity}-${asn}`;

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -4,8 +4,8 @@ import _ from 'lodash';
 import config from 'config';
 import { scopedLogger } from '../logger.js';
 import type { getProbesWithAdminData as serverGetProbesWithAdminData } from '../ws/server.js';
-import type { Probe, ProbeLocation, Tag } from '../../probe/types.js';
-import { normalizeCoordinate, normalizeFromPublicName } from '../geoip/utils.js';
+import type { ExtendedProbeLocation, Probe, ProbeLocation, Tag } from '../../probe/types.js';
+import { getGroupingKey, normalizeCoordinate, normalizeFromPublicName } from '../geoip/utils.js';
 import { getContinentByCountry, getContinentName, getCountryByIso, getIndex, getRegionByCountry, getStateNameByIso } from '../location/location.js';
 import { countries } from 'countries-list';
 import { randomUUID } from 'crypto';
@@ -214,15 +214,16 @@ export class AdoptedProbes {
 		return this.uuidToAdoption.get(uuid) || null;
 	}
 
-	getUpdatedLocation (probe: Probe, adminLocation?: ProbeLocation | null): ProbeLocation | null {
+	getUpdatedLocation (probe: Probe, adminLocation?: ProbeLocation | null): ExtendedProbeLocation | null {
 		const adoption = this.getByIp(probe.ipAddress);
+		const location = adminLocation || probe.location;
 
 		if (!adoption || !adoption.customLocation || !adoption.country || !probe.location.allowedCountries.includes(adoption.country)) {
 			return null;
 		}
 
 		return {
-			...(adminLocation || probe.location),
+			...location,
 			continent: getContinentByCountry(adoption.country),
 			region: getRegionByCountry(adoption.country),
 			country: adoption.country,
@@ -231,6 +232,7 @@ export class AdoptedProbes {
 			state: adoption.state,
 			latitude: adoption.latitude!,
 			longitude: adoption.longitude!,
+			groupingKey: getGroupingKey(adoption.country, adoption.state, normalizeFromPublicName(adoption.city!), location.asn),
 		};
 	}
 

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -23,7 +23,7 @@ export class MeasurementRunner {
 
 	async run (ctx: ExtendedContext): Promise<{ measurementId: string; probesCount: number }> {
 		const userRequest = ctx.request.body as UserRequest;
-		const { onlineProbesMap, allProbes, request } = await captureSpan('findMatchingProbes', () => this.router.findMatchingProbes(userRequest));
+		const { onlineProbesMap, allProbes, request } = await this.router.findMatchingProbes(userRequest);
 		const ipVersion = userRequest.measurementOptions?.ipVersion;
 
 		if (allProbes.length === 0) {

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -7,9 +7,10 @@ import { ProbeError } from '../lib/probe-error.js';
 import { getGeoIpClient, LocationInfo } from '../lib/geoip/client.js';
 import getProbeIp from '../lib/get-probe-ip.js';
 import { getRegion } from '../lib/cloud-ip-ranges.js';
-import type { Probe, ProbeLocation, Tag } from './types.js';
+import type { ExtendedProbeLocation, Probe, Tag } from './types.js';
 import { probeIpLimit } from '../lib/ws/server.js';
 import { fakeLookup } from '../lib/geoip/fake-client.js';
+import { getGroupingKey } from '../lib/geoip/utils.js';
 import { isIpBlocked } from '../lib/blocked-ip-ranges.js';
 
 export const buildProbe = async (socket: Socket): Promise<Probe> => {
@@ -97,7 +98,7 @@ export const buildProbe = async (socket: Socket): Promise<Probe> => {
 	};
 };
 
-const getLocation = (ipInfo: LocationInfo): ProbeLocation => ({
+const getLocation = (ipInfo: LocationInfo): ExtendedProbeLocation => ({
 	continent: ipInfo.continent,
 	region: ipInfo.region,
 	country: ipInfo.country,
@@ -110,6 +111,7 @@ const getLocation = (ipInfo: LocationInfo): ProbeLocation => ({
 	network: ipInfo.network,
 	normalizedNetwork: ipInfo.normalizedNetwork,
 	allowedCountries: ipInfo.allowedCountries,
+	groupingKey: getGroupingKey(ipInfo.country, ipInfo.state, ipInfo.normalizedCity, ipInfo.asn),
 });
 
 const getTags = (clientIp: string, ipInfo: LocationInfo) => {

--- a/src/probe/probes-location-filter.ts
+++ b/src/probe/probes-location-filter.ts
@@ -67,7 +67,6 @@ export class ProbesLocationFilter {
 	magicFilter (probes: Probe[], magicLocation: string) {
 		let resultProbes = probes;
 		const keywords = magicLocation.toLowerCase().split('+').map(k => ({ system: k.replaceAll('-', ' ').trim(), userTag: k.trim() }));
-		const bestProbePositions: number[] = [];
 
 		const keywordsWithPositions = keywords.map(keyword => ({
 			keyword,
@@ -79,18 +78,7 @@ export class ProbesLocationFilter {
 			let filteredProbes = [];
 
 			if (noExactMatches) {
-				// Positions are only relevant for non-exact matches, as exact matches must all occur at the same level.
-				filteredProbes = resultProbes.filter((probe, index) => {
-					const pos = this.getIndexPosition(probe, keyword.system);
-
-					if (pos !== -1) {
-						if (!bestProbePositions[index] || bestProbePositions[index] > pos) {
-							bestProbePositions[index] = pos;
-						}
-					}
-
-					return pos !== -1;
-				});
+				filteredProbes = resultProbes.filter(probe => this.getIndexPosition(probe, keyword.system) !== -1);
 			} else {
 				filteredProbes = resultProbes.filter(probe => this.checkExactIndexPosition(probe, keyword.system, position));
 			}
@@ -102,7 +90,7 @@ export class ProbesLocationFilter {
 			resultProbes = filteredProbes;
 		}
 
-		return { filteredProbes: resultProbes, bestProbePositions };
+		return resultProbes;
 	}
 
 	checkExactIndexPosition (probe: Probe, filterValue: string, position: number) {
@@ -146,13 +134,12 @@ export class ProbesLocationFilter {
 		}
 
 		let filteredProbes = probes;
-		let bestProbePositions: number[];
 
 		Object.keys(location).forEach((key) => {
 			if (key === 'tags') {
 				filteredProbes = probes.filter(probe => location.tags!.every(tag => this.hasTag(probe, tag)));
 			} else if (key === 'magic') {
-				({ filteredProbes, bestProbePositions } = captureSpan('magicFilter', () => this.magicFilter(filteredProbes, location.magic!)));
+				filteredProbes = captureSpan('magicFilter', () => this.magicFilter(filteredProbes, location.magic!));
 			} else {
 				const probeKey = Object.hasOwn(locationKeyMap, key) ? locationKeyMap[key as keyof typeof locationKeyMap] : key;
 				// @ts-expect-error it's a string
@@ -164,7 +151,7 @@ export class ProbesLocationFilter {
 
 		const isMagicSorting = Object.keys(location).includes('magic');
 
-		return captureSpan('shuffle', () => isMagicSorting ? this.magicSort(filteredProbes, bestProbePositions) : this.diversifiedShuffle(filteredProbes));
+		return captureSpan('shuffle', () => isMagicSorting ? this.magicSort(filteredProbes, location.magic!) : this.diversifiedShuffle(filteredProbes));
 	}
 
 	public filterByLocationAndWeight (probes: Probe[], distribution: Map<Location, number>, limit: number): Probe[] {
@@ -206,19 +193,17 @@ export class ProbesLocationFilter {
 		return [ ...pickedProbes ];
 	}
 
-	private magicSort (probes: Probe[], bestProbePositions: number[]): Probe[] {
-		const probesGroupedByIndexPosition = probes.reduce<{ [k: string]: Probe[] }>((grouped, probe, probeIndex) => {
-			const groupIndex = bestProbePositions[probeIndex] ?? 0;
+	private magicSort (probes: Probe[], magicString: string): Probe[] {
+		const getClosestIndexPosition = (probe: Probe) => {
+			const keywords = magicString.split('+');
+			const closestIndexPosition = keywords.reduce((smallestIndex, keyword) => {
+				const indexPosition = this.getIndexPosition(probe, keyword);
+				return indexPosition < smallestIndex ? indexPosition : smallestIndex;
+			}, Number.POSITIVE_INFINITY);
+			return closestIndexPosition;
+		};
 
-			if (!grouped[groupIndex]) {
-				grouped[groupIndex] = [];
-			}
-
-			grouped[groupIndex].push(probe);
-			return grouped;
-		}, {});
-
-		// Object.values sorts values by (numerical) keys
+		const probesGroupedByIndexPosition = _.groupBy(probes, getClosestIndexPosition);
 		const groupsSortedByIndexPosition = Object.values(probesGroupedByIndexPosition).reduce(({ groups, count }, group) => {
 			// Discard the remaining groups if we already have more than enough probes.
 			if (count >= MAX_MEASUREMENT_PROBES) {
@@ -229,7 +214,7 @@ export class ProbesLocationFilter {
 			return { groups, count: count + group.length };
 		}, { groups: [] as Probe[][], count: 0 }).groups;
 
-		const groupsWithShuffledItems = captureSpan('diversifiedShuffle', () => groupsSortedByIndexPosition.map((group, i) => i === 0 ? this.diversifiedShuffle(group) : group));
+		const groupsWithShuffledItems = groupsSortedByIndexPosition.map(group => this.diversifiedShuffle(group));
 		const resultProbes = groupsWithShuffledItems.flat();
 
 		return resultProbes;

--- a/src/probe/probes-location-filter.ts
+++ b/src/probe/probes-location-filter.ts
@@ -218,7 +218,7 @@ export class ProbesLocationFilter {
 		// Group by unique location + ASN, order by the ranking function.
 		let groupedProbes = _(probes)
 			.shuffle() // Ensure the initial order of groups and their content is random.
-			.groupBy(probe => `${probe.location.country}-${probe.location.state}-${probe.location.city}-${probe.location.asn}`)
+			.groupBy(probe => probe.location.groupingKey)
 			.map((probes, groupKey) => ({ probes, rank: groupRank(probes.length), cityKey: groupKey.split('-').slice(0, -1).join('-'), prevSameCity: 0 }))
 			.sort((a, b) => b.rank - a.rank)
 			.value();

--- a/src/probe/probes-location-filter.ts
+++ b/src/probe/probes-location-filter.ts
@@ -19,6 +19,8 @@ const locationKeyMap = {
 	city: 'normalizedCity',
 };
 
+const MAX_MEASUREMENT_PROBES = config.get<number>('measurement.limits.authenticatedTestsPerMeasurement');
+
 export class ProbesLocationFilter {
 	private readonly globalIndex: Set<string>[];
 
@@ -218,7 +220,8 @@ export class ProbesLocationFilter {
 
 		// Object.values sorts values by (numerical) keys
 		const groupsSortedByIndexPosition = Object.values(probesGroupedByIndexPosition).reduce(({ groups, count }, group) => {
-			if (count >= 500) {
+			// Discard the remaining groups if we already have more than enough probes.
+			if (count >= MAX_MEASUREMENT_PROBES) {
 				return { groups, count };
 			}
 

--- a/src/probe/router.ts
+++ b/src/probe/router.ts
@@ -4,7 +4,7 @@ import type { Location } from '../lib/location/types.js';
 import type { OfflineProbe, Probe } from './types.js';
 import { ProbesLocationFilter } from './probes-location-filter.js';
 import { getMeasurementStore, MeasurementStore } from '../measurement/store.js';
-import { normalizeFromPublicName, normalizeNetworkName } from '../lib/geoip/utils.js';
+import { getGroupingKey, normalizeFromPublicName, normalizeNetworkName } from '../lib/geoip/utils.js';
 import { onProbesUpdate as onServerProbesUpdate } from '../lib/ws/server.js';
 import { captureSpan } from '../lib/metrics.js';
 
@@ -173,6 +173,7 @@ export class ProbeRouter {
 			network: test.probe.network,
 			normalizedNetwork: normalizeNetworkName(test.probe.network),
 			allowedCountries: [ test.probe.country ],
+			groupingKey: getGroupingKey(test.probe.country, test.probe.state, normalizeFromPublicName(test.probe.city), test.probe.asn),
 		},
 		index: [],
 		resolvers: test.probe.resolvers,

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -13,6 +13,10 @@ export type ProbeLocation = {
 	allowedCountries: string[];
 };
 
+export type ExtendedProbeLocation = ProbeLocation & {
+	groupingKey: string;
+};
+
 export type ProbeStats = {
 	cpu: {
 		load: Array<{
@@ -51,7 +55,7 @@ export type Probe = {
 	ipAddress: string;
 	altIpAddresses: string[];
 	host: string;
-	location: ProbeLocation;
+	location: ExtendedProbeLocation;
 	index: ProbeIndex;
 	resolvers: string[];
 	tags: Tag[];

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -78,6 +78,7 @@ describe('Create measurement request', () => {
 				network: 'The Constant Company LLC',
 				normalizedNetwork: 'the constant company llc',
 				allowedCountries: [ 'US' ],
+				groupingKey: 'US-TX-dallas-20004',
 			},
 		]);
 

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -1033,6 +1033,7 @@ describe('AdoptedProbes', () => {
 			network: 'Amazon.com, Inc.',
 			normalizedNetwork: 'amazon.com, inc.',
 			allowedCountries: [ 'IE', 'GL' ],
+			groupingKey: 'GL-null-nuuk-16509',
 		});
 	});
 

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -64,6 +64,7 @@ describe('AdoptedProbes', () => {
 			network: 'Amazon.com, Inc.',
 			normalizedNetwork: 'amazon.com, inc.',
 			allowedCountries: [ 'IE' ],
+			groupingKey: 'IE-null-dublin-16509',
 		},
 		isHardware: false,
 		hardwareDevice: null,


### PR DESCRIPTION
1. Use a precomputed grouping key in the diversified shuffle.
2. ~~Avoid repeated `getIndexPosition()` calls by collecting the returned values the first time.~~