### PR TITLE
perf: reduce event loop delays

### DIFF
--- a/src/lib/location/location.ts
+++ b/src/lib/location/location.ts
@@ -115,31 +115,30 @@ export const getRegionAliases = (key: string): string[] => {
 	return array ?? [];
 };
 
-const toIndexString = (s: string) => s.toLowerCase().replaceAll('-', ' ');
-const toIndexStrings = (array: string[]) => array.map(toIndexString);
+const toIndexStrings = (array: string[]) => array.map(s => s.toLowerCase().replaceAll('-', ' '));
 
 const getCountryCategories = _.memoize((country: string) => [
-	[ toIndexString(country) ],
-	[ toIndexString(getCountryIso3ByIso2(country)) ],
-	[ toIndexString(getCountryByIso(country)) ],
+	toIndexStrings([ country ]),
+	toIndexStrings([ getCountryIso3ByIso2(country) ]),
+	toIndexStrings([ getCountryByIso(country) ]),
 	toIndexStrings(getCountryAliases(country)),
 ]);
 
-const getCityCategory = _.memoize((normalizedCity: string) => [ toIndexString(normalizedCity) ]);
+const getCityCategory = _.memoize((normalizedCity: string) => toIndexStrings([ normalizedCity ]));
 
 const getStateCategories = _.memoize((state: string) => [
-	[ toIndexString(state) ],
-	[ toIndexString(getStateExtendedIsoByIso(state)) ],
-	[ toIndexString(getStateNameByIso(state)) ],
+	toIndexStrings([ state ]),
+	toIndexStrings([ getStateExtendedIsoByIso(state) ]),
+	toIndexStrings([ getStateNameByIso(state) ]),
 ]);
 
 const getContinentCategories = _.memoize((continent: string) => [
-	[ toIndexString(continent) ],
-	continent ? [ toIndexString(getContinentName(continent)) ] : [],
+	toIndexStrings([ continent ]),
+	continent ? toIndexStrings([ getContinentName(continent) ]) : [],
 ]);
 
 const getRegionCategories = _.memoize((region: string) => [
-	[ toIndexString(region) ],
+	toIndexStrings([ region ]),
 	toIndexStrings(getRegionAliases(region)),
 ]);
 
@@ -149,17 +148,32 @@ const getNetworkCategories = _.memoize((normalizedNetwork: string) => [
 ]);
 
 export const getIndex = (location: ProbeLocation, normalizedTags: Tag[]) => {
+	const [ country, countryIso3, countryName, countryAliases ] = getCountryCategories(location.country);
+	const city = getCityCategory(location.normalizedCity);
+	const [ state, stateExtendedIso, stateName ] = location.state ? getStateCategories(location.state) : [ [], [], [] ];
+	const [ continent, continentName ] = getContinentCategories(location.continent);
+	const [ region, regionAliases ] = getRegionCategories(location.region);
+	const [ networkPrefixes, networkAliases ] = getNetworkCategories(location.normalizedNetwork);
+
 	// Storing the index as string[][] so each category has its exact position in the index array across all probes.
 	// When adding/removing/moving categories, make sure to update ProbeIndex and all places where it's used.
 	const index = [
-		...getCountryCategories(location.country),
-		getCityCategory(location.normalizedCity),
-		...(location.state ? getStateCategories(location.state) : [ [], [], [] ]),
-		...getContinentCategories(location.continent),
-		...getRegionCategories(location.region),
+		country,
+		countryIso3,
+		countryName,
+		countryAliases,
+		city,
+		state,
+		stateExtendedIso,
+		stateName,
+		continent,
+		continentName,
+		region,
+		regionAliases,
 		[ `as${location.asn}` ],
-		normalizedTags.filter(tag => tag.type === 'system').map(tag => toIndexString(tag.value)),
-		...getNetworkCategories(location.normalizedNetwork),
+		toIndexStrings(normalizedTags.filter(tag => tag.type === 'system').map(tag => tag.value)),
+		networkPrefixes,
+		networkAliases,
 	];
 
 	return index as ProbeIndex;

--- a/src/lib/location/location.ts
+++ b/src/lib/location/location.ts
@@ -115,27 +115,52 @@ export const getRegionAliases = (key: string): string[] => {
 	return array ?? [];
 };
 
+const toIndexString = (s: string) => s.toLowerCase().replaceAll('-', ' ');
+const toIndexStrings = (array: string[]) => array.map(toIndexString);
+
+const getCountryCategories = _.memoize((country: string) => [
+	[ toIndexString(country) ],
+	[ toIndexString(getCountryIso3ByIso2(country)) ],
+	[ toIndexString(getCountryByIso(country)) ],
+	toIndexStrings(getCountryAliases(country)),
+]);
+
+const getCityCategory = _.memoize((normalizedCity: string) => [ toIndexString(normalizedCity) ]);
+
+const getStateCategories = _.memoize((state: string) => [
+	[ toIndexString(state) ],
+	[ toIndexString(getStateExtendedIsoByIso(state)) ],
+	[ toIndexString(getStateNameByIso(state)) ],
+]);
+
+const getContinentCategories = _.memoize((continent: string) => [
+	[ toIndexString(continent) ],
+	continent ? [ toIndexString(getContinentName(continent)) ] : [],
+]);
+
+const getRegionCategories = _.memoize((region: string) => [
+	[ toIndexString(region) ],
+	toIndexStrings(getRegionAliases(region)),
+]);
+
+const getNetworkCategories = _.memoize((normalizedNetwork: string) => [
+	toIndexStrings(getNetworkPrefixes(normalizedNetwork)),
+	toIndexStrings(getNetworkAliases(normalizedNetwork)),
+]);
+
 export const getIndex = (location: ProbeLocation, normalizedTags: Tag[]) => {
 	// Storing the index as string[][] so each category has its exact position in the index array across all probes.
 	// When adding/removing/moving categories, make sure to update ProbeIndex and all places where it's used.
 	const index = [
-		[ location.country ],
-		[ getCountryIso3ByIso2(location.country) ],
-		[ getCountryByIso(location.country) ],
-		getCountryAliases(location.country),
-		[ location.normalizedCity ],
-		location.state ? [ location.state ] : [],
-		location.state ? [ getStateExtendedIsoByIso(location.state) ] : [],
-		location.state ? [ getStateNameByIso(location.state) ] : [],
-		[ location.continent ],
-		location.continent ? [ getContinentName(location.continent) ] : [],
-		[ location.region ],
-		getRegionAliases(location.region),
+		...getCountryCategories(location.country),
+		getCityCategory(location.normalizedCity),
+		...(location.state ? getStateCategories(location.state) : [ [], [], [] ]),
+		...getContinentCategories(location.continent),
+		...getRegionCategories(location.region),
 		[ `as${location.asn}` ],
-		normalizedTags.filter(tag => tag.type === 'system').map(tag => tag.value),
-		getNetworkPrefixes(location.normalizedNetwork),
-		getNetworkAliases(location.normalizedNetwork),
-	].map(category => category.map(s => s.toLowerCase().replaceAll('-', ' ')));
+		normalizedTags.filter(tag => tag.type === 'system').map(tag => toIndexString(tag.value)),
+		...getNetworkCategories(location.normalizedNetwork),
+	];
 
 	return index as ProbeIndex;
 };

--- a/src/lib/override/adopted-probes.ts
+++ b/src/lib/override/adopted-probes.ts
@@ -279,11 +279,11 @@ export class AdoptedProbes {
 		};
 	}
 
-	getUpdatedTags (probe: SocketProbe): Tag[] {
+	getUpdatedTags (probe: SocketProbe): Tag[] | null {
 		const adoption = this.getByIp(probe.ipAddress);
 
 		if (!adoption || (!adoption.tags.length && !adoption.publicProbes)) {
-			return probe.tags;
+			return null;
 		}
 
 		return [
@@ -308,17 +308,19 @@ export class AdoptedProbes {
 				return { ...probe, location: { ...probe.location, hasOverridesApplied: true } };
 			}
 
-			const newLocation = this.getUpdatedLocation(probe) || { ...probe.location, hasOverridesApplied: true };
-
-			const newTags = this.getUpdatedTags(probe);
-			const newNormalizedTags = normalizeTags(newTags);
+			const customLocation = this.getUpdatedLocation(probe);
+			const newLocation = customLocation || { ...probe.location, hasOverridesApplied: true as const };
+			const customTags = this.getUpdatedTags(probe);
+			const newTags = customTags || probe.tags;
+			const newNormalizedTags = customTags ? normalizeTags(customTags) : probe.normalizedTags;
+			const newIndex = customLocation || customTags ? getIndex(newLocation, newNormalizedTags) : probe.index;
 
 			return {
 				...probe,
 				location: newLocation,
 				tags: newTags,
 				normalizedTags: newNormalizedTags,
-				index: getIndex(newLocation, newNormalizedTags),
+				index: newIndex,
 				owner: { id: adoption.userId },
 			};
 		});

--- a/src/lib/ws/synced-probe-list.ts
+++ b/src/lib/ws/synced-probe-list.ts
@@ -404,7 +404,7 @@ export class SyncedProbeList extends EventEmitter {
 		}
 
 		const eventsByNode = _.groupBy(eventsToProcess, event => event.message[MESSAGE_TYPES.NODE]);
-		let appliedUpdates = false;
+		let nodeDataChanged = false;
 
 		const results = await Promise.allSettled(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
 			const changes: NodeChanges = {
@@ -458,7 +458,7 @@ export class SyncedProbeList extends EventEmitter {
 
 				if (newNodeData) {
 					this.setNodeData(newNodeData);
-					appliedUpdates = true;
+					nodeDataChanged = true;
 				}
 
 				return;
@@ -494,10 +494,10 @@ export class SyncedProbeList extends EventEmitter {
 			};
 
 			this.setNodeData(newNodeData);
-			appliedUpdates = true;
+			nodeDataChanged = true;
 		}));
 
-		if (appliedUpdates) {
+		if (nodeDataChanged) {
 			this.updateProbes();
 		}
 

--- a/src/lib/ws/synced-probe-list.ts
+++ b/src/lib/ws/synced-probe-list.ts
@@ -406,7 +406,7 @@ export class SyncedProbeList extends EventEmitter {
 		const eventsByNode = _.groupBy(eventsToProcess, event => event.message[MESSAGE_TYPES.NODE]);
 		let appliedUpdates = false;
 
-		await Promise.all(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
+		const results = await Promise.allSettled(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
 			const changes: NodeChanges = {
 				nodeId,
 				revalidateTimestamp: undefined,
@@ -495,11 +495,17 @@ export class SyncedProbeList extends EventEmitter {
 
 			this.setNodeData(newNodeData);
 			appliedUpdates = true;
-		})).finally(() => {
-			if (appliedUpdates) {
-				this.updateProbes();
-			}
-		});
+		}));
+
+		if (appliedUpdates) {
+			this.updateProbes();
+		}
+
+		const error = results.find(result => result.status === 'rejected');
+
+		if (error) {
+			throw error.reason;
+		}
 
 		this.lastReadEventId = events.at(-1)!.id;
 	}

--- a/src/lib/ws/synced-probe-list.ts
+++ b/src/lib/ws/synced-probe-list.ts
@@ -205,12 +205,16 @@ export class SyncedProbeList extends EventEmitter {
 	}
 
 	private handleUpdate (message: NodeData) {
+		this.setNodeData(message);
+		this.updateProbes();
+	}
+
+	private setNodeData (message: NodeData) {
 		if (message.nodeId !== this.nodeId && !this.nodeData.has(message.nodeId)) {
 			this.logger.info(`Registered new node ${message.nodeId}.`);
 		}
 
 		this.nodeData.set(message.nodeId, message, { ttl: this.syncTimeout });
-		this.updateProbes();
 	}
 
 	private getRemoteDataKey (nodeId: string) {
@@ -400,95 +404,105 @@ export class SyncedProbeList extends EventEmitter {
 		}
 
 		const eventsByNode = _.groupBy(eventsToProcess, event => event.message[MESSAGE_TYPES.NODE]);
+		let appliedUpdates = 0;
 
-		await Promise.all(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
-			const changes: NodeChanges = {
-				nodeId,
-				revalidateTimestamp: undefined,
-				reloadNode: hasMissedEvents,
-				removeProbes: new Set(),
-				updateProbes: new Set(),
-				updateStats: new Map(),
-			};
+		try {
+			await Promise.all(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
+				const changes: NodeChanges = {
+					nodeId,
+					revalidateTimestamp: undefined,
+					reloadNode: hasMissedEvents,
+					removeProbes: new Set(),
+					updateProbes: new Set(),
+					updateStats: new Map(),
+				};
 
-			if (changes.reloadNode) {
-				return changes;
-			}
+				if (changes.reloadNode) {
+					return changes;
+				}
 
-			for (const event of nodeEvents) {
-				for (const [ key, value ] of Object.entries(event.message)) {
-					switch (key) {
-						case MESSAGE_TYPES.ALIVE:
-							changes.revalidateTimestamp = Number(value);
-							break;
+				for (const event of nodeEvents) {
+					for (const [ key, value ] of Object.entries(event.message)) {
+						switch (key) {
+							case MESSAGE_TYPES.ALIVE:
+								changes.revalidateTimestamp = Number(value);
+								break;
 
-						case MESSAGE_TYPES.RELOAD:
-							changes.reloadNode = true;
-							return changes;
+							case MESSAGE_TYPES.RELOAD:
+								changes.reloadNode = true;
+								return changes;
 
-						case MESSAGE_TYPES.REMOVE:
-							value.split(',').forEach(id => changes.removeProbes.add(id));
-							break;
+							case MESSAGE_TYPES.REMOVE:
+								value.split(',').forEach(id => changes.removeProbes.add(id));
+								break;
 
-						case MESSAGE_TYPES.UPDATE:
-							value.split(',').forEach(id => changes.updateProbes.add(id));
-							break;
+							case MESSAGE_TYPES.UPDATE:
+								value.split(',').forEach(id => changes.updateProbes.add(id));
+								break;
 
-						case MESSAGE_TYPES.STATS:
-							Object.entries(JSON.parse(value) as Record<string, string>).forEach(([ id, statsString ]) => {
-								changes.updateStats.set(id, this.unserializeProbeStats(statsString));
-							});
+							case MESSAGE_TYPES.STATS:
+								Object.entries(JSON.parse(value) as Record<string, string>).forEach(([ id, statsString ]) => {
+									changes.updateStats.set(id, this.unserializeProbeStats(statsString));
+								});
 
-							break;
+								break;
+						}
 					}
 				}
-			}
 
-			return changes;
-		}).map(async (changes: NodeChanges) => {
-			const nodeData = this.nodeData.get(changes.nodeId);
+				return changes;
+			}).map(async (changes: NodeChanges) => {
+				const nodeData = this.nodeData.get(changes.nodeId);
 
-			if (!nodeData || changes.reloadNode || changes.updateProbes.size > 5) {
-				const newNodeData = await this.getRemoteNodeData(changes.nodeId);
+				if (!nodeData || changes.reloadNode || changes.updateProbes.size > 5) {
+					const newNodeData = await this.getRemoteNodeData(changes.nodeId);
 
-				if (newNodeData) {
-					this.handleUpdate(newNodeData);
+					if (newNodeData) {
+						this.setNodeData(newNodeData);
+						appliedUpdates++;
+					}
+
+					return;
 				}
 
-				return;
-			}
+				const probesById = _.pickBy(nodeData.probesById, ((probe) => {
+					return !changes.removeProbes.has(probe.client);
+				}));
 
-			const probesById = _.pickBy(nodeData.probesById, ((probe) => {
-				return !changes.removeProbes.has(probe.client);
+				changes.updateStats.forEach((stats, id) => {
+					if (probesById[id]) {
+						probesById[id].stats = stats;
+					}
+				});
+
+				if (changes.updateProbes.size) {
+					const paths = Array.from(changes.updateProbes).map(probeId => `$.probesById['${probeId}']`);
+					const newProbesByPath = await this.getRemoteNodeDataAtPaths<ServerProbe>(changes.nodeId, paths);
+
+					if (newProbesByPath) {
+						newProbesByPath.forEach((probe) => {
+							if (probe) {
+								probesById[probe.client] = probe;
+							}
+						});
+					}
+				}
+
+				const newNodeData: NodeData = {
+					...nodeData,
+					...changes.revalidateTimestamp ? { revalidateTimestamp: changes.revalidateTimestamp } : {},
+					probesById,
+				};
+
+				this.setNodeData(newNodeData);
+				appliedUpdates++;
 			}));
-
-			changes.updateStats.forEach((stats, id) => {
-				if (probesById[id]) {
-					probesById[id].stats = stats;
-				}
-			});
-
-			if (changes.updateProbes.size) {
-				const paths = Array.from(changes.updateProbes).map(probeId => `$.probesById['${probeId}']`);
-				const newProbesByPath = await this.getRemoteNodeDataAtPaths<ServerProbe>(changes.nodeId, paths);
-
-				if (newProbesByPath) {
-					newProbesByPath.forEach((probe) => {
-						if (probe) {
-							probesById[probe.client] = probe;
-						}
-					});
-				}
+		} finally {
+			// A single rebuild for the whole batch; runs even on partial failure so the merged list matches nodeData.
+			if (appliedUpdates) {
+				this.updateProbes();
 			}
-
-			const newNodeData: NodeData = {
-				...nodeData,
-				...changes.revalidateTimestamp ? { revalidateTimestamp: changes.revalidateTimestamp } : {},
-				probesById,
-			};
-
-			this.handleUpdate(newNodeData);
-		}));
+		}
 
 		this.lastReadEventId = events.at(-1)!.id;
 	}

--- a/src/lib/ws/synced-probe-list.ts
+++ b/src/lib/ws/synced-probe-list.ts
@@ -404,105 +404,102 @@ export class SyncedProbeList extends EventEmitter {
 		}
 
 		const eventsByNode = _.groupBy(eventsToProcess, event => event.message[MESSAGE_TYPES.NODE]);
-		let appliedUpdates = 0;
+		let appliedUpdates = false;
 
-		try {
-			await Promise.all(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
-				const changes: NodeChanges = {
-					nodeId,
-					revalidateTimestamp: undefined,
-					reloadNode: hasMissedEvents,
-					removeProbes: new Set(),
-					updateProbes: new Set(),
-					updateStats: new Map(),
-				};
+		await Promise.all(Object.entries(eventsByNode).map(([ nodeId, nodeEvents ]) => {
+			const changes: NodeChanges = {
+				nodeId,
+				revalidateTimestamp: undefined,
+				reloadNode: hasMissedEvents,
+				removeProbes: new Set(),
+				updateProbes: new Set(),
+				updateStats: new Map(),
+			};
 
-				if (changes.reloadNode) {
-					return changes;
-				}
-
-				for (const event of nodeEvents) {
-					for (const [ key, value ] of Object.entries(event.message)) {
-						switch (key) {
-							case MESSAGE_TYPES.ALIVE:
-								changes.revalidateTimestamp = Number(value);
-								break;
-
-							case MESSAGE_TYPES.RELOAD:
-								changes.reloadNode = true;
-								return changes;
-
-							case MESSAGE_TYPES.REMOVE:
-								value.split(',').forEach(id => changes.removeProbes.add(id));
-								break;
-
-							case MESSAGE_TYPES.UPDATE:
-								value.split(',').forEach(id => changes.updateProbes.add(id));
-								break;
-
-							case MESSAGE_TYPES.STATS:
-								Object.entries(JSON.parse(value) as Record<string, string>).forEach(([ id, statsString ]) => {
-									changes.updateStats.set(id, this.unserializeProbeStats(statsString));
-								});
-
-								break;
-						}
-					}
-				}
-
+			if (changes.reloadNode) {
 				return changes;
-			}).map(async (changes: NodeChanges) => {
-				const nodeData = this.nodeData.get(changes.nodeId);
+			}
 
-				if (!nodeData || changes.reloadNode || changes.updateProbes.size > 5) {
-					const newNodeData = await this.getRemoteNodeData(changes.nodeId);
+			for (const event of nodeEvents) {
+				for (const [ key, value ] of Object.entries(event.message)) {
+					switch (key) {
+						case MESSAGE_TYPES.ALIVE:
+							changes.revalidateTimestamp = Number(value);
+							break;
 
-					if (newNodeData) {
-						this.setNodeData(newNodeData);
-						appliedUpdates++;
-					}
+						case MESSAGE_TYPES.RELOAD:
+							changes.reloadNode = true;
+							return changes;
 
-					return;
-				}
+						case MESSAGE_TYPES.REMOVE:
+							value.split(',').forEach(id => changes.removeProbes.add(id));
+							break;
 
-				const probesById = _.pickBy(nodeData.probesById, ((probe) => {
-					return !changes.removeProbes.has(probe.client);
-				}));
+						case MESSAGE_TYPES.UPDATE:
+							value.split(',').forEach(id => changes.updateProbes.add(id));
+							break;
 
-				changes.updateStats.forEach((stats, id) => {
-					if (probesById[id]) {
-						probesById[id].stats = stats;
-					}
-				});
+						case MESSAGE_TYPES.STATS:
+							Object.entries(JSON.parse(value) as Record<string, string>).forEach(([ id, statsString ]) => {
+								changes.updateStats.set(id, this.unserializeProbeStats(statsString));
+							});
 
-				if (changes.updateProbes.size) {
-					const paths = Array.from(changes.updateProbes).map(probeId => `$.probesById['${probeId}']`);
-					const newProbesByPath = await this.getRemoteNodeDataAtPaths<ServerProbe>(changes.nodeId, paths);
-
-					if (newProbesByPath) {
-						newProbesByPath.forEach((probe) => {
-							if (probe) {
-								probesById[probe.client] = probe;
-							}
-						});
+							break;
 					}
 				}
+			}
 
-				const newNodeData: NodeData = {
-					...nodeData,
-					...changes.revalidateTimestamp ? { revalidateTimestamp: changes.revalidateTimestamp } : {},
-					probesById,
-				};
+			return changes;
+		}).map(async (changes: NodeChanges) => {
+			const nodeData = this.nodeData.get(changes.nodeId);
 
-				this.setNodeData(newNodeData);
-				appliedUpdates++;
+			if (!nodeData || changes.reloadNode || changes.updateProbes.size > 5) {
+				const newNodeData = await this.getRemoteNodeData(changes.nodeId);
+
+				if (newNodeData) {
+					this.setNodeData(newNodeData);
+					appliedUpdates = true;
+				}
+
+				return;
+			}
+
+			const probesById = _.pickBy(nodeData.probesById, ((probe) => {
+				return !changes.removeProbes.has(probe.client);
 			}));
-		} finally {
-			// A single rebuild for the whole batch; runs even on partial failure so the merged list matches nodeData.
+
+			changes.updateStats.forEach((stats, id) => {
+				if (probesById[id]) {
+					probesById[id].stats = stats;
+				}
+			});
+
+			if (changes.updateProbes.size) {
+				const paths = Array.from(changes.updateProbes).map(probeId => `$.probesById['${probeId}']`);
+				const newProbesByPath = await this.getRemoteNodeDataAtPaths<ServerProbe>(changes.nodeId, paths);
+
+				if (newProbesByPath) {
+					newProbesByPath.forEach((probe) => {
+						if (probe) {
+							probesById[probe.client] = probe;
+						}
+					});
+				}
+			}
+
+			const newNodeData: NodeData = {
+				...nodeData,
+				...changes.revalidateTimestamp ? { revalidateTimestamp: changes.revalidateTimestamp } : {},
+				probesById,
+			};
+
+			this.setNodeData(newNodeData);
+			appliedUpdates = true;
+		})).finally(() => {
 			if (appliedUpdates) {
 				this.updateProbes();
 			}
-		}
+		});
 
 		this.lastReadEventId = events.at(-1)!.id;
 	}

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -1357,6 +1357,19 @@ describe('AdoptedProbes', () => {
 		expect(updatedLocation).to.equal(null);
 	});
 
+	it(`getUpdatedProbes method should reuse the tags and index of the probe if the adoption doesn't change them`, async () => {
+		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);
+		sql.select.resolves([{ ...defaultAdoption, tags: '[]' }]);
+
+		await adoptedProbes.syncDashboardData();
+		const updatedProbe = adoptedProbes.getUpdatedProbes([ defaultConnectedProbe ])[0]!;
+
+		expect(updatedProbe.tags).to.equal(defaultConnectedProbe.tags);
+		expect(updatedProbe.normalizedTags).to.equal(defaultConnectedProbe.normalizedTags);
+		expect(updatedProbe.index).to.equal(defaultConnectedProbe.index);
+		expect(updatedProbe.owner).to.deep.equal({ id: 'userId' });
+	});
+
 	it('getUpdatedTags method should return null if there is nothing to update', async () => {
 		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);
 		sql.select.resolves([{ ...defaultAdoption, tags: '[]' }]);

--- a/test/tests/unit/override/adopted-probes.test.ts
+++ b/test/tests/unit/override/adopted-probes.test.ts
@@ -1357,13 +1357,13 @@ describe('AdoptedProbes', () => {
 		expect(updatedLocation).to.equal(null);
 	});
 
-	it('getUpdatedTags method should return same tags array', async () => {
+	it('getUpdatedTags method should return null if there is nothing to update', async () => {
 		const adoptedProbes = new AdoptedProbes(sqlStub, getProbesWithAdminData);
 		sql.select.resolves([{ ...defaultAdoption, tags: '[]' }]);
 
 		await adoptedProbes.syncDashboardData();
 		const updatedTags = adoptedProbes.getUpdatedTags(defaultConnectedProbe);
-		expect(updatedTags).to.equal(defaultConnectedProbe.tags);
+		expect(updatedTags).to.equal(null);
 	});
 
 	it('getUpdatedTags method should return user tags', async () => {

--- a/test/tests/unit/ws/synced-probe-list.test.ts
+++ b/test/tests/unit/ws/synced-probe-list.test.ts
@@ -273,6 +273,34 @@ describe('SyncedProbeList', () => {
 		expect(redisJsonGet.callCount).to.equal(2);
 	});
 
+	it('rebuilds the probe list once per syncPull batch', async () => {
+		const probesA = { A: getProbe('A') };
+		const probesB = { B: getProbe('B') };
+		const updateListener = sandbox.stub();
+		syncedProbeList.on(syncedProbeList.localUpdateEvent, updateListener);
+
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote1', r: '1' } },
+			{ id: '1-2', message: { n: 'remote2', r: '1' } },
+		]);
+
+		redisJsonGet.onFirstCall().resolves({ nodeId: 'remote1', probesById: probesA, changeTimestamp: Date.now(), revalidateTimestamp: Date.now() });
+		redisJsonGet.onSecondCall().resolves({ nodeId: 'remote2', probesById: probesB, changeTimestamp: Date.now(), revalidateTimestamp: Date.now() });
+
+		await syncedProbeList.syncPull();
+		expect(updateListener.callCount).to.equal(1);
+		expect(omitNode(syncedProbeList.getProbes())).to.deep.equal([ ...Object.values(probesA), ...Object.values(probesB) ]);
+
+		redisXRange.resolves([
+			{ id: '1-2', message: {} },
+			{ id: '1-3', message: { n: 'remote1', a: '2' } },
+			{ id: '1-4', message: { n: 'remote2', a: '2' } },
+		]);
+
+		await syncedProbeList.syncPull();
+		expect(updateListener.callCount).to.equal(2);
+	});
+
 	it('expires remote probes after the timeout', async () => {
 		const probes = {
 			A: getProbe('A'),

--- a/test/tests/unit/ws/synced-probe-list.test.ts
+++ b/test/tests/unit/ws/synced-probe-list.test.ts
@@ -301,6 +301,37 @@ describe('SyncedProbeList', () => {
 		expect(updateListener.callCount).to.equal(2);
 	});
 
+	it('applies successful updates on partial failure, then retries the whole batch', async () => {
+		const probesA = { A: getProbe('A') };
+		const probesB = { B: getProbe('B') };
+		const updateListener = sandbox.stub();
+		syncedProbeList.on(syncedProbeList.localUpdateEvent, updateListener);
+
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote1', r: '1' } },
+			{ id: '1-2', message: { n: 'remote2', r: '1' } },
+		]);
+
+		redisJsonGet.withArgs('gp:spl:probes:remote1').resolves({ nodeId: 'remote1', probesById: probesA, changeTimestamp: Date.now(), revalidateTimestamp: Date.now() });
+		redisJsonGet.withArgs('gp:spl:probes:remote2').rejects(new Error('redis error'));
+
+		const cursorBefore = (syncedProbeList as unknown as { lastReadEventId: string }).lastReadEventId;
+		const error = await syncedProbeList.syncPull().catch((err: Error) => err);
+
+		expect(error).to.be.an('error');
+		expect(updateListener.callCount).to.equal(1);
+		expect(omitNode(syncedProbeList.getProbes())).to.deep.equal(Object.values(probesA));
+		expect((syncedProbeList as unknown as { lastReadEventId: string }).lastReadEventId).to.equal(cursorBefore);
+
+		// The event cursor wasn't advanced, so the next pull retries the same events.
+		redisJsonGet.withArgs('gp:spl:probes:remote2').resolves({ nodeId: 'remote2', probesById: probesB, changeTimestamp: Date.now(), revalidateTimestamp: Date.now() });
+
+		await syncedProbeList.syncPull();
+
+		expect(updateListener.callCount).to.equal(2);
+		expect(omitNode(syncedProbeList.getProbes())).to.deep.equal([ ...Object.values(probesA), ...Object.values(probesB) ]);
+	});
+
 	it('expires remote probes after the timeout', async () => {
 		const probes = {
 			A: getProbe('A'),

--- a/test/tests/unit/ws/synced-probe-list.test.ts
+++ b/test/tests/unit/ws/synced-probe-list.test.ts
@@ -332,6 +332,30 @@ describe('SyncedProbeList', () => {
 		expect(omitNode(syncedProbeList.getProbes())).to.deep.equal([ ...Object.values(probesA), ...Object.values(probesB) ]);
 	});
 
+	it('rebuilds only after all node updates settle on partial failure', async () => {
+		const probesB = { B: getProbe('B') };
+		const updateListener = sandbox.stub();
+		syncedProbeList.on(syncedProbeList.localUpdateEvent, updateListener);
+
+		redisXRange.resolves([
+			{ id: '1-1', message: { n: 'remote1', r: '1' } },
+			{ id: '1-2', message: { n: 'remote2', r: '1' } },
+		]);
+
+		redisJsonGet.withArgs('gp:spl:probes:remote1').rejects(new Error('redis error'));
+
+		redisJsonGet.withArgs('gp:spl:probes:remote2').callsFake(async () => {
+			await new Promise(resolve => setImmediate(resolve));
+			return { nodeId: 'remote2', probesById: probesB, changeTimestamp: Date.now(), revalidateTimestamp: Date.now() };
+		});
+
+		const error = await syncedProbeList.syncPull().catch((err: Error) => err);
+
+		expect(error).to.be.an('error');
+		expect(omitNode(syncedProbeList.getProbes())).to.deep.equal(Object.values(probesB));
+		expect(updateListener.callCount).to.equal(1);
+	});
+
 	it('expires remote probes after the timeout', async () => {
 		const probes = {
 			A: getProbe('A'),


### PR DESCRIPTION
Currently `syncPull` is the reason of ~600ms block every 2 seconds:
1. Optimising `syncPull` to call `updateProbes` per call instead of per node.
2. Optimising `updateProbes` itself.