### PR TITLE
feat: add failureSource

### DIFF
--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -1310,11 +1310,11 @@ components:
         - resolver
         - internal
       description: |
-        The source where the failure most likely occurred:
-         - `target` covers missing DNS records and protocol errors or timeouts,
+        The most likely source of the failure:
+         - `target` covers the target and its network path, including misconfigured DNS records and timeouts,
          - `resolver` covers failures communicating with or receiving an unusable response from the DNS resolver,
-         - `internal` covers probe or API failures and policy rejections.
-        The exact cause of the failure may not always be clear so this field is best-effort only.
+         - `internal` covers Globalping probe and API failures.
+        The exact source cannot always be determined reliably, so this field is a best-effort classification.
     OfflineTestStatus:
       allOf:
         - $ref: 'schemas.yaml#/components/schemas/BaseTestStatus'

--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -1312,7 +1312,7 @@ components:
       description: |
         The source where the failure most likely occurred:
          - `target` covers missing DNS records and protocol errors or timeouts,
-         - `resolver` covers failures communicating with or receiving a unusable response from the DNS resolver,
+         - `resolver` covers failures communicating with or receiving an unusable response from the DNS resolver,
          - `internal` covers probe or API failures and policy rejections.
         The exact cause of the failure may not always be clear so this field is best-effort only.
     OfflineTestStatus:

--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -888,6 +888,8 @@ components:
       properties:
         status:
           $ref: 'schemas.yaml#/components/schemas/FailedTestStatus'
+        failureSource:
+          $ref: 'schemas.yaml#/components/schemas/FailureSource'
         rawOutput:
           $ref: 'schemas.yaml#/components/schemas/TestRawOutput'
     OfflineTestResult:
@@ -1301,6 +1303,18 @@ components:
       allOf:
         - $ref: 'schemas.yaml#/components/schemas/BaseTestStatus'
         - const: failed
+    FailureSource:
+      type: string
+      enum:
+        - target
+        - resolver
+        - internal
+      description: |
+        The source where the failure most likely occurred:
+         - `target` covers missing DNS records and protocol errors or timeouts,
+         - `resolver` covers failures communicating with or receiving a unusable response from the DNS resolver,
+         - `internal` covers probe or API failures and policy rejections.
+        The exact cause of the failure may not always be clear so this field is best-effort only.
     OfflineTestStatus:
       allOf:
         - $ref: 'schemas.yaml#/components/schemas/BaseTestStatus'

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -164,6 +164,7 @@ const markFinishedByTimeout = defineScript({
 	for index, resultObject in ipairs(measurement.results) do
 		if resultObject.result.status == 'in-progress' then
 			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.status', '"failed"')
+			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.failureSource', '"internal"')
 			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.rawOutput', cjson.encode((resultObject.result.rawOutput or '') .. timeoutMessage))
 		end
 	end

--- a/src/measurement/handler/result.ts
+++ b/src/measurement/handler/result.ts
@@ -15,6 +15,7 @@ export const handleMeasurementResult = (probe: SocketProbe, measurementRunner: M
 			testId: data.testId,
 			result: {
 				status: 'failed',
+				failureSource: 'internal',
 				rawOutput: 'The probe reported an invalid result.',
 			},
 		});

--- a/src/measurement/schema/probe-response-schema.ts
+++ b/src/measurement/schema/probe-response-schema.ts
@@ -1,6 +1,12 @@
 import Joi from 'joi';
 import { DnsRegularResult, DnsTraceResult, HttpResult, MeasurementProgressMessage, MeasurementResultMessage, MtrResult, PingResult, TestResult, TracerouteResult } from '../types.js';
 
+const failureSourceSchema = Joi.when('status', {
+	is: 'failed',
+	then: Joi.string().valid('target', 'resolver', 'internal'),
+	otherwise: Joi.forbidden(),
+});
+
 export const progressSchema = Joi.object<MeasurementProgressMessage>({
 	testId: Joi.string().max(1024).required(),
 	measurementId: Joi.string().max(1024).required(),
@@ -14,6 +20,7 @@ export const progressSchema = Joi.object<MeasurementProgressMessage>({
 
 export const pingResultSchema = Joi.object<PingResult>({
 	status: Joi.string().valid('finished', 'failed').required(),
+	failureSource: failureSourceSchema,
 	rawOutput: Joi.string().max(10000).allow('').required(),
 	resolvedAddress: Joi.string().max(1024).allow(null),
 	resolvedHostname: Joi.string().max(1024).allow(null),
@@ -34,6 +41,7 @@ export const pingResultSchema = Joi.object<PingResult>({
 
 export const tracerouteResultSchema = Joi.object<TracerouteResult>({
 	status: Joi.string().valid('finished', 'failed').required(),
+	failureSource: failureSourceSchema,
 	rawOutput: Joi.string().max(10000).allow('').required(),
 	resolvedAddress: Joi.string().max(1024).allow(null),
 	resolvedHostname: Joi.string().max(1024).allow(null),
@@ -49,6 +57,7 @@ export const tracerouteResultSchema = Joi.object<TracerouteResult>({
 export const dnsResultSchema = Joi.alternatives([
 	Joi.object<TestResult & DnsRegularResult>({
 		status: Joi.string().valid('finished', 'failed').required(),
+		failureSource: failureSourceSchema,
 		rawOutput: Joi.string().max(10000).allow('').required(),
 		statusCodeName: Joi.string().max(1024).allow(null),
 		statusCode: Joi.number().allow(null),
@@ -69,6 +78,7 @@ export const dnsResultSchema = Joi.alternatives([
 	}),
 	Joi.object<TestResult & DnsTraceResult>({
 		status: Joi.string().valid('finished', 'failed').required(),
+		failureSource: failureSourceSchema,
 		rawOutput: Joi.string().max(10000).allow('').required(),
 		hops: Joi.array().max(1024).items(Joi.object({
 			resolver: Joi.string().max(1024).allow(null).required(),
@@ -91,6 +101,7 @@ export const dnsResultSchema = Joi.alternatives([
 
 export const mtrResultSchema = Joi.object<MtrResult>({
 	status: Joi.string().valid('finished', 'failed').required(),
+	failureSource: failureSourceSchema,
 	rawOutput: Joi.string().max(10000).allow('').required(),
 	resolvedAddress: Joi.string().max(1024).allow(null),
 	resolvedHostname: Joi.string().max(1024).allow(null),
@@ -119,6 +130,7 @@ export const mtrResultSchema = Joi.object<MtrResult>({
 
 export const httpResultSchema = Joi.object<HttpResult>({
 	status: Joi.string().valid('finished', 'failed').required(),
+	failureSource: failureSourceSchema,
 	rawOutput: Joi.string().max(20200).allow('').required(),
 	rawHeaders: Joi.string().max(10100).allow('', null),
 	rawBody: Joi.string().max(10100).allow('', null),

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -7,7 +7,10 @@ import type { Location } from '../lib/location/types.js';
 export type TestResult = {
 	rawOutput: string;
 	status: 'in-progress' | 'finished' | 'failed' | 'offline';
+	failureSource?: FailureSource;
 };
+
+export type FailureSource = 'target' | 'resolver' | 'internal';
 
 type PingTest = {
 	packets: number;

--- a/test/e2e/cases/http.test.ts
+++ b/test/e2e/cases/http.test.ts
@@ -280,6 +280,7 @@ describe('http measurement', () => {
 
 		expect(response.body.status).to.equal('finished');
 		expect(response.body.results[0].result.status).to.equal('failed');
+		expect(response.body.results[0].result.failureSource).to.equal('target');
 		expect(response.body.results[0].result.rawOutput).to.include('ENOTFOUND');
 		expect(response).to.matchApiSchema();
 	});
@@ -299,6 +300,7 @@ describe('http measurement', () => {
 
 		expect(response.body.status).to.equal('finished');
 		expect(response.body.results[0].result.status).to.equal('failed');
+		expect(response.body.results[0].result.failureSource).to.equal('target');
 		expect(response).to.matchApiSchema();
 	});
 });

--- a/test/e2e/cases/offline-probes.test.ts
+++ b/test/e2e/cases/offline-probes.test.ts
@@ -57,6 +57,7 @@ describe('api', () => {
 
 		expect(response.body.status).to.equal('finished');
 		expect(response.body.results[0].result.status).to.equal('failed');
+		expect(response.body.results[0].result.failureSource).to.equal('internal');
 		expect(response.body.results[0].result.rawOutput).to.equal('\n\nThe measurement timed out.');
 		expect(response).to.matchApiSchema();
 	}).timeout(40000);

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -415,8 +415,48 @@ describe('Create measurement request', () => {
 			.expect(200).expect((response) => {
 				expect(response.body.results[0].result).to.deep.equal({
 					status: 'failed',
+					failureSource: 'internal',
 					rawOutput: 'The probe reported an invalid result.',
 				});
+			});
+	});
+
+	it('should preserve the failure source reported by the probe', async () => {
+		probe.emit('probe:status:update', 'ready');
+		probe.emit('probe:isIPv4Supported:update', true);
+		probe.emit('probe:isIPv6Supported:update', true);
+		await waitForProbesUpdate();
+
+		await requestAgent.post('/v1/measurements').send({
+			type: 'ping',
+			target: 'missing.example',
+			locations: [{ country: 'US' }],
+			measurementOptions: { packets: 4 },
+		}).expect(202);
+
+		await setTimeout(20);
+
+		probe.emit('probe:measurement:result', {
+			testId: '0',
+			measurementId: mockedMeasurementId,
+			result: {
+				status: 'failed',
+				failureSource: 'target',
+				rawOutput: 'Name or service not known',
+			},
+		});
+
+		await setTimeout(100);
+
+		await requestAgent.get(`/v1/measurements/${mockedMeasurementId}`).send()
+			.expect(200).expect((response) => {
+				expect(response.body.results[0].result).to.deep.equal({
+					status: 'failed',
+					failureSource: 'target',
+					rawOutput: 'Name or service not known',
+				});
+
+				expect(response).to.matchApiSchema();
 			});
 	});
 

--- a/test/tests/unit/measurement/schema/response-schema.test.ts
+++ b/test/tests/unit/measurement/schema/response-schema.test.ts
@@ -816,4 +816,42 @@ describe('resultSchema', () => {
 		Joi.assert(responseBody.results[0]?.result, httpResultSchema);
 		expect(response).to.matchApiSchema();
 	});
+
+	for (const failureSource of [ 'target', 'resolver', 'internal' ] as const) {
+		it(`accepts failed results with the ${failureSource} failure source`, async () => {
+			const responseBody = _.cloneDeep(defaultPingResponseBody);
+			(responseBody.results[0]!.result as PingResult) = {
+				status: 'failed',
+				failureSource,
+				rawOutput: 'Test failed.',
+			};
+
+			getResponseBody.returns(responseBody);
+
+			const response = await request(mockServer).get('/v1/measurements/measurement-id');
+
+			Joi.assert(responseBody.results[0]?.result, pingResultSchema);
+			expect(response).to.matchApiSchema();
+		});
+	}
+
+	it('rejects invalid failure sources', () => {
+		const validation = pingResultSchema.validate({
+			status: 'failed',
+			failureSource: 'unknown',
+			rawOutput: 'Test failed.',
+		});
+
+		expect(validation.error).to.not.be.undefined;
+	});
+
+	it('rejects a failure source on finished results', () => {
+		const validation = pingResultSchema.validate({
+			status: 'finished',
+			failureSource: 'target',
+			rawOutput: '',
+		});
+
+		expect(validation.error).to.not.be.undefined;
+	});
 });

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -144,6 +144,7 @@ describe('measurement store', () => {
 				probe: {},
 				result: {
 					status: 'failed',
+					failureSource: 'internal',
 					rawOutput: '\n\nThe measurement timed out.',
 				},
 			}],


### PR DESCRIPTION
Adds a `failureSource` field to failed measurement results, allowing clients to distinguish target, resolver, and internal failures.