### PR TITLE
fix: ER_DUP_ENTRY during adopted probes sync

### DIFF
--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -622,7 +622,7 @@ export class AdoptedProbes {
 
 	private findDProbeDuplicates (updatedDProbes: DProbe[]) {
 		const dProbesToDelete: DProbe[] = [];
-		const nullifyIpUpdates: { dProbe: DProbe; update: { ip: null } }[] = [];
+		const nullifyIpUpdates: { dProbe: DProbe; update: { ip: null; status: 'offline' } }[] = [];
 		const dProbeAltIpUpdates: { dProbe: DProbe; update: { altIps: string[] } }[] = [];
 		const uniqUuids = new Map<string, DProbe>();
 		const uniqIps = new Map<string, DProbe>();
@@ -644,7 +644,7 @@ export class AdoptedProbes {
 					offline: _.pick(dProbe, [ 'id', 'uuid', 'ip', 'altIps', 'userId' ]),
 				});
 
-				nullifyIpUpdates.push({ dProbe, update: { ip: null } });
+				nullifyIpUpdates.push({ dProbe, update: { ip: null, status: 'offline' } });
 			} else if (existingDProbe) {
 				logger.error('Unremovable duplication found.', {
 					stay: _.pick(existingDProbe, [ 'id', 'uuid', 'ip', 'altIps', 'userId' ]),

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -323,7 +323,7 @@ export class AdoptedProbes {
 		// 'probe' - usual API probe. 'dProbe' - dashboard probe data stored in sql.
 		const { dProbesWithProbe, dProbesWithoutProbe, probesWithoutDProbe } = this.matchDProbesAndProbes(probes);
 		const { updatedDProbes, dProbeDataUpdates } = this.generateUpdatedDProbes(dProbesWithProbe, dProbesWithoutProbe);
-		const { dProbesToDelete, nullifyIpUpdates, dProbeAltIpUpdates } = this.findDuplicates(updatedDProbes);
+		const { dProbesToDelete, nullifyIpUpdates, dProbeAltIpUpdates } = this.findDProbeDuplicates(updatedDProbes);
 
 		const dProbeUpdates = this.mergeUpdates(dProbeDataUpdates, dProbeAltIpUpdates, dProbesToDelete);
 
@@ -396,6 +396,8 @@ export class AdoptedProbes {
 	 * This ensures that adopted probes take precedence over non-adopted ones in further logic.
 	 */
 	private matchDProbesAndProbes (probes: SocketProbe[]) {
+		// `ipAddress` duplicates are possible (https://github.com/jsdelivr/globalping/issues/502), so we are filtering them out. Sorting by client to prefer the probe that will stay after `syncIpLimit` run.
+		probes = _.uniqBy(_.sortBy(probes, [ 'client' ]), probe => probe.ipAddress);
 		const uuidToProbe = new Map(probes.map(probe => [ probe.uuid, probe ]));
 		const ipToProbe = new Map(probes.map(probe => [ probe.ipAddress, probe ]));
 		const altIpToProbe = new Map(probes.map(probe => probe.altIpAddresses.map(altIp => [ altIp, probe ] as const)).flat());
@@ -618,7 +620,7 @@ export class AdoptedProbes {
 		return { dProbeDataUpdates, updatedDProbes };
 	}
 
-	private findDuplicates (updatedDProbes: DProbe[]) {
+	private findDProbeDuplicates (updatedDProbes: DProbe[]) {
 		const dProbesToDelete: DProbe[] = [];
 		const nullifyIpUpdates: { dProbe: DProbe; update: { ip: null } }[] = [];
 		const dProbeAltIpUpdates: { dProbe: DProbe; update: { altIps: string[] } }[] = [];

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -882,7 +882,7 @@ describe('AdoptedProbes', () => {
 		// Match found by UUID.
 		expect(sql.update.callCount).to.equal(3);
 		expect(sql.where.args[0]).to.deep.equal([{ id: 'p-2' }]);
-		expect(sql.update.args[0]).to.deep.equal([{ ip: null }]);
+		expect(sql.update.args[0]).to.deep.equal([{ ip: null, status: 'offline' }]);
 		expect(sql.where.args[1]).to.deep.equal([{ id: 'p-1' }]);
 		expect(sql.update.args[1]).to.deep.equal([{ ip: '2.2.2.2' }]);
 		expect(sql.where.args[2]).to.deep.equal([{ id: 'p-2' }]);
@@ -933,7 +933,7 @@ describe('AdoptedProbes', () => {
 		expect(sql.delete.callCount).to.equal(0);
 		expect(sql.update.callCount).to.equal(2);
 		expect(sql.where.args[0]).to.deep.equal([{ id: 'dup-primary-ip' }]);
-		expect(sql.update.args[0]).to.deep.equal([{ ip: null }]);
+		expect(sql.update.args[0]).to.deep.equal([{ ip: null, status: 'offline' }]);
 		expect(sql.where.args[1]).to.deep.equal([{ id: 'dup-alt-ip' }]);
 		expect(sql.update.args[1]).to.deep.equal([{ altIps: '[]' }]);
 		expect(sql.insert.callCount).to.equal(0);
@@ -968,7 +968,7 @@ describe('AdoptedProbes', () => {
 		expect(sql.delete.callCount).to.equal(0);
 		expect(sql.update.callCount).to.equal(3);
 		expect(sql.where.args[0]).to.deep.equal([{ id: 'p-2' }]);
-		expect(sql.update.args[0]).to.deep.equal([{ ip: null }]);
+		expect(sql.update.args[0]).to.deep.equal([{ ip: null, status: 'offline' }]);
 		expect(sql.where.args[1]).to.deep.equal([{ id: 'p-1' }]);
 		expect(sql.update.args[1]).to.deep.equal([{ ip: '2.2.2.2', altIps: '["1.1.1.1"]' }]);
 		expect(sql.where.args[2]).to.deep.equal([{ id: 'p-2' }]);

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -1063,6 +1063,23 @@ describe('AdoptedProbes', () => {
 		});
 	});
 
+	it('class should dedupe probes with the same ipAddress: match survivor with existing dProbe and skip insert for the duplicate', async () => {
+		sql.select.resolves([{ ...defaultAdoption, status: 'offline' }]);
+
+		getProbesWithAdminData.returns([
+			{ ...defaultConnectedProbe, uuid: '1-1-1-1-1', ipAddress: '1.1.1.1', client: 'socket-A' },
+			{ ...defaultConnectedProbe, uuid: '9-9-9-9-9', ipAddress: '1.1.1.1', client: 'socket-B' },
+		]);
+
+		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);
+		await adoptedProbes.syncDashboardData();
+
+		expect(sql.insert.callCount).to.equal(0);
+		expect(sql.update.callCount).to.equal(1);
+		expect(sql.where.args[0]).to.deep.equal([{ id: 'p-1' }]);
+		expect(sql.update.args[0]).to.deep.equal([{ status: 'ready' }]);
+	});
+
 	it('class should proceed with syncing other probes if one probe sync fails', async () => {
 		sql.select.resolves([ defaultAdoption, { ...defaultAdoption, id: 'p-2', ip: '2.2.2.2', uuid: '2-2-2-2-2' }]);
 

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -1067,8 +1067,8 @@ describe('AdoptedProbes', () => {
 		sql.select.resolves([{ ...defaultAdoption, status: 'offline' }]);
 
 		getProbesWithAdminData.returns([
-			{ ...defaultConnectedProbe, uuid: '1-1-1-1-1', ipAddress: '1.1.1.1', client: 'socket-A' },
 			{ ...defaultConnectedProbe, uuid: '9-9-9-9-9', ipAddress: '1.1.1.1', client: 'socket-B' },
+			{ ...defaultConnectedProbe, uuid: '1-1-1-1-1', ipAddress: '1.1.1.1', client: 'socket-A' },
 		]);
 
 		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);


### PR DESCRIPTION
First commit is a fix for IPs ER_DUP_ENTRY. 

Second commit is a fix for `CONSTRAINT 'gp_probes_ip_offline_check' failed for 'dashboard-globalping'.'gp_probes'` errors.

Since adopted-probes.ts logic is getting more complex, we should prioritise https://github.com/jsdelivr/globalping/issues/745 to avoid split-brain.