### PR TITLE
perf: precheck rate limit

### DIFF
--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -12,4 +12,4 @@ export class CreditsWorker implements Credits {
 }
 
 // In the master (and single-process runs, e.g. tests) callers use the buffer directly.
-export const credits: Credits = creditsMaster ?? new CreditsWorker();
+export const credits: CreditsWorker = creditsMaster ?? new CreditsWorker();

--- a/src/lib/rate-limiter/rate-limiter-post.ts
+++ b/src/lib/rate-limiter/rate-limiter-post.ts
@@ -4,6 +4,8 @@ import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 import { getPersistentRedisClient } from '../redis/persistent-client.js';
 import createHttpError from 'http-errors';
 import type { ExtendedContext } from '../../types.js';
+import type { UserRequest } from '../../measurement/types.js';
+import { getSumOfLocationsLimits } from '../../measurement/schema/location-schema.js';
 import { credits } from '../credits.js';
 import { getIdFromRequest } from './get-id-from-request.js';
 
@@ -50,6 +52,50 @@ const getRateLimiter = (ctx: ExtendedContext): {
 		id: ctx.state.user?.hashedToken ?? getIdFromRequest(ctx.request),
 		rateLimiter: anonymousRateLimiter,
 	};
+};
+
+const getMaxRequestedProbes = (userRequest: UserRequest) => {
+	const locations = userRequest.locations ?? [];
+
+	if (typeof locations === 'string') {
+		return null;
+	}
+
+	return locations.some(l => l.limit) ? getSumOfLocationsLimits(locations) : userRequest.limit;
+};
+
+export const precheckPostMeasurementRateLimit = async (ctx: ExtendedContext, userRequest: UserRequest) => {
+	if (ctx['isAdmin']) {
+		return;
+	}
+
+	const maxProbes = getMaxRequestedProbes(userRequest);
+
+	if (maxProbes === null) {
+		return;
+	}
+
+	const { rateLimiter, id } = getRateLimiter(ctx);
+	const rateLimiterRes = await rateLimiter.get(id);
+
+	if (!rateLimiterRes || rateLimiterRes.remainingPoints >= maxProbes) {
+		return;
+	}
+
+	if (ctx.state.user?.id) {
+		const requiredCredits = maxProbes - rateLimiterRes.remainingPoints;
+		const attempt = failedCreditsAttempts.get(ctx.state.user.id);
+
+		if (!attempt || requiredCredits < attempt.requiredCredits) {
+			return;
+		}
+
+		setCreditsConsumedHeaders(ctx, 0, attempt.remainingCredits);
+	}
+
+	setRequestCostHeaders(ctx, maxProbes);
+	setRateLimitHeaders(ctx, rateLimiterRes, rateLimiter, 0);
+	throw createHttpError(429, 'Too Many Probes Requested', { type: 'too_many_probes' });
 };
 
 export const checkPostMeasurementRateLimit = async (ctx: ExtendedContext, numberOfProbes: number) => {

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -9,7 +9,7 @@ import type { MetricsAgent } from '../lib/metrics.js';
 import type { MeasurementStore } from './store.js';
 import { getMeasurementStore } from './store.js';
 import type { MeasurementRequest, MeasurementResultMessage, MeasurementProgressMessage, UserRequest, MeasurementRequestMessage } from './types.js';
-import { checkPostMeasurementRateLimit } from '../lib/rate-limiter/rate-limiter-post.js';
+import { checkPostMeasurementRateLimit, precheckPostMeasurementRateLimit } from '../lib/rate-limiter/rate-limiter-post.js';
 import type { ExtendedContext } from '../types.js';
 
 export class MeasurementRunner {
@@ -17,12 +17,15 @@ export class MeasurementRunner {
 		private readonly io: Server,
 		private readonly store: MeasurementStore,
 		private readonly router: ProbeRouter,
+		private readonly precheckRateLimit: typeof precheckPostMeasurementRateLimit,
 		private readonly checkRateLimit: typeof checkPostMeasurementRateLimit,
 		private readonly metrics: MetricsAgent,
 	) {}
 
 	async run (ctx: ExtendedContext): Promise<{ measurementId: string; probesCount: number }> {
 		const userRequest = ctx.request.body as UserRequest;
+		await this.precheckRateLimit(ctx, userRequest);
+
 		const { onlineProbesMap, allProbes, request } = await this.router.findMatchingProbes(userRequest);
 		const ipVersion = userRequest.measurementOptions?.ipVersion;
 
@@ -92,5 +95,12 @@ export class MeasurementRunner {
 }
 
 export const initMeasurementRunner = (io: Server, router: ProbeRouter, metricsAgent: MetricsAgent) => {
-	return new MeasurementRunner(io, getMeasurementStore(), router, checkPostMeasurementRateLimit, metricsAgent);
+	return new MeasurementRunner(
+		io,
+		getMeasurementStore(),
+		router,
+		precheckPostMeasurementRateLimit,
+		checkPostMeasurementRateLimit,
+		metricsAgent,
+	);
 };

--- a/src/measurement/schema/location-schema.ts
+++ b/src/measurement/schema/location-schema.ts
@@ -25,8 +25,10 @@ const validateMagic = (value: string, helpers: CustomHelpers): string | ErrorRep
 	return value;
 };
 
+export const getSumOfLocationsLimits = (locations: LocationWithLimit[]) => locations.reduce((sum, location) => sum + (location.limit || 1), 0);
+
 export const sumOfLocationsLimits = (code: string, max: number) => (value: LocationWithLimit[], helpers: CustomHelpers): LocationWithLimit[] | ErrorReport => {
-	const sum = value.reduce((sum, location) => sum + (location.limit || 1), 0);
+	const sum = getSumOfLocationsLimits(value);
 
 	if (sum > max) {
 		return helpers.error(code);

--- a/test/tests/integration/limits.test.ts
+++ b/test/tests/integration/limits.test.ts
@@ -138,9 +138,7 @@ describe('rate limiter', () => {
 				await dashboardClient(CREDITS_TABLE).insert({
 					user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 					amount: 10,
-				}).onConflict().merge({
-					amount: 10,
-				});
+				}).onConflict().merge();
 
 				const response = await requestAgent.get('/v1/limits')
 					.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')

--- a/test/tests/integration/middleware/authenticate.test.ts
+++ b/test/tests/integration/middleware/authenticate.test.ts
@@ -8,6 +8,7 @@ import nockGeoIpProviders from '../../../utils/nock-geo-ip.js';
 import { addFakeProbe, deleteFakeProbes, getTestServer, waitForProbesUpdate } from '../../../utils/server.js';
 import { dashboardClient } from '../../../../src/lib/sql/client.js';
 import { auth, GP_TOKENS_TABLE, Token } from '../../../../src/lib/http/auth.js';
+import { authenticatedRateLimiter } from '../../../../src/lib/rate-limiter/rate-limiter-post.js';
 import type { AuthenticateOptions } from '../../../../src/lib/http/middleware/authenticate.js';
 
 const sessionConfig = config.get<AuthenticateOptions['session']>('server.session');
@@ -134,6 +135,7 @@ describe('authenticate', () => {
 			});
 
 			await auth.syncTokens();
+			await authenticatedRateLimiter.delete('89da69bd-a236-4ab7-9c5d-b5f52ce09959');
 
 			await requestAgent.post('/v1/measurements')
 				.set('Authorization', 'Bearer hf2fnprguymlgliirdk7qv23664c2xcr')

--- a/test/tests/integration/ratelimit.test.ts
+++ b/test/tests/integration/ratelimit.test.ts
@@ -347,9 +347,7 @@ describe('rate limiter', () => {
 			await dashboardClient(CREDITS_TABLE).insert({
 				user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
 				amount: 10,
-			}).onConflict().merge({
-				amount: 10,
-			});
+			}).onConflict().merge();
 		});
 
 		it('should consume free credits before paid credits', async () => {
@@ -506,6 +504,211 @@ describe('rate limiter', () => {
 			expect(response.headers['x-request-cost']).to.equal('2');
 			const credits = await dashboardClient(CREDITS_TABLE).select('amount').where({ user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959' });
 			expect(credits).to.deep.equal([]);
+		});
+	});
+
+	describe('rate limit precheck', () => {
+		it('should reject before matching if the potential cost exceeds the remaining points (anonymous)', async () => {
+			await anonymousPostRateLimiter.set(clientId, 240, 0); // 10 remaining
+
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+				limit: 50,
+			}).expect(429) as Response;
+
+			expect(response.headers['x-ratelimit-consumed']).to.equal('0');
+			expect(response.headers['x-ratelimit-remaining']).to.equal('10');
+			expect(response.headers['x-request-cost']).to.equal('50');
+
+			const rateLimiterRes = await anonymousPostRateLimiter.get(clientId);
+			expect(rateLimiterRes?.consumedPoints).to.equal(240);
+		});
+
+		it('should reject before matching based on the sum of the location limits (anonymous)', async () => {
+			await anonymousPostRateLimiter.set(clientId, 240, 0); // 10 remaining
+
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+				locations: [
+					{ continent: 'EU', limit: 25 },
+					{ continent: 'NA', limit: 25 },
+				],
+			}).expect(429) as Response;
+
+			expect(response.headers['x-ratelimit-consumed']).to.equal('0');
+			expect(response.headers['x-ratelimit-remaining']).to.equal('10');
+			expect(response.headers['x-request-cost']).to.equal('50');
+		});
+
+		it('should skip the precheck when locations is a measurement id (anonymous)', async () => {
+			const { body: { id } } = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+				limit: 2,
+			}).expect(202) as Response;
+
+			await anonymousPostRateLimiter.set(clientId, 240, 0); // 10 remaining
+
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+				locations: id,
+				limit: 50,
+			}).expect(202) as Response;
+
+			expect(response.headers['x-ratelimit-consumed']).to.equal('2');
+			expect(response.headers['x-request-cost']).to.equal('2');
+		});
+
+		it('should pass if the remaining points cover the potential cost (anonymous)', async () => {
+			await anonymousPostRateLimiter.set(clientId, 200, 0); // 50 remaining
+
+			const response = await requestAgent.post('/v1/measurements').send({
+				type: 'ping',
+				target: 'jsdelivr.com',
+				limit: 50,
+			}).expect(202) as Response;
+
+			expect(response.headers['x-ratelimit-consumed']).to.equal('2');
+			expect(response.headers['x-ratelimit-remaining']).to.equal('48');
+			expect(response.headers['x-request-cost']).to.equal('2');
+		});
+
+		it('should pass when there is no recent failed credits attempt (authenticated)', async () => {
+			await authenticatedPostRateLimiter.set('89da69bd-a236-4ab7-9c5d-b5f52ce09959', 490, 0); // 10 remaining
+
+			await dashboardClient(CREDITS_TABLE).insert({
+				user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
+				amount: 100,
+			}).onConflict().merge();
+
+			const response = await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 50,
+				}).expect(202) as Response;
+
+			expect(response.headers['x-ratelimit-consumed']).to.equal('2');
+			expect(response.headers['x-ratelimit-remaining']).to.equal('8');
+			expect(response.headers['x-credits-consumed']).to.not.exist;
+			expect(response.headers['x-request-cost']).to.equal('2');
+			const [{ amount }] = await dashboardClient(CREDITS_TABLE).select('amount').where({ user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959' });
+			expect(amount).to.equal(100);
+		});
+
+		it('should reject before matching after a failed credits attempt (authenticated)', async () => {
+			await authenticatedPostRateLimiter.set('89da69bd-a236-4ab7-9c5d-b5f52ce09959', 500, 0); // 0 remaining
+
+			await dashboardClient(CREDITS_TABLE).insert({
+				user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
+				amount: 1,
+			}).onConflict().merge();
+
+			const response = await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 50,
+				}).expect(429) as Response;
+
+			// The first request is rejected by the real check, after matching.
+			expect(response.headers['x-request-cost']).to.equal('2');
+			expect(response.headers['x-ratelimit-consumed']).to.equal('0');
+			expect(response.headers['x-ratelimit-remaining']).to.equal('0');
+			expect(response.headers['x-credits-consumed']).to.equal('0');
+			expect(response.headers['x-credits-remaining']).to.equal('1');
+
+			expect(failedCreditsAttempts.get('89da69bd-a236-4ab7-9c5d-b5f52ce09959')).to.deep.equal({ requiredCredits: 2, remainingCredits: 1 });
+
+			const response2 = await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 50,
+				}).expect(429) as Response;
+
+			// The second request is rejected by the precheck, before matching.
+			expect(response2.headers['x-request-cost']).to.equal('50');
+			expect(response2.headers['x-ratelimit-consumed']).to.equal('0');
+			expect(response2.headers['x-ratelimit-remaining']).to.equal('0');
+			expect(response2.headers['x-credits-consumed']).to.equal('0');
+			expect(response2.headers['x-credits-remaining']).to.equal('1');
+			const [{ amount }] = await dashboardClient(CREDITS_TABLE).select('amount').where({ user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959' });
+			expect(amount).to.equal(1);
+		});
+
+		it('should keep rejecting after a donation until the failed attempt expires (authenticated)', async () => {
+			await authenticatedPostRateLimiter.set('89da69bd-a236-4ab7-9c5d-b5f52ce09959', 500, 0); // 0 remaining
+
+			await dashboardClient(CREDITS_TABLE).insert({
+				user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
+				amount: 1,
+			}).onConflict().merge();
+
+			await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 50,
+				}).expect(429) as Response;
+
+			await dashboardClient(CREDITS_TABLE).update({
+				amount: 100,
+			}).where({
+				user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
+			});
+
+			const response = await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 50,
+				}).expect(429) as Response;
+
+			expect(response.headers['x-request-cost']).to.equal('50');
+			expect(response.headers['x-credits-remaining']).to.equal('1');
+			const [{ amount }] = await dashboardClient(CREDITS_TABLE).select('amount').where({ user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959' });
+			expect(amount).to.equal(100);
+		});
+
+		it('should pass a smaller request after a failed attempt on a bigger one (authenticated)', async () => {
+			await authenticatedPostRateLimiter.set('89da69bd-a236-4ab7-9c5d-b5f52ce09959', 500, 0); // 0 remaining
+
+			await dashboardClient(CREDITS_TABLE).insert({
+				user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959',
+				amount: 1,
+			}).onConflict().merge();
+
+			await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 50,
+				}).expect(429) as Response;
+
+			const response = await requestAgent.post('/v1/measurements')
+				.set('Authorization', 'Bearer qz5kdukfcr3vggv3xbujvjwvirkpkkpx')
+				.send({
+					type: 'ping',
+					target: 'jsdelivr.com',
+					limit: 1,
+				}).expect(202) as Response;
+
+			expect(response.headers['x-request-cost']).to.equal('1');
+			expect(response.headers['x-ratelimit-consumed']).to.equal('0');
+			expect(response.headers['x-credits-consumed']).to.equal('1');
+			expect(response.headers['x-credits-remaining']).to.equal('0');
+			const [{ amount }] = await dashboardClient(CREDITS_TABLE).select('amount').where({ user_id: '89da69bd-a236-4ab7-9c5d-b5f52ce09959' });
+			expect(amount).to.equal(0);
 		});
 	});
 });

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -29,6 +29,7 @@ describe('MeasurementRunner', () => {
 	const router = sandbox.createStubInstance(ProbeRouter);
 	const metrics = sandbox.createStubInstance(MetricsAgent);
 	const rateLimit = sandbox.stub();
+	const precheckRateLimit = sandbox.stub();
 	let runner: MeasurementRunner;
 	let testId: number;
 
@@ -38,7 +39,7 @@ describe('MeasurementRunner', () => {
 	before(async () => {
 		await td.replaceEsm('crypto-random-string', null, () => testId++);
 		const { MeasurementRunner } = await import('../../../../src/measurement/runner.js');
-		runner = new MeasurementRunner(io, store, router, rateLimit, metrics);
+		runner = new MeasurementRunner(io, store, router, precheckRateLimit, rateLimit, metrics);
 	});
 
 	beforeEach(() => {
@@ -47,6 +48,7 @@ describe('MeasurementRunner', () => {
 		to.returns({ emit });
 		io.of.withArgs('/probes').returns({ to } as any);
 		store.createMeasurement.resolves(mockedMeasurementId);
+		precheckRateLimit.resolves();
 		testId = 0;
 	});
 
@@ -417,5 +419,76 @@ describe('MeasurementRunner', () => {
 		expect(store.createMeasurement.callCount).to.equal(1);
 		expect(to.callCount).to.equal(0);
 		expect(emit.callCount).to.equal(0);
+	});
+
+	it('should precheck the rate limit before matching probes', async () => {
+		const request = {
+			type: 'ping' as const,
+			target: 'jsdelivr.com',
+			measurementOptions: {
+				packets: 3,
+				ipVersion: 4,
+				port: 80,
+				protocol: 'ICMP',
+			} as const,
+			locations: [{ country: 'US' }, { country: 'DE' }],
+			limit: 10,
+			inProgressUpdates: false,
+		};
+
+		router.findMatchingProbes.resolves({
+			onlineProbesMap: new Map([ getProbe(0) ].entries()),
+			allProbes: [ getProbe(0) ],
+			request,
+		});
+
+		const ctx = {
+			set,
+			get,
+			req,
+			request: {
+				body: request,
+			},
+			state: {},
+		} as unknown as ExtendedContext;
+
+		await runner.run(ctx);
+
+		expect(precheckRateLimit.callCount).to.equal(1);
+		expect(precheckRateLimit.args[0]).to.deep.equal([ ctx, request ]);
+		expect(precheckRateLimit.calledBefore(router.findMatchingProbes)).to.equal(true);
+	});
+
+	it('should not match probes if the precheck rejects', async () => {
+		const request = {
+			type: 'ping' as const,
+			target: 'jsdelivr.com',
+			measurementOptions: {
+				packets: 3,
+				ipVersion: 4,
+				port: 80,
+				protocol: 'ICMP',
+			} as const,
+			locations: [],
+			limit: 10,
+			inProgressUpdates: false,
+		};
+
+		const error = createHttpError(429, 'Too Many Probes Requested', { type: 'too_many_probes' });
+		precheckRateLimit.rejects(error);
+
+		const err = await runner.run({
+			set,
+			get,
+			req,
+			request: {
+				body: request,
+			},
+			state: {},
+		} as unknown as ExtendedContext).catch((err: unknown) => err);
+
+		expect(err).to.equal(error);
+		expect(router.findMatchingProbes.callCount).to.equal(0);
+		expect(store.createMeasurement.callCount).to.equal(0);
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/709

Today 90% of rejected 429 requests are anon. For authenticated users we need their credits balance to reject correctly. Doing an "extra select" as well as "cache user credits" are both bad options, so we are checking `failedCreditsAttempts` instead.

We can also move `failedCreditsAttempts` to Redis so any worker charges it for every other, but that means extra redis.get for every POST.