### PR TITLE
feat: improve server shutdown handling

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -133,5 +133,5 @@ module.exports = {
 		},
 	},
 	reconnectProbesDelay: 2 * 60 * 1000,
-	sigtermDelay: 15000,
+	sigtermDelay: 25000,
 };

--- a/config/development.cjs
+++ b/config/development.cjs
@@ -30,4 +30,5 @@ module.exports = {
 		syncInterval: 5000,
 	},
 	reconnectProbesDelay: 0,
+	sigtermDelay: 0,
 };

--- a/src/health/route/get.ts
+++ b/src/health/route/get.ts
@@ -1,7 +1,7 @@
 import type { DefaultContext, DefaultState, ParameterizedContext } from 'koa';
 import type Router from '@koa/router';
 
-import termListener from '../term-listener.js';
+import termListener from '../../lib/term-listener.js';
 
 const handle = (ctx: ParameterizedContext<DefaultState, DefaultContext & Router.RouterParamContext>): void => {
 	const isTerminating = termListener.getIsTerminating();

--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -8,6 +8,7 @@ import { handleDnsUpdate } from '../../probe/handler/dns.js';
 import { handleStatsReport } from '../../probe/handler/stats.js';
 import { scopedLogger } from '../logger.js';
 import { probeOverride, getWsServer, PROBES_NAMESPACE, ServerSocket } from './server.js';
+import { health } from './middleware/health.js';
 import { probeMetadata } from './middleware/probe-metadata.js';
 import { errorHandler } from './helper/error-handler.js';
 import { subscribeWithHandler } from './helper/subscribe-handler.js';
@@ -22,6 +23,7 @@ const metricsAgent = getMetricsAgent();
 
 io
 	.of(PROBES_NAMESPACE)
+	.use(health)
 	.use(probeMetadata)
 	.on('connect', errorHandler(async (socket: ServerSocket) => {
 		const probe = socket.data.probe;

--- a/src/lib/ws/helper/reconnect-probes.ts
+++ b/src/lib/ws/helper/reconnect-probes.ts
@@ -7,11 +7,11 @@ const reconnectProbesDelay = config.get<number>('reconnectProbesDelay');
 
 const TIME_UNTIL_VM_BECOMES_HEALTHY = 8000;
 
-const disconnectProbes = async () => {
+export const disconnectProbes = async (delay = reconnectProbesDelay) => {
 	const sockets = await fetchRawSockets();
 
 	for (const socket of sockets) {
-		setTimeout(() => socket.disconnect(), Math.random() * reconnectProbesDelay);
+		setTimeout(() => socket.disconnect(), Math.random() * delay);
 	}
 };
 

--- a/src/lib/ws/middleware/health.ts
+++ b/src/lib/ws/middleware/health.ts
@@ -1,0 +1,10 @@
+import type { ServerSocket } from '../server.js';
+import termListener from '../../term-listener.js';
+
+export const health = (_socket: ServerSocket, next: (error?: Error) => void) => {
+	if (termListener.getIsTerminating()) {
+		return next(new Error('The server is terminating.'));
+	}
+
+	next();
+};


### PR DESCRIPTION
During the first 15 seconds:
 - Report as "down" at /health to force HAProxy to stop sending new requests (existed before this PR, it should take around 10s).
 - Stop accepting connections from new probes (those will retry, so that's safe - I'll also update them to not log this as an error).

At 15 seconds:
 - Disconnect all probes so that they stop sending data to this instance (this wouldn't be handled by HAProxy since the connections are already open), and there's no chance of measurement data loss between the time it's received by the API and written into Redis. 
 - Wait for 10 more seconds to process any remaining tasks like the in-memory jobs from #749 and sync the now-empty probe list (this should resolve the duplicated IP error).