### PR TITLE
fix: avoid leading newlines in timeout output

### DIFF
--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -163,9 +163,10 @@ const markFinishedByTimeout = defineScript({
 
 	for index, resultObject in ipairs(measurement.results) do
 		if resultObject.result.status == 'in-progress' then
+			local rawOutput = resultObject.result.rawOutput or ''
 			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.status', '"failed"')
 			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.failureSource', '"internal"')
-			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.rawOutput', cjson.encode((resultObject.result.rawOutput or '') .. timeoutMessage))
+			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.rawOutput', cjson.encode(rawOutput .. (rawOutput ~= '' and '\\n\\n' or '') .. timeoutMessage))
 		end
 	end
 
@@ -178,7 +179,7 @@ const markFinishedByTimeout = defineScript({
 
 		parser.push(
 			new Date().toISOString(),
-			'\n\nThe measurement timed out.',
+			'The measurement timed out.',
 		);
 	},
 	transformReply (reply: Buffer | null) {

--- a/test/e2e/cases/offline-probes.test.ts
+++ b/test/e2e/cases/offline-probes.test.ts
@@ -58,7 +58,7 @@ describe('api', () => {
 		expect(response.body.status).to.equal('finished');
 		expect(response.body.results[0].result.status).to.equal('failed');
 		expect(response.body.results[0].result.failureSource).to.equal('internal');
-		expect(response.body.results[0].result.rawOutput).to.equal('\n\nThe measurement timed out.');
+		expect(response.body.results[0].result.rawOutput).to.equal('The measurement timed out.');
 		expect(response).to.matchApiSchema();
 	}).timeout(40000);
 });

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -145,7 +145,7 @@ describe('measurement store', () => {
 				result: {
 					status: 'failed',
 					failureSource: 'internal',
-					rawOutput: '\n\nThe measurement timed out.',
+					rawOutput: 'The measurement timed out.',
 				},
 			}],
 		};


### PR DESCRIPTION
Closes https://github.com/jsdelivr/globalping/issues/877.