### PR TITLE
feat: add measurement timeout option

### DIFF
--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -596,6 +596,13 @@ components:
               $ref: 'schemas.yaml#/components/schemas/MeasurementLocations'
             limit:
               $ref: 'schemas.yaml#/components/schemas/MeasurementLimit'
+            timeout:
+              type: integer
+              minimum: 5
+              maximum: 30
+              description: |
+                The probe-side wall-clock timeout for each test, in seconds. If omitted, the value is calculated based on the provided measurement options and can be up to 20 seconds.
+                In all cases, callers should allow at least 10 additional seconds for probe-to-API communication and API measurement finalization before triggering a client-side timeout.
             measurementOptions:
               $ref: 'schemas.yaml#/components/schemas/MeasurementOptions'
     MeasurementResponse:
@@ -640,6 +647,12 @@ components:
           allOf:
             - $ref: 'schemas.yaml#/components/schemas/MeasurementLimit'
             - description: The limit you specified when creating the measurement if different from the default value.
+        timeout:
+          type: integer
+          minimum: 5
+          maximum: 30
+          description: |
+            The probe-side wall-clock timeout for each test, in seconds, if different from the calculated value.
         measurementOptions:
           allOf:
             - $ref: 'schemas.yaml#/components/schemas/MeasurementOptions'

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -74,6 +74,7 @@ export class MeasurementRunner {
 					type: request.type,
 					target: request.target,
 					inProgressUpdates,
+					timeout: request.timeout,
 				},
 			};
 			this.io.of(PROBES_NAMESPACE).to(probe.client).emit('probe:measurement:request', requestMessage);

--- a/src/measurement/schema/global-schema.ts
+++ b/src/measurement/schema/global-schema.ts
@@ -5,7 +5,8 @@ import {
 	measurementSchema,
 } from './command-schema.js';
 import { schema as locationSchema } from './location-schema.js';
-import { GLOBAL_DEFAULTS } from './utils.js';
+import { GLOBAL_DEFAULTS, getMeasurementTimeout } from './utils.js';
+import type { MeasurementRequest } from '../types.js';
 
 const authenticatedTestsPerMeasurement = config.get<number>('measurement.limits.authenticatedTestsPerMeasurement');
 const anonymousTestsPerMeasurement = config.get<number>('measurement.limits.anonymousTestsPerMeasurement');
@@ -14,6 +15,10 @@ export const schema = Joi.object({
 	type: Joi.string().valid('ping', 'traceroute', 'dns', 'mtr', 'http').insensitive().required(),
 	target: targetSchema,
 	measurementOptions: measurementSchema,
+	timeout: Joi.number().integer().min(5).max(30).default((request: MeasurementRequest) => getMeasurementTimeout(
+		request.type,
+		'packets' in request.measurementOptions ? request.measurementOptions.packets : undefined,
+	)),
 	locations: locationSchema,
 	limit: Joi.number().min(1).when('$user.id', {
 		is: Joi.string().required(),

--- a/src/measurement/schema/global-schema.ts
+++ b/src/measurement/schema/global-schema.ts
@@ -15,10 +15,7 @@ export const schema = Joi.object({
 	type: Joi.string().valid('ping', 'traceroute', 'dns', 'mtr', 'http').insensitive().required(),
 	target: targetSchema,
 	measurementOptions: measurementSchema,
-	timeout: Joi.number().integer().min(5).max(30).default((request: MeasurementRequest) => getMeasurementTimeout(
-		request.type,
-		'packets' in request.measurementOptions ? request.measurementOptions.packets : undefined,
-	)),
+	timeout: Joi.number().integer().min(5).max(30).default((request: MeasurementRequest) => getMeasurementTimeout(request.type, request.measurementOptions)),
 	locations: locationSchema,
 	limit: Joi.number().min(1).when('$user.id', {
 		is: Joi.string().required(),

--- a/src/measurement/schema/utils.ts
+++ b/src/measurement/schema/utils.ts
@@ -11,7 +11,7 @@ import {
 } from '../../lib/malware/client.js';
 import { joiValidate as joiMalwareValidateIp } from '../../lib/malware/ip.js';
 import { joiValidate as joiMalwareValidateDomain } from '../../lib/malware/domain.js';
-import type { MeasurementRecord, MeasurementRequest } from '../types.js';
+import type { MeasurementRecord, MeasurementRequest, RequestType } from '../types.js';
 import { isIpPrivate } from '../../lib/private-ip.js';
 
 export const globalIpOptions: { version: string[]; cidr: PresenceMode } = { version: [ 'ipv4', 'ipv6' ], cidr: 'forbidden' };
@@ -143,6 +143,21 @@ export const COMMAND_DEFAULTS = {
 	},
 } as const;
 
+export const getMeasurementTimeout = (type: RequestType, packets?: number): number => {
+	if (type === 'ping') {
+		packets ??= COMMAND_DEFAULTS.ping.packets;
+		return Math.max(5, Math.ceil((packets - 1) * 0.5 + 3));
+	}
+
+	if (type === 'mtr') {
+		packets ??= COMMAND_DEFAULTS.mtr.packets;
+		// Packet intervals + MTR grace + target DNS + ASN lookups.
+		return Math.max(5, Math.ceil(packets * 0.5 + 3 + 3 + 3));
+	}
+
+	return { http: 10, traceroute: 5, dns: 7 }[type];
+};
+
 // Some joi defaults are not values but functions, they need to be executed to get actual value
 const processFunctionDefaults = (obj: object, request: MeasurementRequest): unknown => _.mapValues(obj, (value: unknown) => {
 	if (_.isFunction(value)) {
@@ -158,6 +173,7 @@ export const getDefaults = (request: MeasurementRequest) => {
 	const defaultRules = {
 		...GLOBAL_DEFAULTS,
 		measurementOptions: COMMAND_DEFAULTS[request.type],
+		timeout: getMeasurementTimeout(request.type, 'packets' in request.measurementOptions ? request.measurementOptions.packets : undefined),
 	};
 
 	const defaults = processFunctionDefaults(defaultRules, request) as Partial<MeasurementRecord>;

--- a/src/measurement/schema/utils.ts
+++ b/src/measurement/schema/utils.ts
@@ -11,7 +11,7 @@ import {
 } from '../../lib/malware/client.js';
 import { joiValidate as joiMalwareValidateIp } from '../../lib/malware/ip.js';
 import { joiValidate as joiMalwareValidateDomain } from '../../lib/malware/domain.js';
-import type { MeasurementRecord, MeasurementRequest, RequestType } from '../types.js';
+import type { MeasurementOptions, MeasurementRecord, MeasurementRequest, RequestType } from '../types.js';
 import { isIpPrivate } from '../../lib/private-ip.js';
 
 export const globalIpOptions: { version: string[]; cidr: PresenceMode } = { version: [ 'ipv4', 'ipv6' ], cidr: 'forbidden' };
@@ -143,19 +143,24 @@ export const COMMAND_DEFAULTS = {
 	},
 } as const;
 
-export const getMeasurementTimeout = (type: RequestType, packets?: number): number => {
+export const getMeasurementTimeout = (type: RequestType, measurementOptions: MeasurementOptions): number => {
 	if (type === 'ping') {
-		packets ??= COMMAND_DEFAULTS.ping.packets;
+		const packets = 'packets' in measurementOptions ? measurementOptions.packets : COMMAND_DEFAULTS.ping.packets;
 		return Math.max(5, Math.ceil((packets - 1) * 0.5 + 3));
 	}
 
 	if (type === 'mtr') {
-		packets ??= COMMAND_DEFAULTS.mtr.packets;
+		const packets = 'packets' in measurementOptions ? measurementOptions.packets : COMMAND_DEFAULTS.mtr.packets;
 		// Packet intervals + MTR grace + target DNS + ASN lookups.
 		return Math.max(5, Math.ceil(packets * 0.5 + 3 + 3 + 3));
 	}
 
-	return { http: 10, traceroute: 5, dns: 7 }[type];
+	if (type === 'dns') {
+		// Four servers, two attempts each, averaging two seconds per attempt.
+		return 'trace' in measurementOptions && measurementOptions.trace ? 4 * 2 * 2 : 7;
+	}
+
+	return { http: 10, traceroute: 5 }[type];
 };
 
 // Some joi defaults are not values but functions, they need to be executed to get actual value
@@ -173,7 +178,7 @@ export const getDefaults = (request: MeasurementRequest) => {
 	const defaultRules = {
 		...GLOBAL_DEFAULTS,
 		measurementOptions: COMMAND_DEFAULTS[request.type],
-		timeout: getMeasurementTimeout(request.type, 'packets' in request.measurementOptions ? request.measurementOptions.packets : undefined),
+		timeout: getMeasurementTimeout(request.type, request.measurementOptions),
 	};
 
 	const defaults = processFunctionDefaults(defaultRules, request) as Partial<MeasurementRecord>;

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -119,7 +119,8 @@ export class MeasurementStore {
 	async createMeasurement (request: MeasurementRequest, onlineProbesMap: Map<number, ServerProbe>, allProbes: (ServerProbe | OfflineProbe)[], userType?: AuthenticateStateUser['userType'], exportMeta: ExportMeta = {}): Promise<string> {
 		const startTime = new Date();
 		const isFinishedImmediately = onlineProbesMap.size === 0;
-		const timeoutTime = config.get<number>('measurement.timeout') * 1000;
+		const timeoutSeconds = request.timeout + 5;
+		const timeoutTime = timeoutSeconds * 1000;
 		const results = this.probesToResults(allProbes, request.type);
 		const id = generateMeasurementId(startTime, userType);
 		const key = getMeasurementKey(id);
@@ -131,6 +132,7 @@ export class MeasurementStore {
 			createdAt: startTime.toISOString(),
 			updatedAt: startTime.toISOString(),
 			target: request.target,
+			timeout: request.timeout,
 			...(request.limit && { limit: request.limit }),
 			probesCount: allProbes.length,
 			...(request.locations && { locations: request.locations }),
@@ -144,7 +146,7 @@ export class MeasurementStore {
 
 		await Promise.all([
 			!isFinishedImmediately && this.redis.zAdd('gp:in-progress-timeouts', { score: startTime.getTime() + timeoutTime, value: id }),
-			!isFinishedImmediately && this.redis.set(getMeasurementKey(id, 'probes_awaiting'), onlineProbesMap.size, { EX: config.get<number>('measurement.timeout') + 30 }),
+			!isFinishedImmediately && this.redis.set(getMeasurementKey(id, 'probes_awaiting'), onlineProbesMap.size, { EX: timeoutSeconds + 30 }),
 			this.redis.json.set(key, '$', measurementWithoutDefaults),
 			this.redis.json.set(getMeasurementKey(id, 'ips'), '$', allProbes.map(probe => probe.ipAddress)),
 			this.redis.json.set(getMeasurementKey(id, 'meta'), '$', exportMeta),
@@ -152,7 +154,7 @@ export class MeasurementStore {
 			this.redis.expire(getMeasurementKey(id, 'ips'), config.get<number>('measurement.resultTTL')),
 			this.redis.expire(getMeasurementKey(id, 'meta'), config.get<number>('measurement.resultTTL')),
 			!_.isEmpty(testsToProbes) && this.redis.hSet('gp:test-to-probe', testsToProbes),
-			!_.isEmpty(testsToProbes) && this.redis.hExpire('gp:test-to-probe', Object.keys(testsToProbes), config.get<number>('measurement.timeout') + 120),
+			!_.isEmpty(testsToProbes) && this.redis.hExpire('gp:test-to-probe', Object.keys(testsToProbes), timeoutSeconds + 120),
 		]);
 
 		if (isFinishedImmediately) {

--- a/src/measurement/types.ts
+++ b/src/measurement/types.ts
@@ -216,6 +216,7 @@ export type MeasurementRequest = {
 	type: 'ping' | 'traceroute' | 'dns' | 'http' | 'mtr';
 	target: string;
 	measurementOptions: MeasurementOptions;
+	timeout: number;
 	locations: LocationWithLimit[] | undefined;
 	limit: number | undefined;
 	inProgressUpdates: boolean;
@@ -251,6 +252,7 @@ export type MeasurementRecord = {
 	probesCount: number;
 	locations?: LocationWithLimit[];
 	measurementOptions?: MeasurementOptions;
+	timeout?: number;
 	results: MeasurementResult[];
 	scheduleId?: string;
 	configurationId?: string;
@@ -267,6 +269,7 @@ export type MeasurementRequestMessage = {
 		type: MeasurementRequest['type'];
 		target: MeasurementRequest['target'];
 		inProgressUpdates: MeasurementRequest['inProgressUpdates'];
+		timeout: MeasurementRequest['timeout'];
 	};
 };
 

--- a/src/schedule/executor.ts
+++ b/src/schedule/executor.ts
@@ -129,10 +129,7 @@ export class StreamScheduleExecutor {
 				continue;
 			}
 
-			const timeout = getMeasurementTimeout(
-				configuration.measurement_type,
-				'packets' in configuration.measurement_options ? configuration.measurement_options.packets : undefined,
-			);
+			const timeout = getMeasurementTimeout(configuration.measurement_type, configuration.measurement_options);
 			const requestBase = {
 				type: configuration.measurement_type,
 				target: configuration.measurement_target,

--- a/src/schedule/executor.ts
+++ b/src/schedule/executor.ts
@@ -10,6 +10,7 @@ import type { WsServer } from '../lib/ws/server.js';
 import type { SyncedProbeList } from '../lib/ws/synced-probe-list.js';
 import type { MeasurementStore } from '../measurement/store.js';
 import { getMeasurementStore } from '../measurement/store.js';
+import { getMeasurementTimeout } from '../measurement/schema/utils.js';
 import { getStreamScheduleLoader, type ScheduleLoader } from './loader.js';
 
 const logger = scopedLogger('schedule-executor');
@@ -128,6 +129,10 @@ export class StreamScheduleExecutor {
 				continue;
 			}
 
+			const timeout = getMeasurementTimeout(
+				configuration.measurement_type,
+				'packets' in configuration.measurement_options ? configuration.measurement_options.packets : undefined,
+			);
 			const requestBase = {
 				type: configuration.measurement_type,
 				target: configuration.measurement_target,
@@ -136,6 +141,7 @@ export class StreamScheduleExecutor {
 				scheduleId: schedule.id,
 				configurationId: configuration.id,
 				inProgressUpdates: false,
+				timeout,
 				limit: undefined,
 			};
 
@@ -187,6 +193,7 @@ export class StreamScheduleExecutor {
 				...requestBase.measurementOptions,
 				type: requestBase.type,
 				target: requestBase.target,
+				timeout: requestBase.timeout,
 				inProgressUpdates: requestBase.inProgressUpdates,
 			},
 		});

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -133,7 +133,7 @@ describe('Create measurement request', () => {
 		expect(requestHandlerStub.firstCall.args[0]).to.deep.equal({
 			measurementId: mockedMeasurementId,
 			testId: '0',
-			measurement: { packets: 4, port: 80, protocol: 'ICMP', ipVersion: 4, type: 'ping', target: 'jsdelivr.com', inProgressUpdates: false },
+			measurement: { packets: 4, port: 80, protocol: 'ICMP', ipVersion: 4, type: 'ping', target: 'jsdelivr.com', inProgressUpdates: false, timeout: 5 },
 		});
 
 		await requestAgent.get(`/v1/measurements/${mockedMeasurementId}`).send()

--- a/test/tests/integration/schedule/stream-schedule.test.ts
+++ b/test/tests/integration/schedule/stream-schedule.test.ts
@@ -150,6 +150,7 @@ describe('Stream schedule execution', () => {
 				packets: 1,
 				port: 80,
 				inProgressUpdates: false,
+				timeout: 5,
 			},
 		});
 	});
@@ -301,6 +302,7 @@ describe('Stream schedule execution', () => {
 				packets: 1,
 				port: 80,
 				inProgressUpdates: false,
+				timeout: 5,
 			},
 		});
 
@@ -313,6 +315,7 @@ describe('Stream schedule execution', () => {
 				ipVersion: 4,
 				port: 80,
 				inProgressUpdates: false,
+				timeout: 5,
 			},
 		});
 	});

--- a/test/tests/integration/schedule/stream-schedule.test.ts
+++ b/test/tests/integration/schedule/stream-schedule.test.ts
@@ -73,7 +73,7 @@ describe('Stream schedule execution', () => {
 				measurement_type: 'ping',
 				measurement_target: 'example.com',
 				measurement_options: {
-					packets: 1,
+					packets: 16,
 					protocol: 'ICMP',
 					port: 80,
 					ipVersion: 4,
@@ -147,10 +147,10 @@ describe('Stream schedule execution', () => {
 				target: 'example.com',
 				protocol: 'ICMP',
 				ipVersion: 4,
-				packets: 1,
+				packets: 16,
 				port: 80,
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 11,
 			},
 		});
 	});

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -73,6 +73,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: false,
+			timeout: 5,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -104,6 +105,7 @@ describe('MeasurementRunner', () => {
 				locations: [],
 				limit: 10,
 				inProgressUpdates: false,
+				timeout: 5,
 			},
 			new Map([ getProbe(0), getProbe(1), getProbe(2), getProbe(3) ].entries()),
 			[ getProbe(0), getProbe(1), getProbe(2), getProbe(3) ],
@@ -118,6 +120,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[0]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -134,6 +137,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[1]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -150,6 +154,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[2]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -166,6 +171,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[3]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -194,6 +200,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: true,
+			timeout: 5,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -225,6 +232,7 @@ describe('MeasurementRunner', () => {
 				locations: [],
 				limit: 10,
 				inProgressUpdates: true,
+				timeout: 5,
 			},
 			new Map([ getProbe(0), getProbe(1), getProbe(2), getProbe(3) ].entries()),
 			[ getProbe(0), getProbe(1), getProbe(2), getProbe(3) ],
@@ -238,6 +246,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[0]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: true,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -252,6 +261,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[1]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: true,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -266,6 +276,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[2]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -280,6 +291,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[3]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
+				timeout: 5,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -329,6 +341,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: false,
+			timeout: 5,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -366,6 +379,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: false,
+			timeout: 5,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -398,6 +412,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: false,
+			timeout: 5,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -434,6 +449,7 @@ describe('MeasurementRunner', () => {
 			locations: [{ country: 'US' }, { country: 'DE' }],
 			limit: 10,
 			inProgressUpdates: false,
+			timeout: 5,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -472,6 +488,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: false,
+			timeout: 5,
 		};
 
 		const error = createHttpError(429, 'This measurement exceeds the remaining hourly rate limit for your IP address.', { type: 'rate_limit_exceeded' });

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -73,7 +73,7 @@ describe('MeasurementRunner', () => {
 			locations: [],
 			limit: 10,
 			inProgressUpdates: false,
-			timeout: 5,
+			timeout: 17,
 		};
 
 		router.findMatchingProbes.resolves({
@@ -105,7 +105,7 @@ describe('MeasurementRunner', () => {
 				locations: [],
 				limit: 10,
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 17,
 			},
 			new Map([ getProbe(0), getProbe(1), getProbe(2), getProbe(3) ].entries()),
 			[ getProbe(0), getProbe(1), getProbe(2), getProbe(3) ],
@@ -120,7 +120,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[0]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 17,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -137,7 +137,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[1]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 17,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -154,7 +154,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[2]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 17,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,
@@ -171,7 +171,7 @@ describe('MeasurementRunner', () => {
 		expect(emit.args[3]).to.deep.equal([ 'probe:measurement:request', {
 			measurement: {
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 17,
 				packets: 3,
 				ipVersion: 4,
 				port: 80,

--- a/test/tests/unit/measurement/schema/request-schema.test.ts
+++ b/test/tests/unit/measurement/schema/request-schema.test.ts
@@ -8,21 +8,11 @@ import {
 	schema as locationSchema,
 } from '../../../../../src/measurement/schema/location-schema.js';
 import {
-	getMeasurementTimeout,
 	joiValidateTarget,
 	joiValidateDomain,
 	joiValidateDomainForDns,
 } from '../../../../../src/measurement/schema/utils.js';
-import type { RequestType } from '../../../../../src/measurement/types.js';
 import { populateDomainList, populateIpList } from '../../../../utils/populate-static-files.js';
-
-const withTimeout = <T extends { type: string; measurementOptions: object }>(request: T) => {
-	const packets = 'packets' in request.measurementOptions && typeof request.measurementOptions.packets === 'number'
-		? request.measurementOptions.packets
-		: undefined;
-
-	return { ...request, timeout: getMeasurementTimeout(request.type as RequestType, packets) };
-};
 
 describe('command schema', async () => {
 	before(async () => {
@@ -57,6 +47,7 @@ describe('command schema', async () => {
 				expect(validate({ type: 'http', target: 'example.com' }).timeout).to.equal(10);
 				expect(validate({ type: 'traceroute', target: 'example.com' }).timeout).to.equal(5);
 				expect(validate({ type: 'dns', target: 'example.com' }).timeout).to.equal(7);
+				expect(validate({ type: 'dns', target: 'example.com', measurementOptions: { trace: true } }).timeout).to.equal(16);
 				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(5);
 				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 16 } }).timeout).to.equal(11);
 				expect(validate({ type: 'mtr', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(11);
@@ -936,7 +927,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should populate with default values (no measurementOptions)', () => {
@@ -961,7 +952,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should pass (deep equal) ip version 6 target is a domain', () => {
@@ -986,7 +977,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -1029,7 +1020,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -1054,7 +1045,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target is bracketed ipv6', () => {
@@ -1080,7 +1071,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 	});
 
@@ -1350,7 +1341,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -1374,7 +1365,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -1428,7 +1419,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -1452,7 +1443,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target bracketed ipv6', () => {
@@ -1477,7 +1468,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
 		});
 	});
 
@@ -1737,7 +1728,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
 		});
 
 		it('should pass (deep equal) ip version 6 resolver is a domain', () => {
@@ -1766,7 +1757,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when resolver is ipv4', () => {
@@ -1805,7 +1796,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when resolver is ipv6', () => {
@@ -1844,7 +1835,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -1872,7 +1863,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
 		});
 
 		it('should fail (ip version provided when resolver is an ip)', () => {
@@ -2366,7 +2357,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 14 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -2397,7 +2388,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 14 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target bracketed ipv6', () => {
@@ -2428,7 +2419,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 14 });
 		});
 
 		it('should pass (deep equal) ip version 6 domain', () => {
@@ -2453,7 +2444,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 14 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -2478,7 +2469,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 11 });
 		});
 	});
 
@@ -2782,7 +2773,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass', () => {
@@ -2825,7 +2816,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -2855,7 +2846,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 target is a domain', () => {
@@ -2903,7 +2894,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -2998,7 +2989,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target is ipv6', () => {
@@ -3045,7 +3036,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 	});
 
@@ -3093,6 +3084,6 @@ describe('command schema', async () => {
 		const valid = globalSchema.validate(input, { convert: true });
 
 		expect(valid.error).to.not.exist;
-		expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
+		expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 	});
 });

--- a/test/tests/unit/measurement/schema/request-schema.test.ts
+++ b/test/tests/unit/measurement/schema/request-schema.test.ts
@@ -8,11 +8,21 @@ import {
 	schema as locationSchema,
 } from '../../../../../src/measurement/schema/location-schema.js';
 import {
+	getMeasurementTimeout,
 	joiValidateTarget,
 	joiValidateDomain,
 	joiValidateDomainForDns,
 } from '../../../../../src/measurement/schema/utils.js';
+import type { RequestType } from '../../../../../src/measurement/types.js';
 import { populateDomainList, populateIpList } from '../../../../utils/populate-static-files.js';
+
+const withTimeout = <T extends { type: string; measurementOptions: object }>(request: T) => {
+	const packets = 'packets' in request.measurementOptions && typeof request.measurementOptions.packets === 'number'
+		? request.measurementOptions.packets
+		: undefined;
+
+	return { ...request, timeout: getMeasurementTimeout(request.type as RequestType, packets) };
+};
 
 describe('command schema', async () => {
 	before(async () => {
@@ -21,6 +31,39 @@ describe('command schema', async () => {
 	});
 
 	describe('global', () => {
+		describe('timeout', () => {
+			const validate = (input: Record<string, unknown>) => {
+				const result = globalSchema.validate(input, { convert: true });
+
+				expect(result.error).to.not.exist;
+				return result.value;
+			};
+
+			it('should accept the minimum and maximum values', () => {
+				expect(validate({ type: 'ping', target: 'example.com', timeout: 5 }).timeout).to.equal(5);
+				expect(validate({ type: 'ping', target: 'example.com', timeout: 30 }).timeout).to.equal(30);
+				expect(validate({ type: 'mtr', target: 'example.com', timeout: 5 }).timeout).to.equal(5);
+			});
+
+			it('should reject out-of-range and fractional values', () => {
+				for (const timeout of [ 4, 31, 5.5 ]) {
+					const result = globalSchema.validate({ type: 'ping', target: 'example.com', timeout }, { convert: true });
+
+					expect(result.error).to.exist;
+				}
+			});
+
+			it('should resolve defaults based on the measurement type and packets', () => {
+				expect(validate({ type: 'http', target: 'example.com' }).timeout).to.equal(10);
+				expect(validate({ type: 'traceroute', target: 'example.com' }).timeout).to.equal(5);
+				expect(validate({ type: 'dns', target: 'example.com' }).timeout).to.equal(7);
+				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(5);
+				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 16 } }).timeout).to.equal(11);
+				expect(validate({ type: 'mtr', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(11);
+				expect(validate({ type: 'mtr', target: 'example.com', measurementOptions: { packets: 16 } }).timeout).to.equal(17);
+			});
+		});
+
 		describe('limits', () => {
 			it('should correct limit (1 by default)', () => {
 				const input = {
@@ -893,7 +936,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should populate with default values (no measurementOptions)', () => {
@@ -918,7 +961,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 target is a domain', () => {
@@ -943,7 +986,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -986,7 +1029,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -1011,7 +1054,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target is bracketed ipv6', () => {
@@ -1037,7 +1080,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 	});
 
@@ -1307,7 +1350,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -1331,7 +1374,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -1385,7 +1428,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -1409,7 +1452,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target bracketed ipv6', () => {
@@ -1434,7 +1477,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 	});
 
@@ -1694,7 +1737,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 resolver is a domain', () => {
@@ -1723,7 +1766,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when resolver is ipv4', () => {
@@ -1762,7 +1805,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when resolver is ipv6', () => {
@@ -1801,7 +1844,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -1829,7 +1872,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should fail (ip version provided when resolver is an ip)', () => {
@@ -2323,7 +2366,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -2354,7 +2397,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target bracketed ipv6', () => {
@@ -2385,7 +2428,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 domain', () => {
@@ -2410,7 +2453,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -2435,7 +2478,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 	});
 
@@ -2739,7 +2782,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass', () => {
@@ -2782,7 +2825,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -2812,7 +2855,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 target is a domain', () => {
@@ -2860,7 +2903,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -2955,7 +2998,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target is ipv6', () => {
@@ -3002,7 +3045,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal(desiredOutput);
+			expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 		});
 	});
 
@@ -3050,6 +3093,6 @@ describe('command schema', async () => {
 		const valid = globalSchema.validate(input, { convert: true });
 
 		expect(valid.error).to.not.exist;
-		expect(valid.value).to.deep.equal(desiredOutput);
+		expect(valid.value).to.deep.equal(withTimeout(desiredOutput));
 	});
 });

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -228,6 +228,7 @@ describe('measurement store', () => {
 				locations: [],
 				limit: 4,
 				inProgressUpdates: false,
+				timeout: 11,
 			},
 			new Map([ getProbe('z', '1.1.1.1'), getProbe('10', '2.2.2.2'), getProbe('x', '3.3.3.3'), getProbe('0', '4.4.4.4') ].entries()),
 			[ getProbe('z', '1.1.1.1'), getProbe('10', '2.2.2.2'), getProbe('x', '3.3.3.3'), getProbe('0', '4.4.4.4') ],
@@ -237,12 +238,12 @@ describe('measurement store', () => {
 		expect(redisMock.zAdd.callCount).to.equal(1);
 
 		expect(redisMock.zAdd.args[0]).to.deep.equal([ 'gp:in-progress-timeouts', {
-			score: now + 30_000,
+			score: now + 16_000,
 			value: mockedMeasurementId1,
 		}]);
 
 		expect(redisMock.set.callCount).to.equal(1);
-		expect(redisMock.set.args[0]).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:probes_awaiting`, 4, { EX: 60 }]);
+		expect(redisMock.set.args[0]).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:probes_awaiting`, 4, { EX: 46 }]);
 		expect(redisMock.json.set.callCount).to.equal(3);
 
 		expect(redisMock.json.set.args[0]).to.deep.equal([ `gp:m:{${mockedMeasurementId1}}:results`, '$', {
@@ -252,6 +253,7 @@ describe('measurement store', () => {
 			createdAt: new Date(now).toISOString(),
 			updatedAt: new Date(now).toISOString(),
 			target: 'jsdelivr.com',
+			timeout: 11,
 			limit: 4,
 			probesCount: 4,
 			results: [{
@@ -347,7 +349,7 @@ describe('measurement store', () => {
 				`${mockedMeasurementId1}_2`,
 				`${mockedMeasurementId1}_3`,
 			],
-			150,
+			136,
 		]);
 	});
 
@@ -362,6 +364,7 @@ describe('measurement store', () => {
 				locations: [],
 				limit: 1,
 				inProgressUpdates: false,
+				timeout: 5,
 			},
 			new Map([ [ 0, getProbe('id', '1.1.1.1') ] ]),
 			[ getProbe('id', '1.1.1.1') ],
@@ -420,6 +423,7 @@ describe('measurement store', () => {
 				locations: [],
 				limit: 1,
 				inProgressUpdates: false,
+				timeout: 10,
 			},
 			new Map([ [ 0, getProbe('id', '1.1.1.1') ] ]),
 			[ getProbe('id', '1.1.1.1') ],
@@ -474,6 +478,7 @@ describe('measurement store', () => {
 				locations: [],
 				limit: 1,
 				inProgressUpdates: false,
+				timeout: 5,
 			},
 			new Map(),
 			[ getOfflineProbe('id', '1.1.1.1') ],
@@ -550,6 +555,7 @@ describe('measurement store', () => {
 				}],
 				limit: 2,
 				inProgressUpdates: false,
+				timeout: 10,
 			},
 			new Map([ [ 0, getProbe('id', '1.1.1.1') ] ]),
 			[ getProbe('id', '1.1.1.1') ],
@@ -608,6 +614,7 @@ describe('measurement store', () => {
 				locations: [],
 				limit: 1,
 				inProgressUpdates: false,
+				timeout: 5,
 				scheduleId: 'schedule-id',
 				configurationId: 'configuration-id',
 			},
@@ -676,6 +683,7 @@ describe('measurement store', () => {
 				limit: 1,
 				locations: [],
 				inProgressUpdates: false,
+				timeout: 10,
 			},
 			new Map([ [ 0, getProbe('id', '1.1.1.1') ] ]),
 			[ getProbe('id', '1.1.1.1') ],


### PR DESCRIPTION
Closes https://github.com/jsdelivr/globalping/issues/746. The error classification is based on https://github.com/jsdelivr/globalping/pull/879 rather than adding a new field. The default timeout is now lower and based on what is realistically needed with the options we use.