### PR TITLE
perf: improve measurement timeout cleanup

### DIFF
--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -201,5 +201,35 @@ const markFinishedByTimeout = defineScript({
 	},
 });
 
-export const scripts = { recordProgress, recordProgressAppend, recordResult, markFinished, markFinishedByTimeout };
+const claimTimedOutMeasurements = defineScript({
+	NUMBER_OF_KEYS: 1,
+	SCRIPT: `
+	local keyMeasurementTimeouts = KEYS[1]
+	local now = ARGV[1]
+	local batchSize = tonumber(ARGV[2])
+	local leaseUntil = ARGV[3]
+
+	local ids = redis.call('ZRANGEBYSCORE', keyMeasurementTimeouts, '-inf', now, 'LIMIT', 0, batchSize)
+
+	for _, id in ipairs(ids) do
+		redis.call('ZADD', keyMeasurementTimeouts, leaseUntil, id)
+	end
+
+	return ids
+	`,
+	parseCommand (parser: CommandParser, key: string, now: number, batchSize: number, leaseUntil: number) {
+		parser.pushKey(key);
+
+		parser.push(
+			now.toString(),
+			batchSize.toString(),
+			leaseUntil.toString(),
+		);
+	},
+	transformReply (reply: string[]) {
+		return reply;
+	},
+});
+
+export const scripts = { recordProgress, recordProgressAppend, recordResult, markFinished, markFinishedByTimeout, claimTimedOutMeasurements };
 export type RedisScripts = typeof scripts;

--- a/src/measurement/route/get-measurement.ts
+++ b/src/measurement/route/get-measurement.ts
@@ -34,7 +34,7 @@ const handle = async (ctx: ExtendedContext): Promise<void> => {
 	}
 
 	const measurementAgeSeconds = Math.floor((Date.now() - minutesSinceEpoch * 60_000) / 1000);
-	const isStableMeasurement = measurementAgeSeconds >= 2 * 60;
+	const isStableMeasurement = measurementAgeSeconds >= 3 * 60;
 
 	ctx.set(
 		'Cache-Control',

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -118,6 +118,7 @@ export class MeasurementStore {
 
 	async createMeasurement (request: MeasurementRequest, onlineProbesMap: Map<number, ServerProbe>, allProbes: (ServerProbe | OfflineProbe)[], userType?: AuthenticateStateUser['userType'], exportMeta: ExportMeta = {}): Promise<string> {
 		const startTime = new Date();
+		const timeoutTime = config.get<number>('measurement.timeout') * 1000;
 		const results = this.probesToResults(allProbes, request.type);
 		const id = generateMeasurementId(startTime, userType);
 		const key = getMeasurementKey(id);
@@ -142,6 +143,7 @@ export class MeasurementStore {
 
 		await Promise.all([
 			this.redis.hSet('gp:in-progress', id, startTime.getTime()),
+			this.redis.zAdd('gp:in-progress-timeouts', { score: startTime.getTime() + timeoutTime, value: id }),
 			this.redis.set(getMeasurementKey(id, 'probes_awaiting'), onlineProbesMap.size, { EX: config.get<number>('measurement.timeout') + 30 }),
 			this.redis.json.set(key, '$', measurementWithoutDefaults),
 			this.redis.json.set(getMeasurementKey(id, 'ips'), '$', allProbes.map(probe => probe.ipAddress)),
@@ -178,6 +180,7 @@ export class MeasurementStore {
 		const [ recordBuffer ] = await Promise.all([
 			this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).markFinished(id),
 			this.redis.hDel('gp:in-progress', id),
+			this.redis.zRem('gp:in-progress-timeouts', id),
 		]);
 
 		const record = await parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
@@ -199,7 +202,10 @@ export class MeasurementStore {
 			return parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
 		}, { concurrency: 32 })).filter(is.truthy);
 
-		await this.redis.hDel('gp:in-progress', ids);
+		await Promise.all([
+			this.redis.hDel('gp:in-progress', ids),
+			this.redis.zRem('gp:in-progress-timeouts', ids),
+		]);
 
 		for (const measurement of measurements) {
 			this.offloader.enqueueForOffload(measurement);
@@ -208,16 +214,24 @@ export class MeasurementStore {
 
 	async cleanup () {
 		const SCAN_BATCH_SIZE = 5000;
+		const CLEANUP_LEASE_TIME = 30_000;
+		const now = Date.now();
 		const timeoutTime = config.get<number>('measurement.timeout') * 1000;
-		const { cursor, entries } = await this.redis.hScan('gp:in-progress', '0', { COUNT: SCAN_BATCH_SIZE });
+		const [ claimResult, scanResult ] = await Promise.allSettled([
+			this.redis.claimTimedOutMeasurements('gp:in-progress-timeouts', now, SCAN_BATCH_SIZE, now + CLEANUP_LEASE_TIME),
+			this.redis.hScan('gp:in-progress', '0', { COUNT: SCAN_BATCH_SIZE }),
+		]);
+		const claimedTimedOutIds = claimResult.status === 'fulfilled' ? claimResult.value : [];
+		const { cursor, entries } = scanResult.status === 'fulfilled' ? scanResult.value : { cursor: '0', entries: [] };
 
 		if (cursor !== '0') {
 			logger.warn(`There are more than ${SCAN_BATCH_SIZE} "in-progress" elements in db`);
 		}
 
-		const timedOutIds = entries
-			.filter(({ value: time }) => Date.now() - Number(time) >= timeoutTime)
+		const legacyTimedOutIds = entries
+			.filter(({ value: time }) => now - Number(time) >= timeoutTime)
 			.map(({ field: id }) => id);
+		const timedOutIds = _.uniq([ ...legacyTimedOutIds, ...claimedTimedOutIds ]);
 
 		await this.markFinishedByTimeout(timedOutIds);
 	}

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -62,6 +62,8 @@ describe('measurement store', () => {
 		hDel: sandbox.stub(),
 		hSet: sandbox.stub(),
 		hExpire: sandbox.stub(),
+		zAdd: sandbox.stub(),
+		zRem: sandbox.stub(),
 		set: sandbox.stub(),
 		expire: sandbox.stub(),
 		del: sandbox.stub(),
@@ -76,6 +78,7 @@ describe('measurement store', () => {
 		recordResult: sandbox.stub(),
 		markFinished: sandbox.stub(),
 		markFinishedByTimeout: sandbox.stub(),
+		claimTimedOutMeasurements: sandbox.stub(),
 	};
 
 	const mockedMeasurementId1 = '2E2SZgEwA6W6HvzlT0001z9VK';
@@ -120,6 +123,8 @@ describe('measurement store', () => {
 		redisMock.compressedJsonGetBufferCompressed.reset();
 		redisMock.recordResult.reset();
 		redisMock.markFinishedByTimeout.reset();
+		redisMock.claimTimedOutMeasurements.reset();
+		redisMock.claimTimedOutMeasurements.resolves([]);
 		sandbox.resetHistory();
 	});
 
@@ -158,6 +163,8 @@ describe('measurement store', () => {
 			],
 		});
 
+		redisMock.claimTimedOutMeasurements.resolves([ mockedMeasurementId3 ]);
+
 		redisMock.markFinishedByTimeout.onFirstCall().resolves(Buffer.concat([
 			Buffer.from([ 0x00 ]),
 			Buffer.from(JSON.stringify(finishedRecord)),
@@ -169,13 +176,20 @@ describe('measurement store', () => {
 
 		await clock.tickAsyncStepped(16_000);
 
+		const cleanupTime = now + 12_000;
+
 		expect(redisMock.hScan.callCount).to.equal(1);
 		expect(redisMock.hScan.firstCall.args).to.deep.equal([ 'gp:in-progress', '0', { COUNT: 5000 }]);
-		expect(redisMock.markFinishedByTimeout.callCount).to.equal(2);
+		expect(redisMock.claimTimedOutMeasurements.callCount).to.equal(1);
+		expect(redisMock.claimTimedOutMeasurements.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', cleanupTime, 5000, cleanupTime + 30_000 ]);
+		expect(redisMock.markFinishedByTimeout.callCount).to.equal(3);
 		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
 		expect(redisMock.markFinishedByTimeout.secondCall.args).to.deep.equal([ mockedMeasurementId2 ]);
+		expect(redisMock.markFinishedByTimeout.thirdCall.args).to.deep.equal([ mockedMeasurementId3 ]);
 		expect(redisMock.hDel.callCount).to.equal(1);
-		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1, mockedMeasurementId2 ] ]);
+		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1, mockedMeasurementId2, mockedMeasurementId3 ] ]);
+		expect(redisMock.zRem.callCount).to.equal(1);
+		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1, mockedMeasurementId2, mockedMeasurementId3 ] ]);
 		expect(redisMock.del.callCount).to.equal(0);
 		expect(redisMock.json.set.callCount).to.equal(0);
 		expect(redisMock.compressedJsonCompress.callCount).to.equal(0);
@@ -203,7 +217,32 @@ describe('measurement store', () => {
 		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
 		expect(redisMock.hDel.callCount).to.equal(1);
 		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1 ] ]);
+		expect(redisMock.zRem.callCount).to.equal(1);
+		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1 ] ]);
 		expect(enqueueForOffloadStub.callCount).to.equal(0);
+	});
+
+	it('should continue legacy timeout cleanup when the timeout index claim fails', async () => {
+		redisMock.claimTimedOutMeasurements.rejects(new Error('zset unavailable'));
+
+		redisMock.hScan.resolves({
+			cursor: '0',
+			entries: [
+				{ field: mockedMeasurementId1, value: relativeDayUtc(-1).valueOf() },
+			],
+		});
+
+		redisMock.markFinishedByTimeout.resolves(null);
+
+		const store = getMeasurementStore();
+		await store.cleanup();
+
+		expect(redisMock.markFinishedByTimeout.callCount).to.equal(1);
+		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
+		expect(redisMock.hDel.callCount).to.equal(1);
+		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1 ] ]);
+		expect(redisMock.zRem.callCount).to.equal(1);
+		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1 ] ]);
 	});
 
 	it('should read compressed measurement results for the offloader batch path', async () => {
@@ -247,6 +286,13 @@ describe('measurement store', () => {
 		expect(redisMock.hSet.callCount).to.equal(2);
 
 		expect(redisMock.hSet.args[0]).to.deep.equal([ 'gp:in-progress', mockedMeasurementId1, now ]);
+		expect(redisMock.zAdd.callCount).to.equal(1);
+
+		expect(redisMock.zAdd.args[0]).to.deep.equal([ 'gp:in-progress-timeouts', {
+			score: now + 30_000,
+			value: mockedMeasurementId1,
+		}]);
+
 		expect(redisMock.set.callCount).to.equal(1);
 		expect(redisMock.set.args[0]).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:probes_awaiting`, 4, { EX: 60 }]);
 		expect(redisMock.json.set.callCount).to.equal(3);
@@ -790,6 +836,8 @@ describe('measurement store', () => {
 		expect(redisMock.markFinished.args[0]).to.deep.equal([ mockedMeasurementId1 ]);
 		expect(redisMock.hDel.callCount).to.equal(1);
 		expect(redisMock.hDel.args[0]).to.deep.equal([ 'gp:in-progress', mockedMeasurementId1 ]);
+		expect(redisMock.zRem.callCount).to.equal(1);
+		expect(redisMock.zRem.args[0]).to.deep.equal([ 'gp:in-progress-timeouts', mockedMeasurementId1 ]);
 		expect(enqueueForOffloadStub.callCount).to.equal(1);
 		expect(enqueueForOffloadStub.firstCall.args).to.deep.equal([ finishedRecord ]);
 	});


### PR DESCRIPTION
Improves measurement timeout cleanup so it can keep up when many measurements are in progress. New measurements are added to a timeout-ordered Redis index instead of a hash map, allowing cleanup workers to claim expired measurements directly instead of listing the unexpired ones too.