### PR TITLE
feat: add more dc networks

### DIFF
--- a/src/lib/geoip/overrides.ts
+++ b/src/lib/geoip/overrides.ts
@@ -9,4 +9,14 @@ export const isHostingOverrides = [
 		normalizedNetwork: /psychz networks/,
 		isHosting: true,
 	},
+	// https://www.hetzner.com/
+	{
+		normalizedNetwork: /hetzner online/,
+		isHosting: true,
+	},
+	// https://www.ovhcloud.com/
+	{
+		normalizedNetwork: /\bovh\b/,
+		isHosting: true,
+	},
 ];

--- a/test/tests/unit/geoip/client.test.ts
+++ b/test/tests/unit/geoip/client.test.ts
@@ -243,7 +243,7 @@ describe('geoip service', () => {
 			network: 'Hetzner Online',
 			normalizedNetwork: 'hetzner online',
 			isProxy: false,
-			isHosting: null,
+			isHosting: true,
 			isAnycast: null,
 			allowedCountries: [ 'DE' ],
 		});
@@ -267,7 +267,7 @@ describe('geoip service', () => {
 			network: 'Hetzner Online',
 			normalizedNetwork: 'hetzner online',
 			isProxy: false,
-			isHosting: null,
+			isHosting: true,
 			isAnycast: null,
 			allowedCountries: [ 'DE' ],
 		});


### PR DESCRIPTION
Adding overrides so OVH or Hetzner probes are not marked as eyeball.

Also Baxet uses both `Baxet` and `Baxet Group` network name. It might make sense to either merge them, or make regex broader `/baxet group/ -> /baxet/`.