### PR TITLE
temp: log new dProbes to debug duplicated inserts

### DIFF
--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -312,6 +312,7 @@ export class AdoptedProbes {
 
 		await this.resolveIfError(this.deleteDProbes(dProbesToDelete));
 		await Bluebird.map(dProbeUpdates, ({ dProbe, update }) => this.resolveIfError(this.updateDProbe(dProbe, update)), { concurrency: 8 });
+		probesWithoutDProbe.length && logger.info('probesWithoutDProbe:', probesWithoutDProbe);
 		await Bluebird.map(probesWithoutDProbe, probe => this.resolveIfError(this.createDProbe(probe)), { concurrency: 8 });
 	}
 
@@ -703,6 +704,7 @@ export class AdoptedProbes {
 			dProbe[dProbeField] = probeValue;
 		});
 
+		logger.info('inserting dProbe:', dProbe);
 		await this.sql(DASH_PROBES_TABLE).insert(dProbe);
 	}
 


### PR DESCRIPTION
There are regular log messages in Elastic:
`insert into 'gp_probes' ... ER_DUP_ENTRY: Duplicate entry for key 'gp_probes_ip_unique'`.

Data in DB and inserted data are almost identical, so it should be duplicate insert. The reason may be 2 hosts that are running sync in parallel, but I am not sure. Adding temp logging to debug.