### PR TITLE
fix: redirect /demo to /demo/ to resolve 404 without trailing slash

### DIFF
--- a/src/lib/http/server.ts
+++ b/src/lib/http/server.ts
@@ -61,6 +61,11 @@ export const getHttpServer = (ioContext: IoContext) => {
 		};
 	});
 
+	// GET /demo — redirect to /demo/ so koa-static resolves demo/index.html
+	rootRouter.get('/demo', (ctx) => {
+		ctx.redirect('/demo/');
+	});
+
 	const apiRouter = new Router<CustomState, CustomContext>({ strict: true, sensitive: true });
 
 	apiRouter.prefix('/v1')


### PR DESCRIPTION
## Summary
Fixes #275 — accessing the demo page at `/demo` (without trailing slash) was returning 404 while `/demo/` worked correctly.

## Root cause
`koa-static` serves `demo/index.html` when accessing `/demo/`, but when `/demo` is requested without the trailing slash, it's treated as a file lookup for a resource named "demo" rather than a directory, resulting in a 404.

## Change
Added a redirect on `rootRouter` from `/demo` to `/demo/` so both URLs work for users.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Minimal change (5 lines)
- [x] Does not affect other routes