### PR TITLE
fix: increase measurement timeout defaults

### DIFF
--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -601,7 +601,7 @@ components:
               minimum: 5
               maximum: 30
               description: |
-                The probe-side wall-clock timeout for each test, in seconds. If omitted, the value is calculated based on the provided measurement options and can be up to 20 seconds.
+                The probe-side wall-clock timeout for each test, in seconds. If omitted, the value is calculated based on the provided measurement options and can be up to 30 seconds.
                 In all cases, callers should allow at least 10 additional seconds for probe-to-API communication and API measurement finalization before triggering a client-side timeout.
             measurementOptions:
               $ref: 'schemas.yaml#/components/schemas/MeasurementOptions'

--- a/src/measurement/schema/utils.ts
+++ b/src/measurement/schema/utils.ts
@@ -146,21 +146,21 @@ export const COMMAND_DEFAULTS = {
 export const getMeasurementTimeout = (type: RequestType, measurementOptions: MeasurementOptions): number => {
 	if (type === 'ping') {
 		const packets = 'packets' in measurementOptions ? measurementOptions.packets : COMMAND_DEFAULTS.ping.packets;
-		return Math.max(5, Math.ceil((packets - 1) * 0.5 + 3));
+		return Math.max(10, Math.ceil((packets - 1) * 0.5 + 3));
 	}
 
 	if (type === 'mtr') {
 		const packets = 'packets' in measurementOptions ? measurementOptions.packets : COMMAND_DEFAULTS.mtr.packets;
-		// Packet intervals + MTR grace + target DNS + ASN lookups.
+		// Packet intervals, MTR grace, expected target DNS headroom, and best-effort ASN headroom.
 		return Math.max(5, Math.ceil(packets * 0.5 + 3 + 3 + 3));
 	}
 
 	if (type === 'dns') {
-		// Four servers, two attempts each, averaging two seconds per attempt.
-		return 'trace' in measurementOptions && measurementOptions.trace ? 4 * 2 * 2 : 7;
+		// Four servers, two attempts each, three seconds per attempt, plus one second of overhead.
+		return 'trace' in measurementOptions && measurementOptions.trace ? 4 * 2 * 3 + 1 : 10;
 	}
 
-	return { http: 10, traceroute: 5 }[type];
+	return { http: 15, traceroute: 10 }[type];
 };
 
 // Some joi defaults are not values but functions, they need to be executed to get actual value

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -133,7 +133,7 @@ describe('Create measurement request', () => {
 		expect(requestHandlerStub.firstCall.args[0]).to.deep.equal({
 			measurementId: mockedMeasurementId,
 			testId: '0',
-			measurement: { packets: 4, port: 80, protocol: 'ICMP', ipVersion: 4, type: 'ping', target: 'jsdelivr.com', inProgressUpdates: false, timeout: 5 },
+			measurement: { packets: 4, port: 80, protocol: 'ICMP', ipVersion: 4, type: 'ping', target: 'jsdelivr.com', inProgressUpdates: false, timeout: 10 },
 		});
 
 		await requestAgent.get(`/v1/measurements/${mockedMeasurementId}`).send()

--- a/test/tests/integration/schedule/stream-schedule.test.ts
+++ b/test/tests/integration/schedule/stream-schedule.test.ts
@@ -302,7 +302,7 @@ describe('Stream schedule execution', () => {
 				packets: 1,
 				port: 80,
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 10,
 			},
 		});
 
@@ -315,7 +315,7 @@ describe('Stream schedule execution', () => {
 				ipVersion: 4,
 				port: 80,
 				inProgressUpdates: false,
-				timeout: 5,
+				timeout: 10,
 			},
 		});
 	});

--- a/test/tests/unit/measurement/schema/request-schema.test.ts
+++ b/test/tests/unit/measurement/schema/request-schema.test.ts
@@ -44,11 +44,11 @@ describe('command schema', async () => {
 			});
 
 			it('should resolve defaults based on the measurement type and packets', () => {
-				expect(validate({ type: 'http', target: 'example.com' }).timeout).to.equal(10);
-				expect(validate({ type: 'traceroute', target: 'example.com' }).timeout).to.equal(5);
-				expect(validate({ type: 'dns', target: 'example.com' }).timeout).to.equal(7);
-				expect(validate({ type: 'dns', target: 'example.com', measurementOptions: { trace: true } }).timeout).to.equal(16);
-				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(5);
+				expect(validate({ type: 'http', target: 'example.com' }).timeout).to.equal(15);
+				expect(validate({ type: 'traceroute', target: 'example.com' }).timeout).to.equal(10);
+				expect(validate({ type: 'dns', target: 'example.com' }).timeout).to.equal(10);
+				expect(validate({ type: 'dns', target: 'example.com', measurementOptions: { trace: true } }).timeout).to.equal(25);
+				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(10);
 				expect(validate({ type: 'ping', target: 'example.com', measurementOptions: { packets: 16 } }).timeout).to.equal(11);
 				expect(validate({ type: 'mtr', target: 'example.com', measurementOptions: { packets: 3 } }).timeout).to.equal(11);
 				expect(validate({ type: 'mtr', target: 'example.com', measurementOptions: { packets: 16 } }).timeout).to.equal(17);
@@ -927,7 +927,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should populate with default values (no measurementOptions)', () => {
@@ -952,7 +952,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 target is a domain', () => {
@@ -977,7 +977,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -1020,7 +1020,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -1045,7 +1045,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target is bracketed ipv6', () => {
@@ -1071,7 +1071,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 	});
 
@@ -1341,7 +1341,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -1365,7 +1365,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -1419,7 +1419,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target ipv6', () => {
@@ -1443,7 +1443,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target bracketed ipv6', () => {
@@ -1468,7 +1468,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 5 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 	});
 
@@ -1728,7 +1728,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 resolver is a domain', () => {
@@ -1757,7 +1757,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 4 automatically selected when resolver is ipv4', () => {
@@ -1796,7 +1796,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when resolver is ipv6', () => {
@@ -1835,7 +1835,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -1863,7 +1863,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 7 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
 		});
 
 		it('should fail (ip version provided when resolver is an ip)', () => {
@@ -2773,7 +2773,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 		});
 
 		it('should pass', () => {
@@ -2816,7 +2816,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 		});
 
 		it('should populate body with default values (no measurementOptions)', () => {
@@ -2846,7 +2846,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 		});
 
 		it('should pass (deep equal) ip version 6 target is a domain', () => {
@@ -2894,7 +2894,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 		});
 
 		it('should fail ip version provided when target is an ip', () => {
@@ -2989,7 +2989,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 		});
 
 		it('should pass (deep equal) ip version 6 automatically selected when target is ipv6', () => {
@@ -3036,7 +3036,7 @@ describe('command schema', async () => {
 			const valid = globalSchema.validate(input, { convert: true });
 
 			expect(valid.error).to.not.exist;
-			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+			expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 		});
 	});
 
@@ -3084,6 +3084,6 @@ describe('command schema', async () => {
 		const valid = globalSchema.validate(input, { convert: true });
 
 		expect(valid.error).to.not.exist;
-		expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 10 });
+		expect(valid.value).to.deep.equal({ ...desiredOutput, timeout: 15 });
 	});
 });

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -380,6 +380,7 @@ describe('measurement store', () => {
 				createdAt: new Date(now).toISOString(),
 				updatedAt: new Date(now).toISOString(),
 				target: 'jsdelivr.com',
+				timeout: 5,
 				probesCount: 1,
 				results: [
 					{
@@ -439,6 +440,7 @@ describe('measurement store', () => {
 				createdAt: new Date(now).toISOString(),
 				updatedAt: new Date(now).toISOString(),
 				target: 'jsdelivr.com',
+				timeout: 10,
 				probesCount: 1,
 				results: [
 					{
@@ -494,6 +496,7 @@ describe('measurement store', () => {
 				createdAt: new Date(now).toISOString(),
 				updatedAt: new Date(now).toISOString(),
 				target: 'jsdelivr.com',
+				timeout: 5,
 				probesCount: 1,
 				results: [
 					{
@@ -568,6 +571,7 @@ describe('measurement store', () => {
 			createdAt: new Date(now).toISOString(),
 			updatedAt: new Date(now).toISOString(),
 			target: 'jsdelivr.com',
+			timeout: 10,
 			probesCount: 1,
 			measurementOptions: {
 				protocol: 'HTTP',
@@ -634,6 +638,7 @@ describe('measurement store', () => {
 				createdAt: new Date(now).toISOString(),
 				updatedAt: new Date(now).toISOString(),
 				target: 'jsdelivr.com',
+				timeout: 5,
 				probesCount: 1,
 				scheduleId: 'schedule-id',
 				configurationId: 'configuration-id',
@@ -683,7 +688,7 @@ describe('measurement store', () => {
 				limit: 1,
 				locations: [],
 				inProgressUpdates: false,
-				timeout: 10,
+				timeout: 15,
 			},
 			new Map([ [ 0, getProbe('id', '1.1.1.1') ] ]),
 			[ getProbe('id', '1.1.1.1') ],


### PR DESCRIPTION
Increase the default ping, traceroute, HTTP, and DNS timeouts so probes have enough time for hostname resolution, while preserving explicit timeouts and the existing MTR defaults.