### PR TITLE
fix: ignore Parse Error on not full client request

### DIFF
--- a/src/lib/http/error-handler.ts
+++ b/src/lib/http/error-handler.ts
@@ -4,7 +4,7 @@ import { scopedLogger } from '../logger.js';
 const logger = scopedLogger('error-handler-http');
 
 export const errorHandler = (error: Error & { code?: string }, ctx: Context) => {
-	const ignore = [ 'ECONNABORTED', 'ECONNRESET', 'EPIPE' ];
+	const ignore = [ 'ECONNABORTED', 'ECONNRESET', 'EPIPE', 'HPE_INVALID_EOF_STATE' ];
 
 	if (error?.code && ignore.includes(error.code)) {
 		return;


### PR DESCRIPTION
This removes "Parse Error" logs from Elastic, which are caused by the client side.