### PR TITLE
feat: prefix-based network matching in magic mode

### DIFF
--- a/src/lib/location/location.ts
+++ b/src/lib/location/location.ts
@@ -95,6 +95,13 @@ export const getNetworkAliases = (key: string): string[] => {
 	return array ?? [];
 };
 
+export const getNetworkPrefixes = (network: string): string[] => {
+	return network.split(' ').reduce((acc: string[], _, i, arr) => {
+		acc.push(arr.slice(0, arr.length - i).join(' '));
+		return acc;
+	}, []);
+};
+
 export function getContinentName (key: string): string {
 	const continent = continents[key as keyof typeof continents];
 
@@ -129,7 +136,7 @@ export const getIndex = (location: ProbeLocation, normalizedTags: Tag[]) => {
 		getRegionAliases(location.region),
 		[ `as${location.asn}` ],
 		normalizedTags.filter(tag => tag.type === 'system').map(tag => tag.value),
-		[ location.normalizedNetwork ],
+		getNetworkPrefixes(location.normalizedNetwork),
 		getNetworkAliases(location.normalizedNetwork),
 	].map(category => category.map(s => s.toLowerCase().replaceAll('-', ' ')));
 

--- a/test/tests/unit/probe/router.test.ts
+++ b/test/tests/unit/probe/router.test.ts
@@ -777,9 +777,9 @@ describe('probe router', () => {
 				limit: 100,
 			} as unknown as UserRequest);
 
-			expect(allProbes.length).to.equal(1);
-			expect(onlineProbesMap.size).to.equal(1);
-			expect(allProbes[0]!.location.normalizedCity).to.equal('poznan');
+			expect(allProbes.length).to.equal(2);
+			expect(onlineProbesMap.size).to.equal(2);
+			expect(allProbes.map(p => p.location.normalizedCity)).to.include.members([ 'warsaw', 'poznan' ]);
 		});
 
 		it('should ignore same-level partial matches if there is an exact match', async () => {


### PR DESCRIPTION
Implements the idea from https://github.com/jsdelivr/globalping/issues/383#issuecomment-3062524054. For network names, we'll consider any full-word prefix match to be "exact", e.g., for `Vodafone Czech Republic a.s.`, all of these are considered exact: `Vodafone Czech Republic a.s.`, `Vodafone Czech Republic`, `Vodafone Czech`, `Vodafone`.

This means `Vodafone` will match all national entities and legal forms, even if a probe with just `Vodafone` network exists.