### PR TITLE
fix: update alt IP country validation logic

### DIFF
--- a/src/lib/alt-ips-client.ts
+++ b/src/lib/alt-ips-client.ts
@@ -102,7 +102,7 @@ export class AltIpsClient {
 		try {
 			const altIpInfo = await this.geoIpClient.lookup(altIp);
 
-			if (!probe.location.allowedCountries.includes(altIpInfo.country)) {
+			if (!altIpInfo.allowedCountries.includes(probe.location.country)) {
 				logger.warn('Alt IP country doesn\'t match the probe country.', { altIp, altIpInfo, ...probeInfo });
 				return { isValid: false, reason: 'Alt IP country doesn\'t match the probe country.' };
 			}

--- a/test/tests/integration/adoption-code.test.ts
+++ b/test/tests/integration/adoption-code.test.ts
@@ -33,7 +33,7 @@ describe('Adoption code', () => {
 		probe.emit('probe:alt-ips', [ [ ip, token ] ]);
 
 		// Wait until alt IP is synced in synced-probe-list.ts.
-		await getProbeByIp('97.247.234.249', { allowStale: false });
+		while (!await getProbeByIp('97.247.234.249', { allowStale: false })) { /* wait */ }
 	});
 
 	afterEach(async () => {


### PR DESCRIPTION
`probe.location.country` is more likely to be correct, so it makes more sense to check in this direction.