### PR TITLE
perf: avoid unnecessary decompress/compress cycles

### DIFF
--- a/src/lib/http/middleware/compressed.ts
+++ b/src/lib/http/middleware/compressed.ts
@@ -1,0 +1,70 @@
+import { promisify } from 'node:util';
+import { brotliDecompress as brotliDecompressCallback, gunzip as gunzipCallback, inflate as inflateCallback } from 'node:zlib';
+import type Koa from 'koa';
+import type Router from '@koa/router';
+import type { ExtendedMiddleware } from '../../../types.js';
+
+const brotliDecompress = promisify(brotliDecompressCallback);
+const gunzip = promisify(gunzipCallback);
+const inflate = promisify(inflateCallback);
+
+export type SupportedCompressionEncoding = 'br' | 'gzip' | 'deflate';
+
+export type CompressedContext = {
+	compressed: (value: Buffer, encoding?: SupportedCompressionEncoding) => void;
+};
+
+export type CompressedMiddleware = Router.Middleware<Koa.DefaultState, CompressedContext>;
+
+type CompressedBody = {
+	value: Buffer;
+	encoding: SupportedCompressionEncoding;
+};
+
+const decompressors: Record<SupportedCompressionEncoding, (buffer: Buffer) => Promise<Buffer>> = {
+	br: brotliDecompress,
+	gzip: gunzip,
+	deflate: inflate,
+};
+
+const decompress = (body: Buffer, encoding: SupportedCompressionEncoding) => {
+	return decompressors[encoding](body);
+};
+
+const isCompressedBody = (body: unknown): body is CompressedBody => {
+	return typeof body === 'object'
+		&& body !== null
+		&& 'value' in body
+		&& 'encoding' in body
+		&& Buffer.isBuffer(body.value)
+		&& typeof body.encoding === 'string';
+};
+
+export const compressed = (): ExtendedMiddleware => {
+	return async (ctx, next) => {
+		ctx.compressed = (value, encoding = 'br') => {
+			ctx.body = { value, encoding };
+		};
+
+		await next();
+
+		if (!isCompressedBody(ctx.body) || ctx.response.get('Content-Encoding')) {
+			return;
+		}
+
+		const compressedBody = ctx.body;
+
+		ctx.vary('Accept-Encoding');
+
+		if (ctx.acceptsEncodings(compressedBody.encoding, 'identity') === compressedBody.encoding) {
+			ctx['compress'] = false;
+			ctx.set('Content-Encoding', compressedBody.encoding);
+			ctx.set('Content-Length', String(compressedBody.value.length));
+			ctx.body = compressedBody.value;
+			return;
+		}
+
+		ctx.remove('Content-Length');
+		ctx.body = await decompress(compressedBody.value, compressedBody.encoding);
+	};
+};

--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -20,6 +20,7 @@ import { registerSendCodeRoute } from '../../adoption/route/adoption-code.js';
 import { registerHealthRoute } from '../../health/route/get.js';
 import { registerSpecRoute } from './spec.js';
 import { errorHandler } from './error-handler.js';
+import { compressed } from './middleware/compressed.js';
 import { defaultJson } from './middleware/default-json.js';
 import { errorHandlerMw } from './middleware/error-handler.js';
 import { corsHandler } from './middleware/cors.js';
@@ -149,6 +150,7 @@ export const getHttpServer = (ioContext: IoContext) => {
 		.use(errorHandlerMw)
 		.use(corsHandler())
 		.use(blacklist)
+		.use(captureMiddlewareSpan(compressed(), { name: 'compressed' }))
 		.use(captureMiddlewareChainSpan('route', 'custom'))
 		.use(rootRouter.routes())
 		.use(healthRouter.routes())

--- a/src/lib/redis/compressed.ts
+++ b/src/lib/redis/compressed.ts
@@ -1,8 +1,9 @@
 import { promisify } from 'node:util';
-import { brotliDecompress as brotliDecompressCallback } from 'node:zlib';
+import { brotliCompress as brotliCompressCallback, brotliDecompress as brotliDecompressCallback, constants as zlibConstants } from 'node:zlib';
 import { transformArguments as transformJsonGetArguments } from '@redis/json/dist/commands/GET.js';
 import { RedisCluster } from './shared.js';
 
+const brotliCompress = promisify(brotliCompressCallback);
 const brotliDecompress = promisify(brotliDecompressCallback);
 
 export type CompressedJsonGetOptions = Parameters<typeof transformJsonGetArguments>[1];
@@ -19,17 +20,38 @@ export async function decodeCompressedJsonBuffer (data: Buffer | null) {
 	return brotliDecompress(data.subarray(1));
 }
 
+export async function normalizeCompressedJsonBuffer (data: Buffer | null) {
+	if (!data || !data.length) {
+		return data;
+	}
+
+	if (data[0] === 0x01) {
+		return data.subarray(1);
+	}
+
+	return brotliCompress(data.subarray(1), { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 4 } });
+}
+
 export async function parseCompressedJsonBuffer<T> (data: Buffer | null) {
 	return decodeCompressedJsonBuffer(data)
 		.then(decoded => decoded ? JSON.parse(decoded.toString('utf8')) as T : null);
 }
 
 export async function compressedJsonGetBuffer (this: RedisCluster, key: string, options?: CompressedJsonGetOptions) {
+	return compressedJsonGetRawBuffer.call(this, key, options)
+		.then(data => decodeCompressedJsonBuffer(data));
+}
+
+export async function compressedJsonGetBufferCompressed (this: RedisCluster, key: string, options?: CompressedJsonGetOptions) {
+	return compressedJsonGetRawBuffer.call(this, key, options)
+		.then(data => normalizeCompressedJsonBuffer(data));
+}
+
+async function compressedJsonGetRawBuffer (this: RedisCluster, key: string, options?: CompressedJsonGetOptions) {
 	const args = transformJsonGetArguments(key, options);
 	args[0] = 'COMPRESSED.JSON.GET';
 
-	return this.sendCommand<Buffer | null>(key, true, args, { returnBuffers: true })
-		.then(data => decodeCompressedJsonBuffer(data));
+	return this.sendCommand<Buffer | null>(key, true, args, { returnBuffers: true });
 }
 
 export async function compressedJsonGet<T> (this: RedisCluster, key: string, options?: CompressedJsonGetOptions) {

--- a/src/lib/redis/shared.ts
+++ b/src/lib/redis/shared.ts
@@ -11,7 +11,7 @@ import {
 import _ from 'lodash';
 import Bluebird from 'bluebird';
 import { type RedisScripts, scripts } from './scripts.js';
-import { compressedJsonCompress, compressedJsonGet, compressedJsonGetBuffer } from './compressed.js';
+import { compressedJsonCompress, compressedJsonGet, compressedJsonGetBuffer, compressedJsonGetBufferCompressed } from './compressed.js';
 import { type Logger } from 'h-logger2';
 
 type ClusterExtensions = {
@@ -19,6 +19,7 @@ type ClusterExtensions = {
 	reduceMasters: typeof reduceMasters;
 	compressedJsonGet: typeof compressedJsonGet;
 	compressedJsonGetBuffer: typeof compressedJsonGetBuffer;
+	compressedJsonGetBufferCompressed: typeof compressedJsonGetBufferCompressed;
 	compressedJsonCompress: typeof compressedJsonCompress;
 };
 
@@ -53,6 +54,7 @@ export const createRedisClusterInternal = (options: RedisClusterOptions, logger:
 		reduceMasters,
 		compressedJsonGet,
 		compressedJsonGetBuffer,
+		compressedJsonGetBufferCompressed,
 		compressedJsonCompress,
 	});
 

--- a/src/measurement/route/get-measurement.ts
+++ b/src/measurement/route/get-measurement.ts
@@ -16,7 +16,7 @@ const handle = async (ctx: ExtendedContext): Promise<void> => {
 
 	await checkGetMeasurementRateLimit(ctx);
 
-	const result = await store.getMeasurementBuffer(id);
+	const result = await store.getMeasurementBufferCompressed(id);
 	apmAgent.addLabels({ gpMeasurementId: id });
 
 	if (!result) {
@@ -26,7 +26,7 @@ const handle = async (ctx: ExtendedContext): Promise<void> => {
 	ctx.set('Cache-Control', 'public, max-age=0');
 
 	ctx.type = 'application/json';
-	ctx.body = result;
+	ctx.compressed(result);
 };
 
 export const registerGetMeasurementRoute = (router: ExtendedRouter): void => {

--- a/src/measurement/store-offloader.ts
+++ b/src/measurement/store-offloader.ts
@@ -1,5 +1,5 @@
 import { promisify } from 'node:util';
-import { brotliCompress as brotliCompressCallback, brotliDecompress as brotliDecompressCallback, constants as zlibConstants } from 'node:zlib';
+import { brotliCompress as brotliCompressCallback, constants as zlibConstants } from 'node:zlib';
 import { Queue as BullQueue, Worker } from 'bullmq';
 import BatchQueue from '@martin-kolarik/batch-queue';
 import Bluebird from 'bluebird';
@@ -15,14 +15,9 @@ import type { ExportMeta } from './types.js';
 
 const logger = scopedLogger('db-store');
 const brotliCompress = promisify(brotliCompressCallback);
-const brotliDecompress = promisify(brotliDecompressCallback);
 
 const compressRecord = (record: string): Promise<Buffer> => {
 	return brotliCompress(record, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 5 } });
-};
-
-const decompressRecord = async (buffer: Buffer): Promise<Buffer> => {
-	return brotliDecompress(buffer);
 };
 
 export class MeasurementStoreOffloader {
@@ -59,7 +54,7 @@ export class MeasurementStoreOffloader {
 		this.offloadQueues[tier].push(measurement);
 	}
 
-	async getMeasurementBuffer (id: string, userTierNum: keyof typeof USER_TIER_INVERTED, createdAtRounded: number): Promise<Buffer | null> {
+	async getMeasurementBufferCompressed (id: string, userTierNum: keyof typeof USER_TIER_INVERTED, createdAtRounded: number): Promise<Buffer | null> {
 		const tier = USER_TIER_INVERTED[userTierNum];
 		const table = `measurement_${tier}`;
 		const createdAt = new Date(createdAtRounded);
@@ -73,7 +68,7 @@ export class MeasurementStoreOffloader {
 			return null;
 		}
 
-		return decompressRecord(row.data);
+		return row.data;
 	}
 
 	startRetryWorker () {

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -1,3 +1,5 @@
+import { promisify } from 'node:util';
+import { brotliDecompress as brotliDecompressCallback } from 'node:zlib';
 import is from '@sindresorhus/is';
 import Bluebird from 'bluebird';
 import config from 'config';
@@ -26,6 +28,7 @@ import type { ExportMeta } from './types.js';
 
 const logger = scopedLogger('store');
 const singleFlight = scopedFlight('store');
+const brotliDecompress = promisify(brotliDecompressCallback);
 
 export const getMeasurementKey = (id: string, suffix: string = 'results'): string => {
 	return `gp:m:{${id}}:${suffix}`;
@@ -60,18 +63,17 @@ export class MeasurementStore {
 		this.offloader = new MeasurementStoreOffloader(measurementStoreClient, this);
 	}
 
-	async getMeasurementBuffer (id: string): Promise<Buffer | null> {
-		return this.getFromRedisOrOffloader(id);
+	async getMeasurementBufferCompressed (id: string): Promise<Buffer | null> {
+		return this.getFromRedisOrOffloaderBufferCompressed(id);
 	}
 
 	async getMeasurement (id: string): Promise<MeasurementRecord | null> {
-		return this.getFromRedisOrOffloader(id, b => b ? JSON.parse(b.toString('utf8')) as MeasurementRecord : b);
+		return this.getFromRedisOrOffloaderBufferCompressed(id)
+			.then(b => b?.length ? brotliDecompress(b) : b)
+			.then(b => b ? JSON.parse(b.toString('utf8')) as MeasurementRecord : null);
 	}
 
-	private async getFromRedisOrOffloader<T extends Buffer | MeasurementRecord> (
-		id: string,
-		parse: (b: Buffer | null) => T | null = b => b as T,
-	): Promise<T | null> {
+	private async getFromRedisOrOffloaderBufferCompressed (id: string): Promise<Buffer | null> {
 		let userTier;
 		let minutesSinceEpoch;
 
@@ -87,7 +89,7 @@ export class MeasurementStore {
 		return singleFlight(getMeasurementKey(id), async (key) => {
 			if (isOlderThan30m) {
 				try {
-					const offloaded = await this.offloader.getMeasurementBuffer(id, userTier, createdAtMs);
+					const offloaded = await this.offloader.getMeasurementBufferCompressed(id, userTier, createdAtMs);
 
 					if (offloaded) {
 						return offloaded;
@@ -97,8 +99,8 @@ export class MeasurementStore {
 				}
 			}
 
-			return this.redis.compressedJsonGetBuffer(key);
-		}).then(parse);
+			return this.redis.compressedJsonGetBufferCompressed(key);
+		});
 	}
 
 	async getMeasurementsForOffloader (ids: string[]): Promise<(MeasurementRecord | null)[]> {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,9 +2,10 @@ import Koa from 'koa';
 import type Router from '@koa/router';
 import type { DocsLinkContext } from './lib/http/middleware/docs-link.js';
 import type { AuthenticateState } from './lib/http/middleware/authenticate.js';
+import type { CompressedContext } from './lib/http/middleware/compressed.js';
 
 export type CustomState = Koa.DefaultState & AuthenticateState;
-export type CustomContext = Koa.DefaultContext & DocsLinkContext;
+export type CustomContext = Koa.DefaultContext & DocsLinkContext & CompressedContext;
 
 export type UnknownNext = () => Promise<unknown>;
 export type ExtendedContext = Router.RouterContext<CustomState, CustomContext>;

--- a/test/tests/integration/measurement/get-measurement.test.ts
+++ b/test/tests/integration/measurement/get-measurement.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from 'node:http';
-import { brotliCompress as brotliCompressCallback, constants as zlibConstants } from 'node:zlib';
+import { brotliCompress as brotliCompressCallback, brotliDecompress as brotliDecompressCallback, gunzip as gunzipCallback, constants as zlibConstants } from 'node:zlib';
 import { promisify } from 'node:util';
 import request, { Agent } from 'supertest';
 import Bluebird from 'bluebird';
@@ -12,6 +12,8 @@ import { generateMeasurementId, roundIdTime } from '../../../../src/measurement/
 import { getMeasurementKey } from '../../../../src/measurement/store.js';
 
 const brotliCompress = promisify(brotliCompressCallback);
+const brotliDecompress = promisify(brotliDecompressCallback);
+const gunzip = promisify(gunzipCallback);
 
 describe('Get measurement', () => {
 	let app: Server;
@@ -28,6 +30,14 @@ describe('Get measurement', () => {
 			probesCount: 1,
 			results: [],
 		};
+	};
+
+	const binaryParser = (response: any, callback: (error: Error | null, body: Buffer) => void) => {
+		const chunks: Buffer[] = [];
+
+		response.on('data', (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+		response.on('end', () => callback(null, Buffer.concat(chunks)));
+		response.on('error', (error: Error) => callback(error, Buffer.alloc(0)));
 	};
 
 	before(async () => {
@@ -110,6 +120,52 @@ describe('Get measurement', () => {
 				.expect((response) => {
 					expect(response.body).to.deep.equal(record);
 					expect(response).to.matchApiSchema();
+				});
+		});
+
+		it('should return the precompressed Brotli payload when the client accepts br', async () => {
+			const now = new Date();
+			const id = generateMeasurementId(now);
+			const key = getMeasurementKey(id);
+			const record = buildMeasurementRecord(id, now);
+			record.target = 'x'.repeat(12_000);
+
+			const redis = getMeasurementRedisClient();
+			await redis.json.set(key, '$', record);
+			redisKeysToCleanup.push(key);
+
+			await requestAgent
+				.get(`/v1/measurements/${id}`)
+				.set('Accept-Encoding', 'br')
+				.buffer(true)
+				.parse(binaryParser)
+				.expect(200)
+				.expect(async (response) => {
+					expect(response.headers['content-encoding']).to.equal('br');
+					expect(JSON.parse((await brotliDecompress(response.body)).toString('utf8'))).to.deep.equal(record);
+				});
+		});
+
+		it('should decompress the precompressed payload and let koa-compress re-encode it for gzip clients', async () => {
+			const now = new Date();
+			const id = generateMeasurementId(now);
+			const key = getMeasurementKey(id);
+			const record = buildMeasurementRecord(id, now);
+			record.target = 'x'.repeat(12_000);
+
+			const redis = getMeasurementRedisClient();
+			await redis.json.set(key, '$', record);
+			redisKeysToCleanup.push(key);
+
+			await requestAgent
+				.get(`/v1/measurements/${id}`)
+				.set('Accept-Encoding', 'gzip')
+				.buffer(true)
+				.parse(binaryParser)
+				.expect(200)
+				.expect(async (response) => {
+					expect(response.headers['content-encoding']).to.equal('gzip');
+					expect(JSON.parse((await gunzip(response.body)).toString('utf8'))).to.deep.equal(record);
 				});
 		});
 	});

--- a/test/tests/integration/measurement/get-measurement.test.ts
+++ b/test/tests/integration/measurement/get-measurement.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from 'node:http';
-import { brotliCompress as brotliCompressCallback, brotliDecompress as brotliDecompressCallback, gunzip as gunzipCallback, constants as zlibConstants } from 'node:zlib';
+import { brotliCompress as brotliCompressCallback, constants as zlibConstants } from 'node:zlib';
 import { promisify } from 'node:util';
 import request, { Agent } from 'supertest';
 import Bluebird from 'bluebird';
@@ -12,8 +12,6 @@ import { generateMeasurementId, roundIdTime } from '../../../../src/measurement/
 import { getMeasurementKey } from '../../../../src/measurement/store.js';
 
 const brotliCompress = promisify(brotliCompressCallback);
-const brotliDecompress = promisify(brotliDecompressCallback);
-const gunzip = promisify(gunzipCallback);
 
 describe('Get measurement', () => {
 	let app: Server;
@@ -30,14 +28,6 @@ describe('Get measurement', () => {
 			probesCount: 1,
 			results: [],
 		};
-	};
-
-	const binaryParser = (response: any, callback: (error: Error | null, body: Buffer) => void) => {
-		const chunks: Buffer[] = [];
-
-		response.on('data', (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
-		response.on('end', () => callback(null, Buffer.concat(chunks)));
-		response.on('error', (error: Error) => callback(error, Buffer.alloc(0)));
 	};
 
 	before(async () => {
@@ -134,16 +124,13 @@ describe('Get measurement', () => {
 			await redis.json.set(key, '$', record);
 			redisKeysToCleanup.push(key);
 
-			await requestAgent
+			const response = await requestAgent
 				.get(`/v1/measurements/${id}`)
 				.set('Accept-Encoding', 'br')
-				.buffer(true)
-				.parse(binaryParser)
 				.expect(200)
-				.expect(async (response) => {
-					expect(response.headers['content-encoding']).to.equal('br');
-					expect(JSON.parse((await brotliDecompress(response.body)).toString('utf8'))).to.deep.equal(record);
-				});
+				.expect('content-encoding', 'br');
+
+			expect(response.body).to.deep.equal(record);
 		});
 
 		it('should decompress the precompressed payload and let koa-compress re-encode it for gzip clients', async () => {
@@ -157,16 +144,13 @@ describe('Get measurement', () => {
 			await redis.json.set(key, '$', record);
 			redisKeysToCleanup.push(key);
 
-			await requestAgent
+			const response = await requestAgent
 				.get(`/v1/measurements/${id}`)
 				.set('Accept-Encoding', 'gzip')
-				.buffer(true)
-				.parse(binaryParser)
 				.expect(200)
-				.expect(async (response) => {
-					expect(response.headers['content-encoding']).to.equal('gzip');
-					expect(JSON.parse((await gunzip(response.body)).toString('utf8'))).to.deep.equal(record);
-				});
+				.expect('content-encoding', 'gzip');
+
+			expect(response.body).to.deep.equal(record);
 		});
 	});
 

--- a/test/tests/unit/lib/redis/compressed.test.ts
+++ b/test/tests/unit/lib/redis/compressed.test.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
-import { compressedJsonCompress, compressedJsonGet, compressedJsonGetBuffer } from '../../../../../src/lib/redis/compressed.js';
+import { compressedJsonCompress, compressedJsonGet, compressedJsonGetBuffer, compressedJsonGetBufferCompressed } from '../../../../../src/lib/redis/compressed.js';
 
 const brotliCompress = promisify(brotliCompressCallback);
 
@@ -36,6 +36,24 @@ describe('redis compressed helper', () => {
 		const result = await compressedJsonGetBuffer.call({ sendCommand } as never, 'key');
 
 		expect(result?.toString()).to.equal('{"ok":true}');
+	});
+
+	it('should normalize plain replies into Brotli-compressed buffers', async () => {
+		const sendCommand = sandbox.stub().resolves(Buffer.concat([ Buffer.from([ 0x00 ]), Buffer.from('{"ok":true}') ]));
+
+		const result = await compressedJsonGetBufferCompressed.call({ sendCommand } as never, 'key');
+
+		expect(result).to.be.instanceOf(Buffer);
+		expect(result).to.deep.equal(await brotliCompress(Buffer.from('{"ok":true}')));
+	});
+
+	it('should unwrap Brotli replies for compressed buffer reads', async () => {
+		const compressed = await brotliCompress(Buffer.from('{"ok":true}'));
+		const sendCommand = sandbox.stub().resolves(Buffer.concat([ Buffer.from([ 0x01 ]), compressed ]));
+
+		const result = await compressedJsonGetBufferCompressed.call({ sendCommand } as never, 'key');
+
+		expect(result).to.deep.equal(compressed);
 	});
 
 	it('should call COMPRESSED.JSON.COMPRESS for RedisJSON keys', async () => {

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -1,3 +1,5 @@
+import { promisify } from 'node:util';
+import { brotliCompress as brotliCompressCallback } from 'node:zlib';
 import * as td from 'testdouble';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
@@ -33,6 +35,7 @@ const getOfflineProbe = (id: string, ip: string) => ({
 } as unknown as OfflineProbe);
 
 describe('measurement store', () => {
+	const brotliCompress = promisify(brotliCompressCallback);
 	let getMeasurementStore: () => MeasurementStore;
 
 	const sandbox = sinon.createSandbox();
@@ -41,6 +44,7 @@ describe('measurement store', () => {
 		compressedJsonCompress: sandbox.stub(),
 		compressedJsonGet: sandbox.stub(),
 		compressedJsonGetBuffer: sandbox.stub(),
+		compressedJsonGetBufferCompressed: sandbox.stub(),
 		hScan: sandbox.stub(),
 		hDel: sandbox.stub(),
 		hSet: sandbox.stub(),
@@ -67,7 +71,7 @@ describe('measurement store', () => {
 	sandbox.stub(Math, 'random').returns(0.8);
 
 	const parseMeasurementIdStub = sandbox.stub();
-	const offloaderGetMeasurementBufferStub = sandbox.stub();
+	const offloaderGetMeasurementBufferCompressedStub = sandbox.stub();
 
 	before(async () => {
 		await td.replaceEsm('../../../../src/measurement/id.ts', {
@@ -84,8 +88,8 @@ describe('measurement store', () => {
 				enqueueForOffloadStub(record);
 			}
 
-			getMeasurementBuffer (id: string, userTier: number, createdAtRounded: number) {
-				return offloaderGetMeasurementBufferStub(id, userTier, createdAtRounded);
+			getMeasurementBufferCompressed (id: string, userTier: number, createdAtRounded: number) {
+				return offloaderGetMeasurementBufferCompressedStub(id, userTier, createdAtRounded);
 			}
 		}
 
@@ -98,6 +102,7 @@ describe('measurement store', () => {
 		redisMock.compressedJsonCompress.reset();
 		redisMock.compressedJsonGet.reset();
 		redisMock.compressedJsonGetBuffer.reset();
+		redisMock.compressedJsonGetBufferCompressed.reset();
 		redisMock.recordResult.reset();
 		redisMock.markFinishedByTimeout.reset();
 		sandbox.resetHistory();
@@ -737,79 +742,79 @@ describe('measurement store', () => {
 		expect(redisMock.markFinished.callCount).to.equal(0);
 	});
 
-	it('should prefer the offload DB for likely offloaded measurements', async () => {
+	it('getMeasurementBufferCompressed should prefer the offload DB for likely offloaded measurements', async () => {
 		const store = getMeasurementStore();
 		const nowMs = Date.now();
 		const minutesOld = 45;
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.resolves(Buffer.from('{"from":"db"}'));
-		redisMock.compressedJsonGetBuffer.resolves(null);
+		offloaderGetMeasurementBufferCompressedStub.resolves(await brotliCompress(Buffer.from('{"from":"db"}')));
+		redisMock.compressedJsonGetBufferCompressed.resolves(null);
 
-		const result = await store.getMeasurementBuffer('SOME_ID');
-		expect(result?.toString()).to.equal('{"from":"db"}');
+		const result = await store.getMeasurementBufferCompressed('SOME_ID');
+		expect(result).to.deep.equal(await brotliCompress(Buffer.from('{"from":"db"}')));
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(0);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(0);
 	});
 
-	it('should fallback to Redis if the offload DB returns null (miss)', async () => {
+	it('getMeasurementBufferCompressed should fallback to Redis if the offload DB returns null (miss)', async () => {
 		const store = getMeasurementStore();
 		const nowMs = Date.now();
 		const minutesOld = 45;
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.resolves(null);
+		offloaderGetMeasurementBufferCompressedStub.resolves(null);
 
 		const redisValue = '{"from":"redis"}';
-		redisMock.compressedJsonGetBuffer.resolves(Buffer.from(redisValue));
+		redisMock.compressedJsonGetBufferCompressed.resolves(await brotliCompress(Buffer.from(redisValue)));
 
-		const result = await store.getMeasurementBuffer('SOME_ID');
-		expect(result?.toString()).to.equal(redisValue);
+		const result = await store.getMeasurementBufferCompressed('SOME_ID');
+		expect(result).to.deep.equal(await brotliCompress(Buffer.from(redisValue)));
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.firstCall.args).to.deep.equal([ 'gp:m:{SOME_ID}:results' ]);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.firstCall.args).to.deep.equal([ 'gp:m:{SOME_ID}:results' ]);
 	});
 
-	it('should fallback to Redis if DB throws', async () => {
+	it('getMeasurementBufferCompressed should fallback to Redis if DB throws', async () => {
 		const store = getMeasurementStore();
 		const nowMs = Date.now();
 		const minutesOld = 45;
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.rejects(new Error('DB error'));
+		offloaderGetMeasurementBufferCompressedStub.rejects(new Error('DB error'));
 
 		const redisValue = '{"from":"redis"}';
-		redisMock.compressedJsonGetBuffer.resolves(Buffer.from(redisValue));
+		redisMock.compressedJsonGetBufferCompressed.resolves(await brotliCompress(Buffer.from(redisValue)));
 
-		const result = await store.getMeasurementBuffer('SOME_ID');
-		expect(result?.toString()).to.equal(redisValue);
+		const result = await store.getMeasurementBufferCompressed('SOME_ID');
+		expect(result).to.deep.equal(await brotliCompress(Buffer.from(redisValue)));
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(1);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(1);
 	});
 
-	it('should use Redis when measurement is recent', async () => {
+	it('getMeasurementBufferCompressed should use Redis when measurement is recent', async () => {
 		const store = getMeasurementStore();
 		const nowMs = Date.now();
 		const minutesOld = 5;
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.resolves(Buffer.from('{"from":"db"}'));
+		offloaderGetMeasurementBufferCompressedStub.resolves(await brotliCompress(Buffer.from('{"from":"db"}')));
 
 		const redisValue = '{"from":"redis"}';
-		redisMock.compressedJsonGetBuffer.resolves(Buffer.from(redisValue));
+		redisMock.compressedJsonGetBufferCompressed.resolves(await brotliCompress(Buffer.from(redisValue)));
 
-		const result = await store.getMeasurementBuffer('SOME_ID');
-		expect(result?.toString()).to.equal(redisValue);
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(0);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.firstCall.args).to.deep.equal([ 'gp:m:{SOME_ID}:results' ]);
+		const result = await store.getMeasurementBufferCompressed('SOME_ID');
+		expect(result).to.deep.equal(await brotliCompress(Buffer.from(redisValue)));
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(0);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.firstCall.args).to.deep.equal([ 'gp:m:{SOME_ID}:results' ]);
 	});
 
 	it('getMeasurement should prefer the offload DB for likely offloaded measurements', async () => {
@@ -819,14 +824,14 @@ describe('measurement store', () => {
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.resolves(Buffer.from('{"from":"db"}'));
-		redisMock.compressedJsonGetBuffer.reset();
+		offloaderGetMeasurementBufferCompressedStub.resolves(await brotliCompress(Buffer.from('{"from":"db"}')));
+		redisMock.compressedJsonGetBufferCompressed.reset();
 
 		const result = await store.getMeasurement('SOME_ID');
 		expect(result).to.deep.equal({ from: 'db' });
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(0);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(0);
 	});
 
 	it('getMeasurement should fallback to Redis if the offload DB returns null', async () => {
@@ -836,15 +841,15 @@ describe('measurement store', () => {
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.resolves(null);
-		redisMock.compressedJsonGetBuffer.reset();
-		redisMock.compressedJsonGetBuffer.resolves(Buffer.from('{"from":"redis"}'));
+		offloaderGetMeasurementBufferCompressedStub.resolves(null);
+		redisMock.compressedJsonGetBufferCompressed.reset();
+		redisMock.compressedJsonGetBufferCompressed.resolves(await brotliCompress(Buffer.from('{"from":"redis"}')));
 
 		const result = await store.getMeasurement('SOME_ID');
 		expect(result).to.deep.equal({ from: 'redis' });
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(1);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(1);
 	});
 
 	it('getMeasurement should fallback to Redis if DB throws', async () => {
@@ -854,15 +859,15 @@ describe('measurement store', () => {
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		offloaderGetMeasurementBufferStub.rejects(new Error('DB error'));
-		redisMock.compressedJsonGetBuffer.reset();
-		redisMock.compressedJsonGetBuffer.resolves(Buffer.from('{"from":"redis"}'));
+		offloaderGetMeasurementBufferCompressedStub.rejects(new Error('DB error'));
+		redisMock.compressedJsonGetBufferCompressed.reset();
+		redisMock.compressedJsonGetBufferCompressed.resolves(await brotliCompress(Buffer.from('{"from":"redis"}')));
 
 		const result = await store.getMeasurement('SOME_ID');
 		expect(result).to.deep.equal({ from: 'redis' });
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(1);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(1);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(1);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(1);
 	});
 
 	it('getMeasurement should use Redis when measurement is recent', async () => {
@@ -872,14 +877,14 @@ describe('measurement store', () => {
 		const minutesSinceEpoch = Math.floor((nowMs - minutesOld * 60_000) / 60_000);
 
 		parseMeasurementIdStub.returns({ minutesSinceEpoch, userTier: 0 });
-		redisMock.compressedJsonGetBuffer.reset();
-		redisMock.compressedJsonGetBuffer.resolves(Buffer.from('{"from":"redis"}'));
+		redisMock.compressedJsonGetBufferCompressed.reset();
+		redisMock.compressedJsonGetBufferCompressed.resolves(await brotliCompress(Buffer.from('{"from":"redis"}')));
 
 		const result = await store.getMeasurement('SOME_ID');
 		expect(result).to.deep.equal({ from: 'redis' });
 
-		expect(offloaderGetMeasurementBufferStub.callCount).to.equal(0);
-		expect(redisMock.compressedJsonGetBuffer.callCount).to.equal(1);
+		expect(offloaderGetMeasurementBufferCompressedStub.callCount).to.equal(0);
+		expect(redisMock.compressedJsonGetBufferCompressed.callCount).to.equal(1);
 	});
 
 	it('setOffloadedExpiration should set 60m TTL on results keys', async () => {


### PR DESCRIPTION
When the client requests a compressed response, avoid a decompress-compress cycle and return the compressed value directly.