### PR TITLE
refactor: replace `Probe` type with `ServerProbe` and `SocketProbe`

### DIFF
--- a/src/adoption/adoption-token.ts
+++ b/src/adoption/adoption-token.ts
@@ -1,7 +1,7 @@
 import type { Knex } from 'knex';
 import { scopedLogger } from '../lib/logger.js';
 import { client } from '../lib/sql/client.js';
-import { Probe } from '../probe/types.js';
+import { SocketProbe } from '../probe/types.js';
 import { ServerSocket, adoptedProbes } from '../lib/ws/server.js';
 import { AdoptedProbes } from '../lib/override/adopted-probes.js';
 import got from 'got';
@@ -100,7 +100,7 @@ export class AdoptionToken {
 		return user;
 	}
 
-	async validateToken (token: string, probe: Probe): Promise<{ message: string | null; level?: 'info' | 'warn' }> {
+	async validateToken (token: string, probe: SocketProbe): Promise<{ message: string | null; level?: 'info' | 'warn' }> {
 		const user = await this.getUserByToken(token);
 
 		if (!user) {
@@ -123,7 +123,7 @@ export class AdoptionToken {
 		return { message: 'Probe successfully adopted by token.' };
 	}
 
-	private async fetchDProbe (probe: Probe) {
+	private async fetchDProbe (probe: SocketProbe) {
 		const dProbe = await this.sql(PROBES_TABLE)
 			.where({ uuid: probe.uuid })
 			.orWhere({ ip: probe.ipAddress })
@@ -133,7 +133,7 @@ export class AdoptionToken {
 		return dProbe || null;
 	}
 
-	private async adoptProbe (probe: Probe, user: User) {
+	private async adoptProbe (probe: SocketProbe, user: User) {
 		await got.put(`${directusUrl}/adoption-code/adopt-by-token`, {
 			json: {
 				probe: AdoptedProbes.formatProbeAsDProbe(probe),

--- a/src/adoption/sender.ts
+++ b/src/adoption/sender.ts
@@ -1,7 +1,7 @@
 import createHttpError from 'http-errors';
 import { getProbeByIp as serverGetProbeByIp, getWsServer, PROBES_NAMESPACE, type WsServer } from '../lib/ws/server.js';
 import type { AdoptionCodeRequest } from './types.js';
-import type { Probe } from '../probe/types.js';
+import type { ServerProbe } from '../probe/types.js';
 
 export class CodeSender {
 	constructor (
@@ -21,7 +21,7 @@ export class CodeSender {
 		return probe;
 	}
 
-	private sendToProbe (probe: Probe, code: string) {
+	private sendToProbe (probe: ServerProbe, code: string) {
 		this.io.of(PROBES_NAMESPACE).to(probe.client).emit('probe:adoption:code', {
 			code,
 		});

--- a/src/lib/override/admin-data.ts
+++ b/src/lib/override/admin-data.ts
@@ -2,7 +2,7 @@
 import ipaddr from 'ipaddr.js';
 import type { Knex } from 'knex';
 import config from 'config';
-import type { Probe, ProbeLocation } from '../../probe/types.js';
+import type { ProbeLocation, SocketProbe } from '../../probe/types.js';
 import { normalizeFromPublicName } from '../geoip/utils.js';
 import { getContinentByCountry, getRegionByCountry } from '../location/location.js';
 import { scopedLogger } from '../logger.js';
@@ -88,7 +88,7 @@ export class AdminData {
 		}
 	}
 
-	getUpdatedProbes (probes: Probe[]) {
+	getUpdatedProbes (probes: SocketProbe[]) {
 		return probes.map((probe) => {
 			const updatedFields = this.getUpdatedFields(probe);
 
@@ -106,7 +106,7 @@ export class AdminData {
 		});
 	}
 
-	getUpdatedLocation (probe: Probe): ProbeLocation | null {
+	getUpdatedLocation (probe: SocketProbe): ProbeLocation | null {
 		const updatedFields = this.getUpdatedFields(probe);
 
 		if (!updatedFields) {
@@ -119,7 +119,7 @@ export class AdminData {
 		};
 	}
 
-	private getUpdatedFields (probe: Probe): UpdatedFields | null {
+	private getUpdatedFields (probe: SocketProbe): UpdatedFields | null {
 		const ips = [ probe.ipAddress, ...probe.altIpAddresses ];
 
 		if (ips.some(ip => this.ipsToUpdatedFieldsCache.get(ip) === undefined)) {
@@ -131,7 +131,7 @@ export class AdminData {
 		return this.ipsToUpdatedFieldsCache.get(probe.ipAddress)!;
 	}
 
-	findUpdatedFields (probe: Probe): UpdatedFields | null {
+	findUpdatedFields (probe: SocketProbe): UpdatedFields | null {
 		const parsedIps = [ probe.ipAddress, ...probe.altIpAddresses ].map(this.parseIp);
 
 		for (const [ range, updatedFields ] of this.rangesToUpdatedFields) {

--- a/src/lib/override/probe-override.ts
+++ b/src/lib/override/probe-override.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { ExtendedProbeLocationWithOverrides, SocketProbe } from '../../probe/types.js';
 import type { AdoptedProbes } from './adopted-probes.js';
 import type { AdminData } from './admin-data.js';
 
@@ -20,17 +20,17 @@ export class ProbeOverride {
 		this.adminData.scheduleSync();
 	}
 
-	getUpdatedLocation (probe: Probe) {
+	getUpdatedLocation (probe: SocketProbe): ExtendedProbeLocationWithOverrides {
 		const adminLocation = this.adminData.getUpdatedLocation(probe);
 		const adoptedLocation = this.adoptedProbes.getUpdatedLocation(probe, adminLocation);
-		return { ...probe.location, ...adminLocation, ...adoptedLocation };
+		return { ...probe.location, ...adminLocation, ...adoptedLocation, hasOverridesApplied: true };
 	}
 
-	addAdminData (probes: Probe[]) {
+	addAdminData (probes: SocketProbe[]) {
 		return this.adminData.getUpdatedProbes(probes);
 	}
 
-	addAdoptedData (probes: Probe[]) {
+	addAdoptedData (probes: SocketProbe[]) {
 		return this.adoptedProbes.getUpdatedProbes(probes);
 	}
 }

--- a/src/lib/ws/server.ts
+++ b/src/lib/ws/server.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { Namespace, type RemoteSocket, Server, Socket } from 'socket.io';
 import { createShardedAdapter } from '@socket.io/redis-adapter';
-import type { Probe } from '../../probe/types.js';
+import type { ServerProbe, SocketProbe } from '../../probe/types.js';
 import { getRedisClient } from '../redis/client.js';
 import { SyncedProbeList } from './synced-probe-list.js';
 import { client } from '../sql/client.js';
@@ -18,7 +18,7 @@ export interface DefaultEventsMap {
 }
 
 export type SocketData = {
-	probe: Probe;
+	probe: SocketProbe;
 };
 
 export type RemoteProbeSocket = RemoteSocket<DefaultEventsMap, SocketData>;
@@ -83,7 +83,7 @@ export const fetchRawSockets = async () => {
 	return io.of(PROBES_NAMESPACE).fetchSockets();
 };
 
-export const getProbesWithAdminData = (): Probe[] => {
+export const getProbesWithAdminData = (): SocketProbe[] => {
 	if (!syncedProbeList) {
 		throw new Error('WS server not initialized yet');
 	}
@@ -91,7 +91,7 @@ export const getProbesWithAdminData = (): Probe[] => {
 	return syncedProbeList.getProbesWithAdminData();
 };
 
-export const fetchProbes = async ({ allowStale = true } = {}): Promise<Probe[]> => {
+export const fetchProbes = async ({ allowStale = true } = {}): Promise<ServerProbe[]> => {
 	if (!syncedProbeList) {
 		throw new Error('WS server not initialized yet');
 	}
@@ -99,7 +99,7 @@ export const fetchProbes = async ({ allowStale = true } = {}): Promise<Probe[]> 
 	return allowStale ? syncedProbeList.getProbes() : syncedProbeList.fetchProbes();
 };
 
-export const getProbeByIp = async (ip: string, { allowStale = true } = {}): Promise<Probe | null> => {
+export const getProbeByIp = async (ip: string, { allowStale = true } = {}): Promise<ServerProbe | null> => {
 	if (!syncedProbeList) {
 		throw new Error('WS server not initialized yet');
 	}
@@ -111,7 +111,7 @@ export const getProbeByIp = async (ip: string, { allowStale = true } = {}): Prom
 	return syncedProbeList.getProbeByIp(ip);
 };
 
-export const onProbesUpdate = (callback: (probes: Probe[]) => void): (() => void) => {
+export const onProbesUpdate = (callback: (probes: ServerProbe[]) => void): (() => void) => {
 	const handler = () => callback(syncedProbeList.getProbes());
 	ee.on(E_PROBE_UPDATE, handler);
 

--- a/src/measurement/handler/ack.ts
+++ b/src/measurement/handler/ack.ts
@@ -1,6 +1,6 @@
-import type { Probe } from '../../probe/types.js';
+import type { SocketProbe } from '../../probe/types.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const handleMeasurementAck = (_probe: Probe) => async (_data: null, ack: () => void): Promise<void> => {
+export const handleMeasurementAck = (_probe: SocketProbe) => async (_data: null, ack: () => void): Promise<void> => {
 	ack();
 };

--- a/src/measurement/handler/progress.ts
+++ b/src/measurement/handler/progress.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { SocketProbe } from '../../probe/types.js';
 import type { MeasurementProgressMessage } from '../types.js';
 import { getMeasurementRunner } from '../runner.js';
 import { getProbeValidator } from '../../lib/probe-validator.js';
@@ -6,7 +6,7 @@ import { progressSchema } from '../schema/probe-response-schema.js';
 
 const runner = getMeasurementRunner();
 
-export const handleMeasurementProgress = (probe: Probe) => async (data: MeasurementProgressMessage): Promise<void> => {
+export const handleMeasurementProgress = (probe: SocketProbe) => async (data: MeasurementProgressMessage): Promise<void> => {
 	const validation = progressSchema.validate(data);
 
 	if (validation.error) {

--- a/src/measurement/handler/request.ts
+++ b/src/measurement/handler/request.ts
@@ -1,8 +1,8 @@
-import type { Probe } from '../../probe/types.js';
+import type { SocketProbe } from '../../probe/types.js';
 import { getProbeValidator } from '../../lib/probe-validator.js';
 import { MeasurementRequestMessage } from '../types.js';
 
-export const listenMeasurementRequest = (probe: Probe) => (event: string, data: unknown) => {
+export const listenMeasurementRequest = (probe: SocketProbe) => (event: string, data: unknown) => {
 	if (event !== 'probe:measurement:request') {
 		return;
 	}

--- a/src/measurement/handler/result.ts
+++ b/src/measurement/handler/result.ts
@@ -1,4 +1,4 @@
-import type { Probe } from '../../probe/types.js';
+import type { SocketProbe } from '../../probe/types.js';
 import type { MeasurementResultMessage } from '../types.js';
 import { getMeasurementRunner } from '../runner.js';
 import { getProbeValidator } from '../../lib/probe-validator.js';
@@ -6,7 +6,7 @@ import { resultSchema } from '../schema/probe-response-schema.js';
 
 const runner = getMeasurementRunner();
 
-export const handleMeasurementResult = (probe: Probe) => async (data: MeasurementResultMessage): Promise<void> => {
+export const handleMeasurementResult = (probe: SocketProbe) => async (data: MeasurementResultMessage): Promise<void> => {
 	await getProbeValidator().validateProbe(data.measurementId, data.testId, probe.uuid);
 
 	const validation = resultSchema.validate(data);

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -4,7 +4,7 @@ import createHttpError from 'http-errors';
 import apmAgent from 'elastic-apm-node';
 import { getWsServer, PROBES_NAMESPACE } from '../lib/ws/server.js';
 import { getProbeRouter, type ProbeRouter } from '../probe/router.js';
-import type { Probe } from '../probe/types.js';
+import type { ServerProbe } from '../probe/types.js';
 import { captureSpan, getMetricsAgent, type MetricsAgent } from '../lib/metrics.js';
 import type { MeasurementStore } from './store.js';
 import { getMeasurementStore } from './store.js';
@@ -59,7 +59,7 @@ export class MeasurementRunner {
 		}
 	}
 
-	private sendToProbes (measurementId: string, onlineProbesMap: Map<number, Probe>, request: MeasurementRequest) {
+	private sendToProbes (measurementId: string, onlineProbesMap: Map<number, ServerProbe>, request: MeasurementRequest) {
 		let inProgressTests = 0;
 		const maxInProgressTests = config.get<number>('measurement.maxInProgressTests');
 		onlineProbesMap.forEach((probe, index) => {

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -3,7 +3,7 @@ import Bluebird from 'bluebird';
 import config from 'config';
 import _ from 'lodash';
 import cryptoRandomString from 'crypto-random-string';
-import type { OfflineProbe, Probe } from '../probe/types.js';
+import type { OfflineProbe, ServerProbe } from '../probe/types.js';
 import { scopedLogger } from '../lib/logger.js';
 import type { MeasurementRecord, MeasurementResult, MeasurementRequest, MeasurementProgressMessage, RequestType, MeasurementResultMessage } from './types.js';
 import { getDefaults } from './schema/utils.js';
@@ -60,7 +60,7 @@ export class MeasurementStore {
 		return ips || [];
 	}
 
-	async createMeasurement (request: MeasurementRequest, onlineProbesMap: Map<number, Probe>, allProbes: (Probe | OfflineProbe)[]): Promise<string> {
+	async createMeasurement (request: MeasurementRequest, onlineProbesMap: Map<number, ServerProbe>, allProbes: (ServerProbe | OfflineProbe)[]): Promise<string> {
 		const id = cryptoRandomString({ length: 16, type: 'alphanumeric' });
 		const key = getMeasurementKey(id);
 		const startTime = new Date();
@@ -191,7 +191,7 @@ export class MeasurementStore {
 		return subtractObjects(measurement, defaults) as Partial<MeasurementRecord>;
 	}
 
-	probesToResults (probes: (Probe | OfflineProbe)[], type: RequestType) {
+	probesToResults (probes: (ServerProbe | OfflineProbe)[], type: RequestType) {
 		const results = probes.map(probe => ({
 			probe: {
 				continent: probe.location.continent,
@@ -212,7 +212,7 @@ export class MeasurementStore {
 		return results;
 	}
 
-	getInitialResult (type: RequestType, status: Probe['status'] | OfflineProbe['status']) {
+	getInitialResult (type: RequestType, status: ServerProbe['status'] | OfflineProbe['status']) {
 		if (status === 'offline') {
 			return {
 				status: 'offline',

--- a/src/probe/builder.ts
+++ b/src/probe/builder.ts
@@ -7,13 +7,13 @@ import { ProbeError } from '../lib/probe-error.js';
 import { getGeoIpClient, LocationInfo } from '../lib/geoip/client.js';
 import getProbeIp from '../lib/get-probe-ip.js';
 import { getRegion } from '../lib/cloud-ip-ranges.js';
-import type { ExtendedProbeLocation, Probe, Tag } from './types.js';
+import type { ExtendedProbeLocation, SocketProbe, Tag } from './types.js';
 import { probeIpLimit } from '../lib/ws/server.js';
 import { fakeLookup } from '../lib/geoip/fake-client.js';
 import { getGroupingKey, normalizeTags } from '../lib/geoip/utils.js';
 import { isIpBlocked } from '../lib/blocked-ip-ranges.js';
 
-export const buildProbe = async (socket: Socket): Promise<Probe> => {
+export const buildProbe = async (socket: Socket): Promise<SocketProbe> => {
 	const version = String(socket.handshake.query['version']);
 	const nodeVersion = String(socket.handshake.query['nodeVersion']);
 	const totalMemory = Number(socket.handshake.query['totalMemory']);

--- a/src/probe/handler/alt-ips.ts
+++ b/src/probe/handler/alt-ips.ts
@@ -1,8 +1,8 @@
 import { getAltIpsClient } from '../../lib/alt-ips-client.js';
 import { altIpsSchema } from '../schema/probe-response-schema.js';
-import type { Probe } from '../types.js';
+import type { SocketProbe } from '../types.js';
 
-export const handleAltIps = (probe: Probe) => async (ipsToTokens: [string, string][], callback: (result: { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> }) => void) => {
+export const handleAltIps = (probe: SocketProbe) => async (ipsToTokens: [string, string][], callback: (result: { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> }) => void) => {
 	const validation = altIpsSchema.validate(ipsToTokens);
 
 	if (validation.error) {

--- a/src/probe/handler/dns.ts
+++ b/src/probe/handler/dns.ts
@@ -1,7 +1,7 @@
 import { dnsSchema } from '../schema/probe-response-schema.js';
-import type { Probe } from '../types.js';
+import type { SocketProbe } from '../types.js';
 
-export const handleDnsUpdate = (probe: Probe) => (list: string[]): void => {
+export const handleDnsUpdate = (probe: SocketProbe) => (list: string[]): void => {
 	const validation = dnsSchema.validate(list);
 
 	if (validation.error) {

--- a/src/probe/handler/ip-version.ts
+++ b/src/probe/handler/ip-version.ts
@@ -1,7 +1,7 @@
-import type { Probe } from '../types.js';
+import type { SocketProbe } from '../types.js';
 import { ipVersionSchema } from '../schema/probe-response-schema.js';
 
-export const handleIsIPv4SupportedUpdate = (probe: Probe) => (isIPv4Supported: boolean): void => {
+export const handleIsIPv4SupportedUpdate = (probe: SocketProbe) => (isIPv4Supported: boolean): void => {
 	const validation = ipVersionSchema.validate(isIPv4Supported);
 
 	if (validation.error) {
@@ -11,7 +11,7 @@ export const handleIsIPv4SupportedUpdate = (probe: Probe) => (isIPv4Supported: b
 	probe.isIPv4Supported = validation.value;
 };
 
-export const handleIsIPv6SupportedUpdate = (probe: Probe) => (isIPv6Supported: boolean): void => {
+export const handleIsIPv6SupportedUpdate = (probe: SocketProbe) => (isIPv6Supported: boolean): void => {
 	const validation = ipVersionSchema.validate(isIPv6Supported);
 
 	if (validation.error) {

--- a/src/probe/handler/logs.ts
+++ b/src/probe/handler/logs.ts
@@ -1,4 +1,4 @@
-import { Probe } from '../types.js';
+import { SocketProbe } from '../types.js';
 import { logMessageSchema } from '../schema/probe-response-schema.js';
 import { getProbeLogStorage } from '../logs-storage.js';
 
@@ -14,7 +14,7 @@ export type LogMessage = {
 
 const probeLogStorage = getProbeLogStorage();
 
-export const handleNewLogs = (probe: Probe) => async (logMessage: LogMessage, callback?: (arg: string) => void) => {
+export const handleNewLogs = (probe: SocketProbe) => async (logMessage: LogMessage, callback?: (arg: string) => void) => {
 	const validation = logMessageSchema.validate(logMessage);
 
 	if (validation.error) {

--- a/src/probe/handler/stats.ts
+++ b/src/probe/handler/stats.ts
@@ -1,7 +1,7 @@
-import type { Probe, ProbeStats } from '../types.js';
+import type { SocketProbe, ProbeStats } from '../types.js';
 import { statsSchema } from '../schema/probe-response-schema.js';
 
-export const handleStatsReport = (probe: Probe) => (report: ProbeStats): void => {
+export const handleStatsReport = (probe: SocketProbe) => (report: ProbeStats): void => {
 	const validation = statsSchema.validate(report);
 
 	if (validation.error) {

--- a/src/probe/handler/status.ts
+++ b/src/probe/handler/status.ts
@@ -1,7 +1,7 @@
 import { statusSchema } from '../schema/probe-response-schema.js';
-import type { Probe } from '../types.js';
+import type { SocketProbe } from '../types.js';
 
-export const handleStatusUpdate = (probe: Probe) => (status: Probe['status']) => {
+export const handleStatusUpdate = (probe: SocketProbe) => (status: SocketProbe['status']) => {
 	const validation = statusSchema.validate(status);
 
 	if (validation.error) {

--- a/src/probe/route/get-probes.ts
+++ b/src/probe/route/get-probes.ts
@@ -1,6 +1,6 @@
 import type { DefaultContext, DefaultState, ParameterizedContext } from 'koa';
 import type Router from '@koa/router';
-import type { Probe } from '../types.js';
+import type { ServerProbe } from '../types.js';
 import { fetchProbes } from '../../lib/ws/server.js';
 
 const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & Router.RouterParamContext>): Promise<void> => {
@@ -11,7 +11,7 @@ const handle = async (ctx: ParameterizedContext<DefaultState, DefaultContext & R
 		probes = probes.filter(probe => probe.status === 'ready');
 	}
 
-	ctx.body = probes.map((probe: Probe) => ({
+	ctx.body = probes.map((probe: ServerProbe) => ({
 		status: isAdmin ? probe.status : undefined,
 		version: probe.version,
 		isIPv4Supported: isAdmin ? probe.isIPv4Supported : undefined,

--- a/src/probe/schema/probe-response-schema.ts
+++ b/src/probe/schema/probe-response-schema.ts
@@ -1,8 +1,8 @@
 import Joi from 'joi';
-import { ServerProbe, ProbeStats } from '../types.js';
+import { SocketProbe, ProbeStats } from '../types.js';
 import { globalIpOptions } from '../../measurement/schema/utils.js';
 
-export const statusSchema = Joi.string<ServerProbe['status']>().valid('initializing', 'ready', 'unbuffer-missing', 'ping-test-failed', 'sigterm').required();
+export const statusSchema = Joi.string<SocketProbe['status']>().valid('initializing', 'ready', 'unbuffer-missing', 'ping-test-failed', 'sigterm').required();
 
 export const ipVersionSchema = Joi.boolean().required();
 

--- a/src/probe/schema/probe-response-schema.ts
+++ b/src/probe/schema/probe-response-schema.ts
@@ -1,8 +1,8 @@
 import Joi from 'joi';
-import { Probe, ProbeStats } from '../types.js';
+import { ServerProbe, ProbeStats } from '../types.js';
 import { globalIpOptions } from '../../measurement/schema/utils.js';
 
-export const statusSchema = Joi.string<Probe['status']>().valid('initializing', 'ready', 'unbuffer-missing', 'ping-test-failed', 'sigterm').required();
+export const statusSchema = Joi.string<ServerProbe['status']>().valid('initializing', 'ready', 'unbuffer-missing', 'ping-test-failed', 'sigterm').required();
 
 export const ipVersionSchema = Joi.boolean().required();
 

--- a/src/probe/types.ts
+++ b/src/probe/types.ts
@@ -17,6 +17,10 @@ export type ExtendedProbeLocation = ProbeLocation & {
 	groupingKey: string;
 };
 
+export type ExtendedProbeLocationWithOverrides = ExtendedProbeLocation & {
+	hasOverridesApplied: true;
+};
+
 export type ProbeStats = {
 	cpu: {
 		load: Array<{
@@ -41,7 +45,7 @@ export type Tag = {
 
 export type ProbeIndex = [ string[], string[], string[], string[], string[], string[], string[], string[], string[], string[], string[], string[], string[], string[], string[], string[] ];
 
-export type Probe = {
+type Probe = {
 	status: 'initializing' | 'ready' | 'unbuffer-missing' | 'ping-test-failed' | 'sigterm';
 	isIPv4Supported: boolean;
 	isIPv6Supported: boolean;
@@ -55,20 +59,28 @@ export type Probe = {
 	ipAddress: string;
 	altIpAddresses: string[];
 	host: string;
-	location: ExtendedProbeLocation;
+	location: ProbeLocation;
 	index: ProbeIndex;
 	resolvers: string[];
 	tags: Tag[];
 	normalizedTags: Tag[];
 	stats: ProbeStats;
 	hostInfo: HostInfo;
-	owner?: { id: string };
 	adoptionToken: string | null;
 };
 
 type Modify<T, Fields> = Omit<T, keyof Fields> & Fields;
 
-export type OfflineProbe = Modify<Probe, {
+export type SocketProbe = Modify<Probe, {
+	location: ExtendedProbeLocation;
+}>;
+
+export type ServerProbe = Readonly<Modify<Probe, {
+	location: ExtendedProbeLocationWithOverrides;
+	owner?: { id: string };
+}>>;
+
+export type OfflineProbe = Modify<SocketProbe, {
 	status: 'offline';
 	client: null;
 	version: null;

--- a/test/tests/integration/adoption-code.test.ts
+++ b/test/tests/integration/adoption-code.test.ts
@@ -30,7 +30,9 @@ describe('Adoption code', () => {
 			.set('X-Forwarded-For', '97.247.234.249')
 			.send();
 
-		probe.emit('probe:alt-ips', [ [ ip, token ] ]);
+		probe.emit('probe:alt-ips', [ [ ip, token ] ], (result: { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> }) => {
+			expect(result).to.deep.equal({ addedAltIps: [ ip ], rejectedIpsToReasons: {} });
+		});
 
 		// Wait until alt IP is synced in synced-probe-list.ts.
 		while (!await getProbeByIp('97.247.234.249', { allowStale: false })) { /* wait */ }

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -81,6 +81,7 @@ describe('Create measurement request', () => {
 				normalizedNetwork: 'the constant company',
 				allowedCountries: [ 'US' ],
 				groupingKey: 'US-TX-dallas-20004',
+				hasOverridesApplied: true,
 			},
 		]);
 

--- a/test/tests/unit/alt-ips.test.ts
+++ b/test/tests/unit/alt-ips.test.ts
@@ -1,12 +1,12 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { AltIpsClient } from '../../../src/lib/alt-ips-client.js';
-import type { Probe } from '../../../src/probe/types.js';
+import type { ServerProbe } from '../../../src/probe/types.js';
 
 describe('AltIpsClient', () => {
 	const sandbox = sinon.createSandbox();
 
-	let probe: Probe;
+	let probe: ServerProbe;
 	let redis: any;
 	let geoIpClient: any;
 	let altIps: AltIpsClient;
@@ -20,7 +20,7 @@ describe('AltIpsClient', () => {
 				country: 'IT',
 				allowedCountries: [ 'IT' ],
 			},
-		} as unknown as Probe;
+		} as unknown as ServerProbe;
 
 
 		redis = {

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -5,13 +5,13 @@ import * as td from 'testdouble';
 import { MeasurementStore } from '../../../../src/measurement/store.js';
 import { ProbeRouter } from '../../../../src/probe/router.js';
 import { MetricsAgent } from '../../../../src/lib/metrics.js';
-import type { Probe } from '../../../../src/probe/types.js';
+import type { ServerProbe } from '../../../../src/probe/types.js';
 import type { MeasurementRunner } from '../../../../src/measurement/runner.js';
 import type { MeasurementRecord, MeasurementResultMessage } from '../../../../src/measurement/types.js';
 import createHttpError from 'http-errors';
 import type { ExtendedContext } from '../../../../src/types.js';
 
-const getProbe = (id: number) => ({ client: id } as unknown as Probe);
+const getProbe = (id: number) => ({ client: id } as unknown as ServerProbe);
 
 const req = {
 	headers: {

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import relativeDayUtc from 'relative-day-utc';
 import type { MeasurementStore } from '../../../../src/measurement/store.js';
-import type { OfflineProbe, Probe } from '../../../../src/probe/types.js';
+import type { OfflineProbe, ServerProbe } from '../../../../src/probe/types.js';
 import type { PingResult } from '../../../../src/measurement/types.js';
 
 const getProbe = (id: string, ip: string) => ({
@@ -24,7 +24,7 @@ const getProbe = (id: string, ip: string) => ({
 	},
 	tags: [],
 	resolvers: [],
-} as unknown as Probe);
+} as unknown as ServerProbe);
 
 const getOfflineProbe = (id: string, ip: string) => ({
 	...getProbe(id, ip),

--- a/test/tests/unit/override/admin-data.test.ts
+++ b/test/tests/unit/override/admin-data.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { AdminData } from '../../../../src/lib/override/admin-data.js';
 import type { Knex } from 'knex';
-import type { ServerProbe } from '../../../../src/probe/types.js';
+import type { SocketProbe } from '../../../../src/probe/types.js';
 
 describe('AdminData', () => {
 	const sandbox = sinon.createSandbox();
@@ -35,8 +35,8 @@ describe('AdminData', () => {
 
 		await adminData.syncDashboardData();
 		const updatedProbes = adminData.getUpdatedProbes([
-			{ ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
-			{ ipAddress: '2.2.2.2', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
+			{ ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe,
+			{ ipAddress: '2.2.2.2', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe,
 		]);
 
 		expect(updatedProbes[0]).to.deep.equal({
@@ -63,8 +63,8 @@ describe('AdminData', () => {
 
 		await adminData.syncDashboardData();
 		const updatedProbes = adminData.getUpdatedProbes([
-			{ ipAddress: '2.2.2.2', altIpAddresses: [ '1.1.1.1' ], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
-			{ ipAddress: '3.3.3.3', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
+			{ ipAddress: '2.2.2.2', altIpAddresses: [ '1.1.1.1' ], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe,
+			{ ipAddress: '3.3.3.3', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe,
 		]);
 
 		expect(updatedProbes[0]).to.deep.equal({
@@ -91,8 +91,8 @@ describe('AdminData', () => {
 
 		await adminData.syncDashboardData();
 		const updatedProbes = adminData.getUpdatedProbes([
-			{ ipAddress: '1.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
-			{ ipAddress: '2.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
+			{ ipAddress: '1.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe,
+			{ ipAddress: '2.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe,
 		]);
 
 		expect(updatedProbes[0]?.location.city).to.deep.equal('Bydgoszcz');
@@ -102,7 +102,7 @@ describe('AdminData', () => {
 	it('getUpdatedLocation should return null if no override found', async () => {
 		select.resolves([]);
 		await adminData.syncDashboardData();
-		const updatedLocation = adminData.getUpdatedLocation({ ipAddress: '1.1.1.1', altIpAddresses: [] } as unknown as ServerProbe);
+		const updatedLocation = adminData.getUpdatedLocation({ ipAddress: '1.1.1.1', altIpAddresses: [] } as unknown as SocketProbe);
 		expect(updatedLocation).to.equal(null);
 	});
 
@@ -112,10 +112,10 @@ describe('AdminData', () => {
 		const findUpdatedFieldsSpy = sandbox.spy(adminData, 'findUpdatedFields');
 		await adminData.syncDashboardData();
 
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
 		await adminData.syncDashboardData();
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
 		expect(findUpdatedFieldsSpy.callCount).to.equal(1);
 	});
 
@@ -126,12 +126,12 @@ describe('AdminData', () => {
 		const findUpdatedFieldsSpy = sandbox.spy(adminData, 'findUpdatedFields');
 		await adminData.syncDashboardData();
 
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
 		select.resolves([{ ...overrideLocation, date_updated: new Date('2024-04-10') }]);
 		await adminData.syncDashboardData();
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
 		expect(findUpdatedFieldsSpy.callCount).to.equal(2);
 	});
 
@@ -142,12 +142,12 @@ describe('AdminData', () => {
 		const findUpdatedFieldsSpy = sandbox.spy(adminData, 'findUpdatedFields');
 		await adminData.syncDashboardData();
 
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
 		select.resolves([]);
 		await adminData.syncDashboardData();
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as SocketProbe ]);
 		expect(findUpdatedFieldsSpy.callCount).to.equal(2);
 	});
 });

--- a/test/tests/unit/override/admin-data.test.ts
+++ b/test/tests/unit/override/admin-data.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { AdminData } from '../../../../src/lib/override/admin-data.js';
 import type { Knex } from 'knex';
-import type { Probe } from '../../../../src/probe/types.js';
+import type { ServerProbe } from '../../../../src/probe/types.js';
 
 describe('AdminData', () => {
 	const sandbox = sinon.createSandbox();
@@ -35,8 +35,8 @@ describe('AdminData', () => {
 
 		await adminData.syncDashboardData();
 		const updatedProbes = adminData.getUpdatedProbes([
-			{ ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe,
-			{ ipAddress: '2.2.2.2', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe,
+			{ ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
+			{ ipAddress: '2.2.2.2', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
 		]);
 
 		expect(updatedProbes[0]).to.deep.equal({
@@ -63,8 +63,8 @@ describe('AdminData', () => {
 
 		await adminData.syncDashboardData();
 		const updatedProbes = adminData.getUpdatedProbes([
-			{ ipAddress: '2.2.2.2', altIpAddresses: [ '1.1.1.1' ], location: { city: 'Miami', state: 'FL' } } as unknown as Probe,
-			{ ipAddress: '3.3.3.3', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe,
+			{ ipAddress: '2.2.2.2', altIpAddresses: [ '1.1.1.1' ], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
+			{ ipAddress: '3.3.3.3', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
 		]);
 
 		expect(updatedProbes[0]).to.deep.equal({
@@ -91,8 +91,8 @@ describe('AdminData', () => {
 
 		await adminData.syncDashboardData();
 		const updatedProbes = adminData.getUpdatedProbes([
-			{ ipAddress: '1.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe,
-			{ ipAddress: '2.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe,
+			{ ipAddress: '1.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
+			{ ipAddress: '2.200.210.220', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe,
 		]);
 
 		expect(updatedProbes[0]?.location.city).to.deep.equal('Bydgoszcz');
@@ -102,7 +102,7 @@ describe('AdminData', () => {
 	it('getUpdatedLocation should return null if no override found', async () => {
 		select.resolves([]);
 		await adminData.syncDashboardData();
-		const updatedLocation = adminData.getUpdatedLocation({ ipAddress: '1.1.1.1', altIpAddresses: [] } as unknown as Probe);
+		const updatedLocation = adminData.getUpdatedLocation({ ipAddress: '1.1.1.1', altIpAddresses: [] } as unknown as ServerProbe);
 		expect(updatedLocation).to.equal(null);
 	});
 
@@ -112,10 +112,10 @@ describe('AdminData', () => {
 		const findUpdatedFieldsSpy = sandbox.spy(adminData, 'findUpdatedFields');
 		await adminData.syncDashboardData();
 
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
 		await adminData.syncDashboardData();
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
 		expect(findUpdatedFieldsSpy.callCount).to.equal(1);
 	});
 
@@ -126,12 +126,12 @@ describe('AdminData', () => {
 		const findUpdatedFieldsSpy = sandbox.spy(adminData, 'findUpdatedFields');
 		await adminData.syncDashboardData();
 
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
 		select.resolves([{ ...overrideLocation, date_updated: new Date('2024-04-10') }]);
 		await adminData.syncDashboardData();
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
 		expect(findUpdatedFieldsSpy.callCount).to.equal(2);
 	});
 
@@ -142,12 +142,12 @@ describe('AdminData', () => {
 		const findUpdatedFieldsSpy = sandbox.spy(adminData, 'findUpdatedFields');
 		await adminData.syncDashboardData();
 
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
 		select.resolves([]);
 		await adminData.syncDashboardData();
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
-		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as Probe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
+		adminData.getUpdatedProbes([ { ipAddress: '1.1.1.1', altIpAddresses: [], location: { city: 'Miami', state: 'FL' } } as unknown as ServerProbe ]);
 		expect(findUpdatedFieldsSpy.callCount).to.equal(2);
 	});
 });

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import relativeDayUtc from 'relative-day-utc';
 import { AdoptedProbes, Row } from '../../../../src/lib/override/adopted-probes.js';
-import type { Probe } from '../../../../src/probe/types.js';
+import type { ServerProbe, SocketProbe } from '../../../../src/probe/types.js';
 
 describe('AdoptedProbes', () => {
 	const defaultAdoption: Row = {
@@ -42,7 +42,7 @@ describe('AdoptedProbes', () => {
 		region: 'Northern Europe',
 	};
 
-	const defaultConnectedProbe: Probe = {
+	const defaultConnectedProbe: SocketProbe = {
 		ipAddress: '1.1.1.1',
 		altIpAddresses: [],
 		uuid: '1-1-1-1-1',
@@ -394,7 +394,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB' ],
 				},
-			} as Probe,
+			} as ServerProbe,
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -498,7 +498,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB' ],
 				},
-			} as Probe,
+			} as ServerProbe,
 			{
 				ipAddress: '9.9.9.9',
 				altIpAddresses: [] as string[],
@@ -526,7 +526,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB' ],
 				},
-			} as Probe,
+			} as ServerProbe,
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -622,7 +622,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'IE' ],
 				},
-			} as Probe,
+			} as ServerProbe,
 			{
 				ipAddress: '9.9.9.9',
 				altIpAddresses: [] as string[],
@@ -650,7 +650,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'IE' ],
 				},
-			} as Probe,
+			} as ServerProbe,
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -748,7 +748,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB', 'PT' ],
 				},
-			} as Probe,
+			} as ServerProbe,
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -1035,6 +1035,7 @@ describe('AdoptedProbes', () => {
 			normalizedNetwork: 'amazon.com',
 			allowedCountries: [ 'IE', 'GL' ],
 			groupingKey: 'GL-null-nuuk-16509',
+			hasOverridesApplied: true,
 		});
 	});
 

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import relativeDayUtc from 'relative-day-utc';
 import { AdoptedProbes, Row } from '../../../../src/lib/override/adopted-probes.js';
-import type { ServerProbe, SocketProbe } from '../../../../src/probe/types.js';
+import type { SocketProbe } from '../../../../src/probe/types.js';
 
 describe('AdoptedProbes', () => {
 	const defaultAdoption: Row = {
@@ -394,7 +394,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB' ],
 				},
-			} as ServerProbe,
+			},
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -498,7 +498,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB' ],
 				},
-			} as ServerProbe,
+			},
 			{
 				ipAddress: '9.9.9.9',
 				altIpAddresses: [] as string[],
@@ -526,7 +526,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB' ],
 				},
-			} as ServerProbe,
+			},
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -622,7 +622,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'IE' ],
 				},
-			} as ServerProbe,
+			},
 			{
 				ipAddress: '9.9.9.9',
 				altIpAddresses: [] as string[],
@@ -650,7 +650,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'IE' ],
 				},
-			} as ServerProbe,
+			},
 		]);
 
 		await adoptedProbes.syncDashboardData();
@@ -748,7 +748,7 @@ describe('AdoptedProbes', () => {
 					network: 'The Constant Company',
 					allowedCountries: [ 'GB', 'PT' ],
 				},
-			} as ServerProbe,
+			},
 		]);
 
 		await adoptedProbes.syncDashboardData();

--- a/test/tests/unit/probe/router.test.ts
+++ b/test/tests/unit/probe/router.test.ts
@@ -587,7 +587,7 @@ describe('probe router', () => {
 
 		it('should find probe by normalizedCity value', async () => {
 			const probes: DeepPartial<ServerProbe[]> = [
-				await buildProbe(String(Date.now), location),
+				await buildProbe(String(Date.now()), location),
 			];
 
 			const locations: Location[] = [

--- a/test/tests/unit/ws/probe-logs.test.ts
+++ b/test/tests/unit/ws/probe-logs.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { handleNewLogs, LogMessage } from '../../../../src/probe/handler/logs.js';
 import { getMeasurementRedisClient } from '../../../../src/lib/redis/measurement-client.js';
-import type { Probe } from '../../../../src/probe/types.js';
+import type { ServerProbe } from '../../../../src/probe/types.js';
 
 describe('probe logs', () => {
 	let sandbox: sinon.SinonSandbox;
@@ -22,7 +22,7 @@ describe('probe logs', () => {
 	const mockProbe = {
 		uuid: PROBE_UUID,
 		ipAddress: '1.1.1.1',
-	} as Probe;
+	} as ServerProbe;
 
 	beforeEach(() => {
 		logHandler = handleNewLogs(mockProbe);

--- a/test/tests/unit/ws/synced-probe-list.test.ts
+++ b/test/tests/unit/ws/synced-probe-list.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import { type WsServerNamespace } from '../../../../src/lib/ws/server.js';
 import { SyncedProbeList } from '../../../../src/lib/ws/synced-probe-list.js';
-import type { Probe } from '../../../../src/probe/types.js';
+import type { ServerProbe, SocketProbe } from '../../../../src/probe/types.js';
 import { getRegionByCountry } from '../../../../src/lib/location/location.js';
 import { getRedisClient, RedisClient } from '../../../../src/lib/redis/client.js';
 import { ProbeOverride } from '../../../../src/lib/override/probe-override.js';
@@ -43,7 +43,7 @@ describe('SyncedProbeList', () => {
 			normalizedNetwork: 'abc',
 		},
 		stats: { cpu: { load: [{ usage: 0 }] }, jobs: { count: 0 } },
-	} as unknown as Probe);
+	} as unknown as ServerProbe);
 
 	const ioNamespace = {
 		local: {
@@ -114,9 +114,9 @@ describe('SyncedProbeList', () => {
 
 	it('emits stats in the message on change', async () => {
 		const sockets = [
-			{ data: { probe: getProbe('A') } },
-			{ data: { probe: getProbe('B') } },
-			{ data: { probe: getProbe('C') } },
+			{ data: { probe: getProbe('A') as SocketProbe } },
+			{ data: { probe: getProbe('B') as SocketProbe } },
+			{ data: { probe: getProbe('C') as SocketProbe } },
 		];
 
 		localFetchSocketsStub.resolves(sockets);
@@ -211,7 +211,7 @@ describe('SyncedProbeList', () => {
 			A: getProbe('A'),
 			B: getProbe('B'),
 			C: getProbe('C'),
-		} as unknown as Record<string, Probe>;
+		} as unknown as Record<string, ServerProbe>;
 
 		redisXRange.resolves([
 			{ id: '1-1', message: { n: 'remote', r: '1' } },
@@ -273,7 +273,7 @@ describe('SyncedProbeList', () => {
 		const probes = {
 			A: getProbe('A'),
 			B: getProbe('B'),
-		} as unknown as Record<string, Probe>;
+		} as unknown as Record<string, ServerProbe>;
 
 		redisXRange.resolves([
 			{ id: '1-1', message: { n: 'remote', r: '1' } },
@@ -301,9 +301,9 @@ describe('SyncedProbeList', () => {
 		const probe2 = getProbe('B');
 		const sockets = [{ data: { probe: probe1 } }, { data: { probe: probe2 } }];
 
-		const tags = [{ type: 'user', value: 'u-name:tag1' }] as Probe['tags'];
+		const tags = [{ type: 'user', value: 'u-name:tag1' }] as ServerProbe['tags'];
 
-		const adoptedData = { tags } as Probe;
+		const adoptedData = { tags } as ServerProbe;
 
 		localFetchSocketsStub.resolves(sockets);
 		probeOverride.addAdoptedData.reset();
@@ -337,7 +337,7 @@ describe('SyncedProbeList', () => {
 		const probe2 = getProbe('B');
 		const sockets = [{ data: { probe: probe1 } }, { data: { probe: probe2 } }];
 
-		const updatedProbe1 = { ...probe1, location: { ...probe1.location, city: 'Miami' } } as unknown as Probe;
+		const updatedProbe1 = { ...probe1, location: { ...probe1.location, city: 'Miami' } } as unknown as ServerProbe;
 
 		localFetchSocketsStub.resolves(sockets);
 		probeOverride.addAdminData.reset();


### PR DESCRIPTION
Splits the `Probe` type into:
 - `SocketProbe` - which represents the object that lives on the instance that handles the connection, serves as the data source in the synced probe list, and does not have the location overrides applied,
 - `ServerProbe` - which represents read-only information about the probe shared across servers, with the location overrides applied.

The goal is to prevent bugs where we use one instead of the other. Fixes a bug in `addAltIps()` where the location comparison was done on the raw data, not on the user-corrected location.