### PR TITLE
fix: prevent races in measurement finish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"bullmq": "^5.79.0",
 				"cidr-tools": "^12.1.1",
 				"config": "^4.4.1",
-				"config-mapper-env": "^3.0.1",
+				"config-mapper-env": "^3.0.2",
 				"countries-list": "^3.3.0",
 				"crypto-random-string": "^5.0.0",
 				"csv-parser": "^3.2.1",
@@ -59,7 +59,7 @@
 				"proxy-addr": "^2.0.7",
 				"rate-limiter-flexible": "^11.2.0",
 				"redis": "^5.12.1",
-				"semver": "^7.8.4",
+				"semver": "^7.8.5",
 				"socket.io": "^4.8.3",
 				"type-fest": "^5.7.0",
 				"validator": "^13.15.35"
@@ -5397,12 +5397,12 @@
 			}
 		},
 		"node_modules/config-mapper-env": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/config-mapper-env/-/config-mapper-env-3.0.1.tgz",
-			"integrity": "sha512-gXAfsdm7Wm0giHtidOO1qPB2ee46Nw+31+cRoLZagOwT0U3iQaFnkmz7JFQnvvtdBmxKaXywVOJalpRNTDNveg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/config-mapper-env/-/config-mapper-env-3.0.2.tgz",
+			"integrity": "sha512-/yAe/cSXi/6MHgRURDakyWqrqCbpHzIM3MCnlx52v6XFEdDabu4h5vqlEVkoDk7mhDdEFCH+bLtKA0TgmU6OeA==",
 			"license": "MIT",
 			"dependencies": {
-				"lodash": "^4.17.21"
+				"lodash": "^4.18.1"
 			}
 		},
 		"node_modules/console-log-level": {
@@ -13805,9 +13805,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/semver": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"bullmq": "^5.79.0",
 		"cidr-tools": "^12.1.1",
 		"config": "^4.4.1",
-		"config-mapper-env": "^3.0.1",
+		"config-mapper-env": "^3.0.2",
 		"countries-list": "^3.3.0",
 		"crypto-random-string": "^5.0.0",
 		"csv-parser": "^3.2.1",
@@ -56,7 +56,7 @@
 		"proxy-addr": "^2.0.7",
 		"rate-limiter-flexible": "^11.2.0",
 		"redis": "^5.12.1",
-		"semver": "^7.8.4",
+		"semver": "^7.8.5",
 		"socket.io": "^4.8.3",
 		"type-fest": "^5.7.0",
 		"validator": "^13.15.35"

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -115,10 +115,14 @@ const recordResult = defineScript({
 	redis.call('JSON.SET', keyMeasurementResults, '$.updatedAt', date)
 
 	if probesAwaiting ~= 0 then
-		return 0
+		return
 	end
 
-	return 1
+	redis.call('DEL', keyMeasurementAwaiting)
+	redis.call('JSON.SET', keyMeasurementResults, '$.status', '"finished"')
+	redis.call('COMPRESSED.JSON.COMPRESS', keyMeasurementResults)
+
+	return redis.call('COMPRESSED.JSON.GET', keyMeasurementResults)
 	`,
 	parseCommand (parser: CommandParser, measurementId: string, testId: string, data: MeasurementResultMessage['result']) {
 		pushMeasurementKeys(parser, measurementId);
@@ -128,26 +132,6 @@ const recordResult = defineScript({
 			JSON.stringify(data),
 			`"${new Date().toISOString()}"`,
 		);
-	},
-	transformReply (reply: number) {
-		return Boolean(reply);
-	},
-});
-
-const markFinished = defineScript({
-	NUMBER_OF_KEYS: 2,
-	SCRIPT: `
-	local keyMeasurementResults = KEYS[1]
-	local keyMeasurementAwaiting = KEYS[2]
-
-	redis.call('DEL', keyMeasurementAwaiting)
-	redis.call('JSON.SET', keyMeasurementResults, '$.status', '"finished"')
-	redis.call('COMPRESSED.JSON.COMPRESS', keyMeasurementResults)
-
-	return redis.call('COMPRESSED.JSON.GET', keyMeasurementResults)
-	`,
-	parseCommand (parser: CommandParser, measurementId: string) {
-		pushMeasurementKeys(parser, measurementId);
 	},
 	transformReply (reply: Buffer | null) {
 		return reply;
@@ -231,5 +215,5 @@ const claimTimedOutMeasurements = defineScript({
 	},
 });
 
-export const scripts = { recordProgress, recordProgressAppend, recordResult, markFinished, markFinishedByTimeout, claimTimedOutMeasurements };
+export const scripts = { recordProgress, recordProgressAppend, recordResult, markFinishedByTimeout, claimTimedOutMeasurements };
 export type RedisScripts = typeof scripts;

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -39,9 +39,6 @@ export class MeasurementRunner {
 
 		if (onlineProbesMap.size) {
 			this.sendToProbes(measurementId, onlineProbesMap, request);
-			// If all selected probes are offline, immediately mark the measurement as finished
-		} else {
-			await this.store.markFinished(measurementId);
 		}
 
 		this.metrics.recordMeasurement(request.type, onlineProbesMap.size);

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -118,6 +118,7 @@ export class MeasurementStore {
 
 	async createMeasurement (request: MeasurementRequest, onlineProbesMap: Map<number, ServerProbe>, allProbes: (ServerProbe | OfflineProbe)[], userType?: AuthenticateStateUser['userType'], exportMeta: ExportMeta = {}): Promise<string> {
 		const startTime = new Date();
+		const isFinishedImmediately = onlineProbesMap.size === 0;
 		const timeoutTime = config.get<number>('measurement.timeout') * 1000;
 		const results = this.probesToResults(allProbes, request.type);
 		const id = generateMeasurementId(startTime, userType);
@@ -126,7 +127,7 @@ export class MeasurementStore {
 		const measurement: Partial<MeasurementRecord> = {
 			id,
 			type: request.type,
-			status: 'in-progress',
+			status: isFinishedImmediately ? 'finished' : 'in-progress',
 			createdAt: startTime.toISOString(),
 			updatedAt: startTime.toISOString(),
 			target: request.target,
@@ -142,8 +143,8 @@ export class MeasurementStore {
 		const testsToProbes = Object.fromEntries(Array.from(onlineProbesMap, ([ testId, probe ]) => [ `${id}_${testId}`, probe.uuid ]));
 
 		await Promise.all([
-			this.redis.zAdd('gp:in-progress-timeouts', { score: startTime.getTime() + timeoutTime, value: id }),
-			this.redis.set(getMeasurementKey(id, 'probes_awaiting'), onlineProbesMap.size, { EX: config.get<number>('measurement.timeout') + 30 }),
+			!isFinishedImmediately && this.redis.zAdd('gp:in-progress-timeouts', { score: startTime.getTime() + timeoutTime, value: id }),
+			!isFinishedImmediately && this.redis.set(getMeasurementKey(id, 'probes_awaiting'), onlineProbesMap.size, { EX: config.get<number>('measurement.timeout') + 30 }),
 			this.redis.json.set(key, '$', measurementWithoutDefaults),
 			this.redis.json.set(getMeasurementKey(id, 'ips'), '$', allProbes.map(probe => probe.ipAddress)),
 			this.redis.json.set(getMeasurementKey(id, 'meta'), '$', exportMeta),
@@ -153,6 +154,11 @@ export class MeasurementStore {
 			!_.isEmpty(testsToProbes) && this.redis.hSet('gp:test-to-probe', testsToProbes),
 			!_.isEmpty(testsToProbes) && this.redis.hExpire('gp:test-to-probe', Object.keys(testsToProbes), config.get<number>('measurement.timeout') + 120),
 		]);
+
+		if (isFinishedImmediately) {
+			await this.redis.compressedJsonCompress(key);
+			this.offloader.enqueueForOffload(measurementWithoutDefaults as MeasurementRecord);
+		}
 
 		return id;
 	}
@@ -166,24 +172,11 @@ export class MeasurementStore {
 	}
 
 	async storeMeasurementResult (data: MeasurementResultMessage): Promise<MeasurementRecord | null> {
-		const isFinished = await this.redis.recordResult(data.measurementId, data.testId, data.result);
-
-		if (isFinished) {
-			return this.markFinished(data.measurementId);
-		}
-
-		return null;
-	}
-
-	async markFinished (id: string): Promise<MeasurementRecord | null> {
-		const [ recordBuffer ] = await Promise.all([
-			this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).markFinished(id),
-			this.redis.zRem('gp:in-progress-timeouts', id),
-		]);
-
+		const recordBuffer = await this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).recordResult(data.measurementId, data.testId, data.result);
 		const record = await parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
 
 		if (record) {
+			await this.redis.zRem('gp:in-progress-timeouts', data.measurementId);
 			this.offloader.enqueueForOffload(record);
 		}
 

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -381,10 +381,9 @@ describe('MeasurementRunner', () => {
 			},
 		} as unknown as ExtendedContext).catch((err: unknown) => err);
 		expect(err).to.deep.equal(createHttpError(422, 'No matching IPv4 probes available.', { type: 'no_probes_found' }));
-		expect(store.markFinished.callCount).to.equal(0);
 	});
 
-	it('should immideately call store.markFinished if there are no online probes', async () => {
+	it('should create the measurement without sending requests if there are no online probes', async () => {
 		const request = {
 			type: 'ping' as const,
 			target: 'jsdelivr.com',
@@ -415,7 +414,8 @@ describe('MeasurementRunner', () => {
 			state: {},
 		} as unknown as ExtendedContext);
 
-		expect(store.markFinished.callCount).to.equal(1);
-		expect(store.markFinished.args[0]).to.deep.equal([ mockedMeasurementId ]);
+		expect(store.createMeasurement.callCount).to.equal(1);
+		expect(to.callCount).to.equal(0);
+		expect(emit.callCount).to.equal(0);
 	});
 });

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -73,7 +73,6 @@ describe('measurement store', () => {
 		recordProgress: sandbox.stub(),
 		recordProgressAppend: sandbox.stub(),
 		recordResult: sandbox.stub(),
-		markFinished: sandbox.stub(),
 		markFinishedByTimeout: sandbox.stub(),
 		claimTimedOutMeasurements: sandbox.stub(),
 	};
@@ -463,7 +462,7 @@ describe('measurement store', () => {
 		]);
 	});
 
-	it('should initialize measurement object with the proper default in case of offline probes', async () => {
+	it('should create offline-only measurements as finished and offload them immediately', async () => {
 		const now = clock.pause().now;
 		const store = getMeasurementStore();
 		await store.createMeasurement(
@@ -485,7 +484,7 @@ describe('measurement store', () => {
 			{
 				id: mockedMeasurementId1,
 				type: 'ping',
-				status: 'in-progress',
+				status: 'finished',
 				createdAt: new Date(now).toISOString(),
 				updatedAt: new Date(now).toISOString(),
 				target: 'jsdelivr.com',
@@ -514,7 +513,12 @@ describe('measurement store', () => {
 			},
 		]);
 
-		expect(redisMock.set.args[0]).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:probes_awaiting`, 0, { EX: 60 }]);
+		expect(redisMock.zAdd.callCount).to.equal(0);
+		expect(redisMock.set.callCount).to.equal(0);
+		expect(redisMock.compressedJsonCompress.callCount).to.equal(1);
+		expect(redisMock.compressedJsonCompress.args[0]).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:results` ]);
+		expect(enqueueForOffloadStub.callCount).to.equal(1);
+		expect(enqueueForOffloadStub.firstCall.args).to.deep.equal([ redisMock.json.set.firstCall.args[2] ]);
 	});
 
 	it('should store non-default fields of the measurement request', async () => {
@@ -747,15 +751,14 @@ describe('measurement store', () => {
 		expect(redisMock.recordProgress.firstCall.args).to.deep.equal([ mockedMeasurementId1, 'testid', { rawOutput: 'output' }]);
 	});
 
-	it('should mark measurement as finished if storeMeasurementResult returned record', async () => {
-		redisMock.recordResult.resolves({});
+	it('should offload the final measurement record returned by recordResult', async () => {
 		const finishedRecord = {
 			id: mockedMeasurementId1,
 			type: 'ping',
 			status: 'finished',
 			results: [],
 		};
-		redisMock.markFinished.resolves(Buffer.concat([
+		redisMock.recordResult.resolves(Buffer.concat([
 			Buffer.from([ 0x00 ]),
 			Buffer.from(JSON.stringify(finishedRecord)),
 		]));
@@ -780,8 +783,6 @@ describe('measurement store', () => {
 
 		expect(record).to.deep.equal(finishedRecord);
 
-		expect(redisMock.markFinished.callCount).to.equal(1);
-		expect(redisMock.markFinished.args[0]).to.deep.equal([ mockedMeasurementId1 ]);
 		expect(redisMock.zRem.callCount).to.equal(1);
 		expect(redisMock.zRem.args[0]).to.deep.equal([ 'gp:in-progress-timeouts', mockedMeasurementId1 ]);
 		expect(enqueueForOffloadStub.callCount).to.equal(1);
@@ -806,8 +807,6 @@ describe('measurement store', () => {
 			'testid',
 			{ status: 'finished', rawOutput: 'output' },
 		]);
-
-		expect(redisMock.markFinished.callCount).to.equal(0);
 	});
 
 	it('getMeasurementBufferCompressed should prefer the offload DB for likely offloaded measurements', async () => {


### PR DESCRIPTION
Closes the race between normal measurement completion and timeout cleanup by making the final normal result finish the measurement inside the same Redis script.