### PR TITLE
fix: prevent race conditions in the store cleanup handler

### DIFF
--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -231,33 +231,28 @@ const markFinishedByTimeout: MarkFinishedByTimeoutScript = defineScript({
 	local date = ARGV[1]
 	local timeoutMessage = ARGV[2]
 
-	if redis.call('EXISTS', keyMeasurementAwaiting) == 0 then
-		return
-	end
-
-	redis.call('DEL', keyMeasurementAwaiting)
-
-	local measurementJson = redis.call('JSON.GET', keyMeasurementResults, '$')
-	if not measurementJson then
+	local measurementJson = redis.pcall('JSON.GET', keyMeasurementResults, '$')
+	if measurementJson.err or not measurementJson then
 		return
 	end
 
 	local measurement = cjson.decode(measurementJson)[1]
+	redis.call('DEL', keyMeasurementAwaiting)
+
 	if measurement.status ~= 'in-progress' then
 		return
 	end
 
-	measurement.status = 'finished'
-	measurement.updatedAt = date
+	redis.call('JSON.SET', keyMeasurementResults, '$.status', '"finished"')
+	redis.call('JSON.SET', keyMeasurementResults, '$.updatedAt', '"' .. date .. '"')
 
-	for _, resultObject in ipairs(measurement.results) do
+	for index, resultObject in ipairs(measurement.results) do
 		if resultObject.result.status == 'in-progress' then
-			resultObject.result.status = 'failed'
-			resultObject.result.rawOutput = (resultObject.result.rawOutput or '') .. timeoutMessage
+			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.status', '"failed"')
+			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.rawOutput', cjson.encode((resultObject.result.rawOutput or '') .. timeoutMessage))
 		end
 	end
 
-	redis.call('JSON.SET', keyMeasurementResults, '$', cjson.encode(measurement))
 	redis.call('COMPRESSED.JSON.COMPRESS', keyMeasurementResults)
 
 	return redis.call('COMPRESSED.JSON.GET', keyMeasurementResults)

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -37,11 +37,21 @@ type MarkFinishedScript = {
 	SHA1: string;
 };
 
+type MarkFinishedByTimeoutScript = {
+	NUMBER_OF_KEYS: number;
+	SCRIPT: string;
+	transformArguments (measurementId: string): string[];
+	transformReply (reply: Buffer | null): Buffer | null;
+} & {
+	SHA1: string;
+};
+
 export type RedisScripts = {
 	recordProgress: RecordProgressScript;
 	recordProgressAppend: RecordProgressAppendScript;
 	recordResult: RecordResultScript;
 	markFinished: MarkFinishedScript;
+	markFinishedByTimeout: MarkFinishedByTimeoutScript;
 };
 
 const recordProgress: RecordProgressScript = defineScript({
@@ -212,4 +222,57 @@ const markFinished: MarkFinishedScript = defineScript({
 	},
 });
 
-export const scripts: RedisScripts = { recordProgress, recordProgressAppend, recordResult, markFinished };
+const markFinishedByTimeout: MarkFinishedByTimeoutScript = defineScript({
+	FIRST_KEY_INDEX: 0, // Needed in clusters: https://github.com/redis/node-redis/issues/2521
+	NUMBER_OF_KEYS: 2,
+	SCRIPT: `
+	local keyMeasurementResults = KEYS[1]
+	local keyMeasurementAwaiting = KEYS[2]
+	local date = ARGV[1]
+	local timeoutMessage = ARGV[2]
+
+	if redis.call('EXISTS', keyMeasurementAwaiting) == 0 then
+		return
+	end
+
+	redis.call('DEL', keyMeasurementAwaiting)
+
+	local measurementJson = redis.call('JSON.GET', keyMeasurementResults, '$')
+	if not measurementJson then
+		return
+	end
+
+	local measurement = cjson.decode(measurementJson)[1]
+	if measurement.status ~= 'in-progress' then
+		return
+	end
+
+	measurement.status = 'finished'
+	measurement.updatedAt = date
+
+	for _, resultObject in ipairs(measurement.results) do
+		if resultObject.result.status == 'in-progress' then
+			resultObject.result.status = 'failed'
+			resultObject.result.rawOutput = (resultObject.result.rawOutput or '') .. timeoutMessage
+		end
+	end
+
+	redis.call('JSON.SET', keyMeasurementResults, '$', cjson.encode(measurement))
+	redis.call('COMPRESSED.JSON.COMPRESS', keyMeasurementResults)
+
+	return redis.call('COMPRESSED.JSON.GET', keyMeasurementResults)
+	`,
+	transformArguments (measurementId) {
+		return [
+			`gp:m:{${measurementId}}:results`,
+			`gp:m:{${measurementId}}:probes_awaiting`,
+			new Date().toISOString(),
+			'\n\nThe measurement timed out.',
+		];
+	},
+	transformReply (reply) {
+		return reply;
+	},
+});
+
+export const scripts: RedisScripts = { recordProgress, recordProgressAppend, recordResult, markFinished, markFinishedByTimeout };

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -194,32 +194,12 @@ export class MeasurementStore {
 			return;
 		}
 
-		const keys = ids.map(id => getMeasurementKey(id));
-		const measurements = (await Bluebird.map(keys, key => this.redis.compressedJsonGet<MeasurementRecord>(key), { concurrency: 8 })).filter(is.truthy);
+		const measurements = (await Bluebird.map(ids, async (id) => {
+			const recordBuffer = await this.redis.markFinishedByTimeout(commandOptions({ returnBuffers: true }), id);
+			return parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
+		}, { concurrency: 32 })).filter(is.truthy);
 
-		for (const measurement of measurements) {
-			measurement.status = 'finished';
-			measurement.updatedAt = new Date().toISOString();
-			const inProgressResults = measurement.results.filter(resultObject => resultObject.result.status === 'in-progress');
-
-			for (const resultObject of inProgressResults) {
-				resultObject.result.status = 'failed';
-				resultObject.result.rawOutput += '\n\nThe measurement timed out.';
-			}
-		}
-
-		const updateMeasurements = Bluebird.map(measurements, async (measurement) => {
-			const key = getMeasurementKey(measurement.id);
-			await this.redis.json.set(key, '$', measurement);
-			await this.redis.compressedJsonCompress(key);
-		}, { concurrency: 32 });
-		const deleteAwaitingKeys = Bluebird.map(ids, id => this.redis.del(getMeasurementKey(id, 'probes_awaiting')), { concurrency: 32 });
-
-		await Promise.all([
-			this.redis.hDel('gp:in-progress', ids),
-			deleteAwaitingKeys,
-			updateMeasurements,
-		]);
+		await this.redis.hDel('gp:in-progress', ids);
 
 		for (const measurement of measurements) {
 			this.offloader.enqueueForOffload(measurement);

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -57,6 +57,7 @@ describe('measurement store', () => {
 		recordProgressAppend: sandbox.stub(),
 		recordResult: sandbox.stub(),
 		markFinished: sandbox.stub(),
+		markFinishedByTimeout: sandbox.stub(),
 	};
 
 	const mockedMeasurementId1 = '2E2SZgEwA6W6HvzlT0001z9VK';
@@ -98,6 +99,7 @@ describe('measurement store', () => {
 		redisMock.compressedJsonGet.reset();
 		redisMock.compressedJsonGetBuffer.reset();
 		redisMock.recordResult.reset();
+		redisMock.markFinishedByTimeout.reset();
 		sandbox.resetHistory();
 	});
 
@@ -111,6 +113,21 @@ describe('measurement store', () => {
 
 	it('should call proper redis methods during timeout checks', async () => {
 		const now = clock.pause().now;
+		const finishedRecord = {
+			id: mockedMeasurementId1,
+			type: 'ping',
+			status: 'finished',
+			createdAt: new Date(now).toISOString(),
+			updatedAt: new Date(now + 1_000).toISOString(),
+			probesCount: 1,
+			results: [{
+				probe: {},
+				result: {
+					status: 'failed',
+					rawOutput: '\n\nThe measurement timed out.',
+				},
+			}],
+		};
 
 		redisMock.hScan.resolves({
 			cursor: 0,
@@ -121,23 +138,12 @@ describe('measurement store', () => {
 			],
 		});
 
-		redisMock.compressedJsonGet.onFirstCall().resolves({
-			id: mockedMeasurementId1,
-			type: 'ping',
-			status: 'in-progress',
-			createdAt: new Date(now).toISOString(),
-			updatedAt: new Date(now).toISOString(),
-			probesCount: 1,
-			results: [{
-				probe: {},
-				result: {
-					status: 'in-progress',
-					rawOutput: '',
-				},
-			}],
-		});
+		redisMock.markFinishedByTimeout.onFirstCall().resolves(Buffer.concat([
+			Buffer.from([ 0x00 ]),
+			Buffer.from(JSON.stringify(finishedRecord)),
+		]));
 
-		redisMock.compressedJsonGet.onSecondCall().resolves(null);
+		redisMock.markFinishedByTimeout.onSecondCall().resolves(null);
 
 		getMeasurementStore();
 
@@ -145,38 +151,39 @@ describe('measurement store', () => {
 
 		expect(redisMock.hScan.callCount).to.equal(1);
 		expect(redisMock.hScan.firstCall.args).to.deep.equal([ 'gp:in-progress', 0, { COUNT: 5000 }]);
-		expect(redisMock.compressedJsonGet.callCount).to.equal(2);
-		expect(redisMock.compressedJsonGet.firstCall.args).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:results` ]);
-		expect(redisMock.compressedJsonGet.secondCall.args).to.deep.equal([ `gp:m:{${mockedMeasurementId2}}:results` ]);
+		expect(redisMock.markFinishedByTimeout.callCount).to.equal(2);
+		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ commandOptions({ returnBuffers: true }), mockedMeasurementId1 ]);
+		expect(redisMock.markFinishedByTimeout.secondCall.args).to.deep.equal([ commandOptions({ returnBuffers: true }), mockedMeasurementId2 ]);
 		expect(redisMock.hDel.callCount).to.equal(1);
 		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1, mockedMeasurementId2 ] ]);
-		expect(redisMock.del.callCount).to.equal(2);
-		expect(redisMock.del.firstCall.args).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:probes_awaiting` ]);
-		expect(redisMock.del.secondCall.args).to.deep.equal([ `gp:m:{${mockedMeasurementId2}}:probes_awaiting` ]);
-		expect(redisMock.json.set.callCount).to.equal(1);
-		expect(redisMock.compressedJsonCompress.callCount).to.equal(1);
-		expect(redisMock.compressedJsonCompress.firstCall.args).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:results` ]);
+		expect(redisMock.del.callCount).to.equal(0);
+		expect(redisMock.json.set.callCount).to.equal(0);
+		expect(redisMock.compressedJsonCompress.callCount).to.equal(0);
 
-		expect(redisMock.json.set.firstCall.args).to.have.lengthOf(3);
-		expect(redisMock.json.set.firstCall.args[0]).to.equal(`gp:m:{${mockedMeasurementId1}}:results`);
-		expect(redisMock.json.set.firstCall.args[1]).to.equal('$');
+		expect(enqueueForOffloadStub.callCount).to.equal(1);
+		expect(enqueueForOffloadStub.firstCall.args).to.deep.equal([ finishedRecord ]);
+	});
 
-		expect(redisMock.json.set.firstCall.args[2]).to.deep.include({
-			id: mockedMeasurementId1,
-			type: 'ping',
-			status: 'finished',
-			createdAt: new Date(now).toISOString(),
-			probesCount: 1,
-			results: [{
-				probe: {},
-				result: {
-					status: 'failed',
-					rawOutput: '\n\nThe measurement timed out.',
-				},
-			}],
+	it('should not offload when timeout cleanup loses to a normal finish', async () => {
+		redisMock.hScan.resolves({
+			cursor: 0,
+			tuples: [
+				{ field: mockedMeasurementId1, value: relativeDayUtc(-1).valueOf() },
+			],
 		});
 
-		expect(new Date(redisMock.json.set.firstCall.args[2].updatedAt)).to.be.within(new Date(now + 1), new Date(now + 16_000));
+		redisMock.markFinishedByTimeout.resolves(null);
+
+		getMeasurementStore();
+
+		await clock.tickAsyncStepped(16_000);
+
+		expect(redisMock.hScan.callCount).to.equal(1);
+		expect(redisMock.markFinishedByTimeout.callCount).to.equal(1);
+		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ commandOptions({ returnBuffers: true }), mockedMeasurementId1 ]);
+		expect(redisMock.hDel.callCount).to.equal(1);
+		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1 ] ]);
+		expect(enqueueForOffloadStub.callCount).to.equal(0);
 	});
 
 	it('should read compressed measurement results for the offloader batch path', async () => {


### PR DESCRIPTION
A measurement marked for cleanup may still finish before `markFinishedByTimeout()` is called on it. This is an older bug, but with #828, it got more visible as the attempt to set the timeout message fails if the measurement is already compressed.