### PR TITLE
perf: use Sets instead of RegExes in normalizeLegalName

### DIFF
--- a/src/lib/geoip/legal-name-normalization.ts
+++ b/src/lib/geoip/legal-name-normalization.ts
@@ -244,7 +244,7 @@ const readLegalFormsFile = () => new Promise<{ allForms: CsvLegalFormRow[]; pref
 		.on('data', (form: CsvLegalFormRow) => {
 			// Exclude some words that generate lots of false positives.
 			if (/\bbank\b/i.test(form.entityLegalFormNameLocal)) {
-				// return;
+				return;
 			}
 
 			if (PREFIX_USING_COUNTRIES.includes(form.countryCode)) {

--- a/src/lib/geoip/legal-name-normalization.ts
+++ b/src/lib/geoip/legal-name-normalization.ts
@@ -112,7 +112,7 @@ export const normalizeLegalName = (name: string) => {
 	const stripPrefixWithSet = (set: Set<string>, stripWhitespace: boolean = true) => {
 		for (let i = words.length - 1; i > 0; i--) {
 			const sequence = words.slice(0, i).join(stripWhitespace ? '' : ' ').toLowerCase()
-				// Suffixes Sets don't include dots, parentheses, commas and spaces, so we are removing them from the combination.
+				// Suffix sets don't include dots, parentheses, and commas, so we remove them from the sequence.
 				.replace(/[.,()]/g, '');
 
 			if (set.has(sequence)) {

--- a/src/lib/geoip/legal-name-normalization.ts
+++ b/src/lib/geoip/legal-name-normalization.ts
@@ -150,12 +150,12 @@ function generatePossiblePartSplits (parts: string[]): string[][] {
 
 	const [ first, ...rest ] = parts;
 
-	return generatePossiblePartSplits(rest).flatMap((sub) => {
-		if (!sub.length) {
+	return generatePossiblePartSplits(rest).flatMap((rest) => {
+		if (!rest.length) {
 			return [ [ first! ] ];
 		}
 
-		return [ [ first!, ...sub ], [ first! + sub[0]!, ...sub.slice(1) ] ];
+		return [ [ first!, ...rest ], [ first! + rest[0]!, ...rest.slice(1) ] ];
 	});
 }
 
@@ -164,13 +164,7 @@ function multiPartMatch (parts: string[], set: Set<string>): boolean {
 		const parts = word.replace(/[,()]/g, '').split('.');
 		const splits = generatePossiblePartSplits(parts);
 
-		for (const split of splits) {
-			if (split.every(part => set.has(part))) {
-				return true;
-			}
-		}
-
-		return false;
+		return splits.some(split => split.every(part => set.has(part)));
 	});
 }
 

--- a/src/lib/geoip/legal-name-normalization.ts
+++ b/src/lib/geoip/legal-name-normalization.ts
@@ -18,6 +18,7 @@ const ADDITIONAL_LEGAL_FORMS = [
 	{ name: 'Joint Stock Company', abbr: [ 'JSC' ] }, // Russia
 	{ name: 'Public Company Limited', abbr: [ 'PCL' ] }, // Thailand
 	{ name: 'Liability Company', abbr: [ 'LC' ] }, // Vietnam
+	{ name: 'spolecnost s Rucenim Omezenym', abbr: [ 'SRO' ] }, // Slovakia
 ];
 
 // Some languages have custom transliteration rules.
@@ -30,6 +31,11 @@ const PREFIX_USING_COUNTRIES = [ 'RO', 'LV', 'LT', 'EE', 'RU', 'UA', 'BY', 'MD',
 const normalizedCache = new LRUCache<string, string>({
 	max: 10000,
 });
+
+const allNamesSet = new Set<string>();
+const allAbbrsSet = new Set<string>();
+const prefixNamesSet: Set<string> = new Set();
+const prefixAbbrsSet: Set<string> = new Set();
 
 let legalSuffixNamesPattern: RegExp;
 let legalSuffixAbbrsPattern: RegExp;
@@ -56,6 +62,72 @@ type CsvLegalFormRow = {
 };
 
 export const normalizeLegalName = (name: string) => {
+	if (!legalSuffixNamesPattern || !legalSuffixAbbrsPattern || !legalPrefixNamesPattern || !legalPrefixAbbrsPattern) {
+		throw new Error('Legal name normalization is not initialized.');
+	}
+
+	const normalized = name.trim()
+		// Normalize "trading as" names, e.g., "Matteo Martelloni trading as DELUXHOST" => "DELUXHOST"
+		.split(/\s+trading as\s+/i).at(-1)!
+		// Clean up any double spaces.
+		.replace(/\s+/g, ' ')
+		// Add missing space after commas, e.g., "Hangzhou Alibaba Advertising Co.,Ltd." => "Hangzhou Alibaba Advertising"
+		.replace(/,(?=\S)/g, ', ');
+
+	const words = normalized.split(/\s+/);
+
+	// Searching prefix.
+	const firstWord = words[0]!.toLowerCase().replace(/\./g, '');
+
+	if (prefixNamesSet.has(firstWord) || prefixAbbrsSet.has(firstWord)) {
+		words.splice(0, 1);
+	}
+
+	// Searching suffix. Starting from the 2nd word, try to remove the longest possible combination.
+	for (let i = 1; i < words.length; i++) {
+		const combination = words.slice(i).join('').toLowerCase()
+			// Suffixes Sets don't include dots, parentheses, commas and spaces, so we are removing them from the combination.
+			.replace(/[.,()]/g, '');
+
+		// Remove the last word if it's a hyphen or an ampersand and proceed with suffix search.
+		if (([ '-', '&' ].includes(words[i]!) && i === words.length - 1)) {
+			words.splice(i);
+			i = 0;
+			continue;
+		}
+
+		if (
+			allNamesSet.has(combination)
+			|| allAbbrsSet.has(combination)
+		) {
+			words.splice(i);
+
+			if (
+				// If prev word ends with one of the following, proceed with suffix search.
+				words[i - 1]!.endsWith('.')
+				|| words[i - 1]!.endsWith('.,')
+				|| words[i - 1]!.endsWith(')')
+				|| words[i - 1]!.endsWith('),')
+				// Move to the next iteration to remove hyphen or ampersand there.
+				|| [ '-', '&' ].includes(words[i - 1]!)
+			) {
+				i = 0;
+			} else {
+				break;
+			}
+		}
+	}
+
+	const result = words.join(' ')
+		// Remove trailing commas and spaces after suffix removal.
+		.replace(/\s*,\s*$/, '')
+		// Remove wrapping quotes that are often used with prefixes.
+		.replace(/^"(.*)"$/, '$1');
+
+	return result;
+};
+
+export const normalizeLegalName2 = (name: string) => {
 	if (normalizedCache.has(name)) {
 		return normalizedCache.get(name)!;
 	}
@@ -87,6 +159,10 @@ export const populateLegalNames = async () => {
 	const { allForms, prefixForms } = await readLegalFormsFile();
 	const { names: allNames, abbrs: allAbbrs } = await collectLegalForms(allForms);
 	const { names: prefixNames, abbrs: prefixAbbrs } = await collectLegalForms(prefixForms, 3);
+	allNames.forEach(name => allNamesSet.add(name));
+	allAbbrs.forEach(abbr => allAbbrsSet.add(abbr));
+	prefixNames.forEach(name => prefixNamesSet.add(name));
+	prefixAbbrs.forEach(abbr => prefixAbbrsSet.add(abbr));
 	({ namesPattern: legalSuffixNamesPattern, abbrsPattern: legalSuffixAbbrsPattern } = buildSuffixPatterns(allNames, allAbbrs));
 	({ namesPattern: legalPrefixNamesPattern, abbrsPattern: legalPrefixAbbrsPattern } = buildPrefixPatterns(prefixNames, prefixAbbrs));
 };
@@ -159,7 +235,7 @@ async function collectLegalForms (legalFormsData: CsvLegalFormRow[], minSynthesi
 
 		abbrLocal.split(';').forEach((abbr) => {
 			if (abbr.trim()) {
-				legalFormsAbbr.add(toAscii(abbr.trim()));
+				legalFormsAbbr.add(toAscii(abbr.trim()).replace(/[., ()]/g, ''));
 			}
 		});
 
@@ -167,20 +243,20 @@ async function collectLegalForms (legalFormsData: CsvLegalFormRow[], minSynthesi
 
 		abbrTransliterated.split(';').forEach((abbr) => {
 			if (abbr.trim()) {
-				legalFormsAbbr.add(toAscii(abbr.trim()));
+				legalFormsAbbr.add(toAscii(abbr.trim()).replace(/[., ()]/g, ''));
 			}
 		});
 
 		const nameLocal = row.entityLegalFormNameLocal.trim().toLowerCase();
 
 		if (nameLocal) {
-			legalFormsName.add(toAscii(nameLocal));
+			legalFormsName.add(toAscii(nameLocal).replace(/[., ()]/g, ''));
 
 			if (!abbrLocal) {
 				const abbrParts = nameLocal.split(' ').filter(is.truthy);
 
 				if (abbrParts.length >= minSynthesizedAbbreviationLength) {
-					legalFormsAbbr.add(toAscii(abbrParts.map(w => `${w[0]}.`).join('')));
+					legalFormsAbbr.add(toAscii(abbrParts.map(w => `${w[0]}`).join('')).replace(/[., ()]/g, ''));
 				}
 			}
 		}
@@ -188,13 +264,13 @@ async function collectLegalForms (legalFormsData: CsvLegalFormRow[], minSynthesi
 		const nameTransliterated = row.entityLegalFormNameTransliterated.trim().toLowerCase();
 
 		if (nameTransliterated) {
-			legalFormsName.add(toAscii(nameTransliterated.trim()));
+			legalFormsName.add(toAscii(nameTransliterated.trim()).replace(/[., ()]/g, ''));
 		}
 	});
 
 	ADDITIONAL_LEGAL_FORMS.forEach(({ name, abbr }) => {
-		legalFormsName.add(ascii(name).toLowerCase());
-		abbr.forEach(a => legalFormsAbbr.add(ascii(a).toLowerCase()));
+		legalFormsName.add(ascii(name).toLowerCase().replace(/[., ()]/g, ''));
+		abbr.forEach(a => legalFormsAbbr.add(ascii(a).toLowerCase().replace(/[., ()]/g, '')));
 	});
 
 	// Convert to array and sort by length (longest first) to avoid partial matches

--- a/test/tests/unit/geoip/legal-name-normalization.test.ts
+++ b/test/tests/unit/geoip/legal-name-normalization.test.ts
@@ -28,6 +28,35 @@ describe('legal-name-normalization', () => {
 
 		// Already normalized or no legal suffix
 		{ original: 'AkileCloud Network', expected: 'AkileCloud Network' },
+
+		{ original: 'Hangzhou Alibaba Advertising Co.,Ltd.', expected: 'Hangzhou Alibaba Advertising' },
+		{ original: 'Shanghai Mobile Communications Co.,Ltd.', expected: 'Shanghai Mobile Communications' },
+		{ original: 'Alibaba (US) Technology Co., Ltd.', expected: 'Alibaba (US) Technology' },
+		{ original: 'Siamdata Communication Co.,Ltd.', expected: 'Siamdata Communication' },
+		{ original: 'China Mobile Communications Group Co., Ltd.', expected: 'China Mobile Communications Group' },
+		{ original: 'Rackzar  (Pty) Ltd', expected: 'Rackzar' },
+		{ original: 'Henan Mobile Communications Co. Ltd', expected: 'Henan Mobile Communications' },
+		{ original: 'Web Squad Connect (Pty) Ltd', expected: 'Web Squad Connect' },
+		{ original: 'Web Dadeh Paydar Co (Ltd)', expected: 'Web Dadeh Paydar Co' },
+		{ original: 'Jinx Co. Limited', expected: 'Jinx' },
+
+		{ original: 'DA International Group Ltd.', expected: 'DA International Group' },
+		{ original: 'OKB PROGRESS LLC', expected: 'OKB PROGRESS' },
+		{ original: 'Limited Company Information and Consulting Agency', expected: 'Limited Company Information and Consulting Agency' },
+		{ original: 'IP Vendetta Inc.', expected: 'IP Vendetta' },
+		{ original: 'IP ServerOne Solutions Sdn Bhd', expected: 'IP ServerOne Solutions' },
+		{ original: 'PT. Elektrindo Data Nusantara', expected: 'Elektrindo Data Nusantara' },
+
+		{ original: 'Microchip s.c. W. Wrodarczyk, A. Kossowski', expected: 'Microchip s.c. W. Wrodarczyk, A. Kossowski' },
+		{ original: 'Tencent Building, Kejizhongyi Avenue', expected: 'Tencent Building, Kejizhongyi Avenue' },
+		{ original: 'Hollander & Jacobsen Ug (Haftungsbeschraenkt)', expected: 'Hollander & Jacobsen' },
+		{ original: 'eServer s.r.o.', expected: 'eServer' },
+		{ original: 'synlinq.de', expected: 'synlinq.de' },
+		{ original: 'ServerPoint.com', expected: 'ServerPoint.com' },
+		{ original: 'S.C. INFOTECH-GRUP S.R.L.', expected: 'S.C. INFOTECH-GRUP' },
+		{ original: 'S.SETEVAYA SVYAZ, OOO', expected: 'S.SETEVAYA SVYAZ' },
+		{ original: 'TELECOMUNICACOES ALARCAO E FERNANDES LTDA - ME', expected: 'TELECOMUNICACOES ALARCAO E FERNANDES' },
+		{ original: 'M & R NETWORK LTDA - ME', expected: 'M & R NETWORK' },
 	];
 
 	for (const { original, expected } of cases) {

--- a/test/tests/unit/geoip/legal-name-normalization.test.ts
+++ b/test/tests/unit/geoip/legal-name-normalization.test.ts
@@ -60,6 +60,7 @@ describe('legal-name-normalization', () => {
 		{ original: 'M & R NETWORK LTDA-ME', expected: 'M & R NETWORK' },
 		{ original: 'BEIJING CBD TELECOM CO .LTD', expected: 'BEIJING CBD TELECOM' },
 		{ original: 'CENTRALES ELECTRICAS DE NARIÑO S.A. E.S.P', expected: 'CENTRALES ELECTRICAS DE NARIÑO' },
+		{ original: 'Orange Bank LLC', expected: 'Orange Bank' },
 		{ original: 'ACS', expected: 'ACS' },
 	];
 

--- a/test/tests/unit/geoip/legal-name-normalization.test.ts
+++ b/test/tests/unit/geoip/legal-name-normalization.test.ts
@@ -29,6 +29,7 @@ describe('legal-name-normalization', () => {
 		// Already normalized or no legal suffix
 		{ original: 'AkileCloud Network', expected: 'AkileCloud Network' },
 
+		// Additional cases
 		{ original: 'Hangzhou Alibaba Advertising Co.,Ltd.', expected: 'Hangzhou Alibaba Advertising' },
 		{ original: 'Shanghai Mobile Communications Co.,Ltd.', expected: 'Shanghai Mobile Communications' },
 		{ original: 'Alibaba (US) Technology Co., Ltd.', expected: 'Alibaba (US) Technology' },
@@ -37,7 +38,7 @@ describe('legal-name-normalization', () => {
 		{ original: 'Rackzar  (Pty) Ltd', expected: 'Rackzar' },
 		{ original: 'Henan Mobile Communications Co. Ltd', expected: 'Henan Mobile Communications' },
 		{ original: 'Web Squad Connect (Pty) Ltd', expected: 'Web Squad Connect' },
-		{ original: 'Web Dadeh Paydar Co (Ltd)', expected: 'Web Dadeh Paydar Co' },
+		{ original: 'Web Dadeh Paydar Co (Ltd)', expected: 'Web Dadeh Paydar' },
 		{ original: 'Jinx Co. Limited', expected: 'Jinx' },
 
 		{ original: 'DA International Group Ltd.', expected: 'DA International Group' },
@@ -56,7 +57,10 @@ describe('legal-name-normalization', () => {
 		{ original: 'S.C. INFOTECH-GRUP S.R.L.', expected: 'S.C. INFOTECH-GRUP' },
 		{ original: 'S.SETEVAYA SVYAZ, OOO', expected: 'S.SETEVAYA SVYAZ' },
 		{ original: 'TELECOMUNICACOES ALARCAO E FERNANDES LTDA - ME', expected: 'TELECOMUNICACOES ALARCAO E FERNANDES' },
-		{ original: 'M & R NETWORK LTDA - ME', expected: 'M & R NETWORK' },
+		{ original: 'M & R NETWORK LTDA-ME', expected: 'M & R NETWORK' },
+		{ original: 'BEIJING CBD TELECOM CO .LTD', expected: 'BEIJING CBD TELECOM' },
+		{ original: 'CENTRALES ELECTRICAS DE NARIÑO S.A. E.S.P', expected: 'CENTRALES ELECTRICAS DE NARIÑO' },
+		{ original: 'ACS', expected: 'ACS' },
 	];
 
 	for (const { original, expected } of cases) {

--- a/wallaby.js
+++ b/wallaby.js
@@ -22,12 +22,7 @@ export default function w (wallaby) {
 			'test/types.ts',
 			'package.json',
 			'knexfile.js',
-			'data/GCP_IP_RANGES.json',
-			'data/AWS_IP_RANGES.json',
-			'data/DOMAIN_BLACKLIST.json',
-			'data/IP_BLACKLIST.json',
-			'data/GEONAMES_CITIES.csv',
-			'data/LAST_API_COMMIT_HASH.txt',
+			'data/*',
 		],
 		tests: [
 			'test/tests/integration/**/*.test.ts',


### PR DESCRIPTION
- result is exactly the same as with regexes for all current probes
- speed with node v22.16.0:
```
tsx normalize-from-code.js probes.json
normalizeLegalName xTom GmbH: 0.123ms
normalizeLegalName STYLISH BY A&L SRL: 0.059ms
normalizeLegalName HostPapa: 0.007ms
normalizeLegalName HostPapa: 0.003ms
normalizeLegalName Odido Netherlands B.V.: 0.01ms
normalizeLegalName Odido Netherlands B.V.: 0.008ms
normalizeLegalName Eons Data Communications Limited: 0.068ms
normalizeLegalName AkileCloud Network: 0.011ms
normalizeLegalName GLOBAL INTERNET SOLUTIONS LLC: 0.009ms
normalizeLegalName Oracle Corporation: 0.004ms
normalizeLegalName Terabix: 0.006ms
normalizeLegalName Hetzner Online GmbH: 0.004ms
...
```