### PR TITLE
refactor: remove in-progress use

### DIFF
--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -178,7 +178,6 @@ export class MeasurementStore {
 	async markFinished (id: string): Promise<MeasurementRecord | null> {
 		const [ recordBuffer ] = await Promise.all([
 			this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).markFinished(id),
-			this.redis.hDel('gp:in-progress', id),
 			this.redis.zRem('gp:in-progress-timeouts', id),
 		]);
 
@@ -201,10 +200,7 @@ export class MeasurementStore {
 			return parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
 		}, { concurrency: 32 })).filter(is.truthy);
 
-		await Promise.all([
-			this.redis.hDel('gp:in-progress', ids),
-			this.redis.zRem('gp:in-progress-timeouts', ids),
-		]);
+		await this.redis.zRem('gp:in-progress-timeouts', ids);
 
 		for (const measurement of measurements) {
 			this.offloader.enqueueForOffload(measurement);
@@ -215,36 +211,7 @@ export class MeasurementStore {
 		const SCAN_BATCH_SIZE = 5000;
 		const CLEANUP_LEASE_TIME = 30_000;
 		const now = Date.now();
-		const timeoutTime = config.get<number>('measurement.timeout') * 1000;
-
-		const scanLegacyInProgress = async () => {
-			const entries: { field: string; value: string }[] = [];
-			let cursor = '0';
-
-			do {
-				const result = await this.redis.hScan('gp:in-progress', cursor, { COUNT: SCAN_BATCH_SIZE });
-				cursor = result.cursor;
-				entries.push(...result.entries);
-			} while (cursor !== '0' && entries.length < SCAN_BATCH_SIZE);
-
-			return { cursor, entries };
-		};
-
-		const [ claimResult, scanResult ] = await Promise.allSettled([
-			this.redis.claimTimedOutMeasurements('gp:in-progress-timeouts', now, SCAN_BATCH_SIZE, now + CLEANUP_LEASE_TIME),
-			scanLegacyInProgress(),
-		]);
-		const claimedTimedOutIds = claimResult.status === 'fulfilled' ? claimResult.value : [];
-		const { cursor, entries } = scanResult.status === 'fulfilled' ? scanResult.value : { cursor: '0', entries: [] };
-
-		if (cursor !== '0') {
-			logger.warn(`There are more than ${SCAN_BATCH_SIZE} "in-progress" elements in db`);
-		}
-
-		const legacyTimedOutIds = entries
-			.filter(({ value: time }) => now - Number(time) >= timeoutTime)
-			.map(({ field: id }) => id);
-		const timedOutIds = _.uniq([ ...legacyTimedOutIds, ...claimedTimedOutIds ]);
+		const timedOutIds = await this.redis.claimTimedOutMeasurements('gp:in-progress-timeouts', now, SCAN_BATCH_SIZE, now + CLEANUP_LEASE_TIME);
 
 		await this.markFinishedByTimeout(timedOutIds);
 	}

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -3,7 +3,6 @@ import { brotliCompress as brotliCompressCallback } from 'node:zlib';
 import * as td from 'testdouble';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import relativeDayUtc from 'relative-day-utc';
 import * as id from '../../../../src/measurement/id.js';
 import type { MeasurementStore } from '../../../../src/measurement/store.js';
 import type { OfflineProbe, ServerProbe } from '../../../../src/probe/types.js';
@@ -58,8 +57,6 @@ describe('measurement store', () => {
 		compressedJsonGet: sandbox.stub(),
 		compressedJsonGetBuffer: sandbox.stub(),
 		compressedJsonGetBufferCompressed: sandbox.stub(),
-		hScan: sandbox.stub(),
-		hDel: sandbox.stub(),
 		hSet: sandbox.stub(),
 		hExpire: sandbox.stub(),
 		zAdd: sandbox.stub(),
@@ -83,7 +80,6 @@ describe('measurement store', () => {
 
 	const mockedMeasurementId1 = '2E2SZgEwA6W6HvzlT0001z9VK';
 	const mockedMeasurementId2 = '2F2SZgEwA6W6HvzlT0001z9VK';
-	const mockedMeasurementId3 = '2G2SZgEwA6W6HvzlT0001z9VK';
 
 	sandbox.stub(Math, 'random').returns(0.8);
 	redisMock.withTypeMapping.returns(redisMock);
@@ -124,7 +120,6 @@ describe('measurement store', () => {
 		redisMock.recordResult.reset();
 		redisMock.markFinishedByTimeout.reset();
 		redisMock.claimTimedOutMeasurements.reset();
-		redisMock.hScan.reset();
 		redisMock.claimTimedOutMeasurements.resolves([]);
 		sandbox.resetHistory();
 	});
@@ -155,16 +150,7 @@ describe('measurement store', () => {
 			}],
 		};
 
-		redisMock.hScan.resolves({
-			cursor: '0',
-			entries: [
-				{ field: mockedMeasurementId1, value: relativeDayUtc(-1).valueOf() }, // Timed out measurement
-				{ field: mockedMeasurementId2, value: relativeDayUtc(-1).valueOf() }, // Non-existing measurement
-				{ field: mockedMeasurementId3, value: relativeDayUtc(1).valueOf() }, // Not timed out measurement
-			],
-		});
-
-		redisMock.claimTimedOutMeasurements.resolves([ mockedMeasurementId3 ]);
+		redisMock.claimTimedOutMeasurements.resolves([ mockedMeasurementId1, mockedMeasurementId2 ]);
 
 		redisMock.markFinishedByTimeout.onFirstCall().resolves(Buffer.concat([
 			Buffer.from([ 0x00 ]),
@@ -179,18 +165,13 @@ describe('measurement store', () => {
 
 		const cleanupTime = now + 12_000;
 
-		expect(redisMock.hScan.callCount).to.equal(1);
-		expect(redisMock.hScan.firstCall.args).to.deep.equal([ 'gp:in-progress', '0', { COUNT: 5000 }]);
 		expect(redisMock.claimTimedOutMeasurements.callCount).to.equal(1);
 		expect(redisMock.claimTimedOutMeasurements.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', cleanupTime, 5000, cleanupTime + 30_000 ]);
-		expect(redisMock.markFinishedByTimeout.callCount).to.equal(3);
+		expect(redisMock.markFinishedByTimeout.callCount).to.equal(2);
 		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
 		expect(redisMock.markFinishedByTimeout.secondCall.args).to.deep.equal([ mockedMeasurementId2 ]);
-		expect(redisMock.markFinishedByTimeout.thirdCall.args).to.deep.equal([ mockedMeasurementId3 ]);
-		expect(redisMock.hDel.callCount).to.equal(1);
-		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1, mockedMeasurementId2, mockedMeasurementId3 ] ]);
 		expect(redisMock.zRem.callCount).to.equal(1);
-		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1, mockedMeasurementId2, mockedMeasurementId3 ] ]);
+		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1, mockedMeasurementId2 ] ]);
 		expect(redisMock.del.callCount).to.equal(0);
 		expect(redisMock.json.set.callCount).to.equal(0);
 		expect(redisMock.compressedJsonCompress.callCount).to.equal(0);
@@ -200,80 +181,18 @@ describe('measurement store', () => {
 	});
 
 	it('should not offload when timeout cleanup loses to a normal finish', async () => {
-		redisMock.hScan.resolves({
-			cursor: '0',
-			entries: [
-				{ field: mockedMeasurementId1, value: relativeDayUtc(-1).valueOf() },
-			],
-		});
-
+		redisMock.claimTimedOutMeasurements.resolves([ mockedMeasurementId1 ]);
 		redisMock.markFinishedByTimeout.resolves(null);
 
 		getMeasurementStore();
 
 		await clock.tickAsyncStepped(16_000);
 
-		expect(redisMock.hScan.callCount).to.equal(1);
 		expect(redisMock.markFinishedByTimeout.callCount).to.equal(1);
 		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
-		expect(redisMock.hDel.callCount).to.equal(1);
-		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1 ] ]);
 		expect(redisMock.zRem.callCount).to.equal(1);
 		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1 ] ]);
 		expect(enqueueForOffloadStub.callCount).to.equal(0);
-	});
-
-	it('should continue legacy timeout cleanup when Redis returns an empty scan page', async () => {
-		redisMock.hScan.onFirstCall().resolves({
-			cursor: '142092',
-			entries: [],
-		});
-
-		redisMock.hScan.onSecondCall().resolves({
-			cursor: '0',
-			entries: [
-				{ field: mockedMeasurementId1, value: relativeDayUtc(-1).valueOf() },
-			],
-		});
-
-		redisMock.claimTimedOutMeasurements.resolves([]);
-		redisMock.markFinishedByTimeout.resolves(null);
-
-		const store = getMeasurementStore();
-		await store.cleanup();
-
-		expect(redisMock.hScan.callCount).to.equal(2);
-		expect(redisMock.hScan.firstCall.args).to.deep.equal([ 'gp:in-progress', '0', { COUNT: 5000 }]);
-		expect(redisMock.hScan.secondCall.args).to.deep.equal([ 'gp:in-progress', '142092', { COUNT: 5000 }]);
-		expect(redisMock.markFinishedByTimeout.callCount).to.equal(1);
-		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
-		expect(redisMock.hDel.callCount).to.equal(1);
-		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1 ] ]);
-		expect(redisMock.zRem.callCount).to.equal(1);
-		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1 ] ]);
-	});
-
-	it('should continue legacy timeout cleanup when the timeout index claim fails', async () => {
-		redisMock.claimTimedOutMeasurements.rejects(new Error('zset unavailable'));
-
-		redisMock.hScan.resolves({
-			cursor: '0',
-			entries: [
-				{ field: mockedMeasurementId1, value: relativeDayUtc(-1).valueOf() },
-			],
-		});
-
-		redisMock.markFinishedByTimeout.resolves(null);
-
-		const store = getMeasurementStore();
-		await store.cleanup();
-
-		expect(redisMock.markFinishedByTimeout.callCount).to.equal(1);
-		expect(redisMock.markFinishedByTimeout.firstCall.args).to.deep.equal([ mockedMeasurementId1 ]);
-		expect(redisMock.hDel.callCount).to.equal(1);
-		expect(redisMock.hDel.firstCall.args).to.deep.equal([ 'gp:in-progress', [ mockedMeasurementId1 ] ]);
-		expect(redisMock.zRem.callCount).to.equal(1);
-		expect(redisMock.zRem.firstCall.args).to.deep.equal([ 'gp:in-progress-timeouts', [ mockedMeasurementId1 ] ]);
 	});
 
 	it('should read compressed measurement results for the offloader batch path', async () => {
@@ -863,8 +782,6 @@ describe('measurement store', () => {
 
 		expect(redisMock.markFinished.callCount).to.equal(1);
 		expect(redisMock.markFinished.args[0]).to.deep.equal([ mockedMeasurementId1 ]);
-		expect(redisMock.hDel.callCount).to.equal(1);
-		expect(redisMock.hDel.args[0]).to.deep.equal([ 'gp:in-progress', mockedMeasurementId1 ]);
 		expect(redisMock.zRem.callCount).to.equal(1);
 		expect(redisMock.zRem.args[0]).to.deep.equal([ 'gp:in-progress-timeouts', mockedMeasurementId1 ]);
 		expect(enqueueForOffloadStub.callCount).to.equal(1);


### PR DESCRIPTION
Cleans up after https://github.com/jsdelivr/globalping/pull/853 now that all previous measurements are handled.