### PR TITLE
test: switch from ts-node to tsx

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -5,10 +5,6 @@ if (process.env.LOG_LEVEL === undefined) {
 	process.env.LOG_LEVEL = '50';
 }
 
-if (process.env.TS_NODE_TRANSPILE_ONLY === undefined) {
-	process.env.TS_NODE_TRANSPILE_ONLY = 'true';
-}
-
 module.exports = {
 	'exit': true,
 	'timeout': 20000,
@@ -19,7 +15,7 @@ module.exports = {
 	'node-option': [
 		'enable-source-maps',
 		'experimental-specifier-resolution=node',
-		'loader=ts-node/esm',
+		'import=tsx',
 	],
 	'globals': [
 		'__extends',

--- a/.mocharc.e2e.cjs
+++ b/.mocharc.e2e.cjs
@@ -14,7 +14,7 @@ module.exports = {
 	'node-option': [
 		'enable-source-maps',
 		'experimental-specifier-resolution=node',
-		'loader=ts-node/esm',
+		'import=tsx',
 	],
 	'globals': [
 		'__extends',

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
 				"start-server-and-test": "^3.0.11",
 				"supertest": "^7.2.2",
 				"testdouble": "^3.20.2",
-				"ts-node": "^10.9.2",
 				"tsx": "^4.23.0",
 				"typescript": "npm:@typescript/typescript6@^6.0.3"
 			},
@@ -358,19 +357,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@elastic/ecs-helpers": {
@@ -1476,17 +1462,6 @@
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
 		},
 		"node_modules/@js-sdsl/ordered-map": {
 			"version": "4.4.2",
@@ -3236,34 +3211,6 @@
 				"eslint": "^9.0.0 || ^10.0.0"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@tsconfig/strictest": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.8.tgz",
@@ -4512,19 +4459,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/acorn-walk": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.11.0"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/adm-zip": {
@@ -5951,13 +5885,6 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/cron-parser": {
 			"version": "4.9.0",
@@ -10776,13 +10703,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/mapcap": {
 			"version": "1.0.0",
@@ -15615,67 +15535,6 @@
 				"typescript": ">=4.0.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/ts-node/node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ts-node/node_modules/diff": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -16102,13 +15961,6 @@
 			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.3.0",
@@ -16579,16 +16431,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
 		"start-server-and-test": "^3.0.11",
 		"supertest": "^7.2.2",
 		"testdouble": "^3.20.2",
-		"ts-node": "^10.9.2",
 		"tsx": "^4.23.0",
 		"typescript": "npm:@typescript/typescript6@^6.0.3"
 	},
@@ -136,8 +135,7 @@
 		"lint:types": "tsc --noEmit",
 		"test": "npm run lint && npm run test:mocha && npm run test:portman",
 		"test:dist": "node --test-reporter=spec test/dist.js",
-		"test:mocha": "TS_NODE_TRANSPILE_ONLY=false mocha 'test/tests/unit/**/*.test.ts' 'test/tests/integration/**/*.test.ts'",
-		"test:mocha:dev": "LOG_LEVEL=30 mocha 'test/tests/unit/**/*.test.ts' 'test/tests/integration/**/*.test.ts'",
+		"test:mocha": "mocha 'test/tests/unit/**/*.test.ts' 'test/tests/integration/**/*.test.ts'",
 		"test:mocha:custom": "mocha",
 		"test:perf": "npm i --no-save artillery && tsx test-perf/index.ts",
 		"test:portman": "TEST_DONT_RESTART_WORKERS=1 start-test 'npm run start:test' http://localhost:3000/health 'npm run test:portman:create && npm run test:portman:setup && npm run test:portman:run' || E=$?; rm -rf tmp; exit $E;",
@@ -148,7 +146,7 @@
 		"test:e2e:ipv4": "npm run test:e2e:docker && npm run test:e2e:run -- --grep IPv6 --invert",
 		"test:e2e:ipv6": "npm run test:e2e:docker && npm run test:e2e:run -- --grep IPv6",
 		"test:e2e:docker": "docker build -t globalping-api-e2e . && docker build -t globalping-probe-e2e https://github.com/jsdelivr/globalping-probe.git",
-		"test:e2e:run": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha --config .mocharc.e2e.cjs",
+		"test:e2e:run": "NODE_ENV=test mocha --config .mocharc.e2e.cjs",
 		"update:asn-data": "tsx bin/fetch-asn-data.ts"
 	},
 	"lint-staged": {


### PR DESCRIPTION
ts-node is not maintained, and typechecking already runs on all files in the lint step.