### PR TITLE
fix: filter for ready probes in scheduled measurements

### DIFF
--- a/src/schedule/executor.ts
+++ b/src/schedule/executor.ts
@@ -158,7 +158,7 @@ export class StreamScheduleExecutor {
 	}
 
 	private getFilteredLocalProbes (schedule: Schedule) {
-		const localProbes = this.syncedProbeList.getLocalProbes();
+		const localProbes = this.syncedProbeList.getLocalProbes().filter(probe => probe.status === 'ready');
 
 		if (schedule.locations.length === 0) {
 			return localProbes;

--- a/test/tests/integration/schedule/stream-schedule.test.ts
+++ b/test/tests/integration/schedule/stream-schedule.test.ts
@@ -399,6 +399,35 @@ describe('Stream schedule execution', () => {
 		expect(requestHandlerStub2.callCount).to.be.greaterThan(0);
 	});
 
+	it('skips probes that are not in the ready status', async () => {
+		const requestHandlerStub1 = sandbox.stub();
+		const requestHandlerStub2 = sandbox.stub();
+
+		const probe1 = await addFakeProbe({
+			'probe:measurement:request': requestHandlerStub1,
+		});
+
+		probe1.emit('probe:status:update', 'ready');
+		probe1.emit('probe:isIPv4Supported:update', true);
+
+		nockGeoIpProviders();
+
+		const probe2 = await addFakeProbe({
+			'probe:measurement:request': requestHandlerStub2,
+		});
+
+		probe2.emit('probe:status:update', 'icmp-tcp-test-failed');
+		probe2.emit('probe:isIPv4Supported:update', true);
+		await waitForProbesUpdate();
+
+		await insertSchedule(buildSchedule());
+
+		await clock.tickAsyncStepped(5000);
+
+		expect(requestHandlerStub1.callCount).to.be.greaterThan(0);
+		expect(requestHandlerStub2.callCount).to.equal(0);
+	});
+
 	it('stops emitting measurements after schedule is disabled', async () => {
 		const requestHandlerStub = sandbox.stub();
 


### PR DESCRIPTION
Current scheduled measurements are not filtering probes by `ready` status, which leads to the logs spam on probe side:
```
[2026-08-14 10:39:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:39:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:40:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:40:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:41:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:41:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:42:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:42:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:43:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:43:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:44:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:44:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
[2026-08-14 10:45:33 +02:00] [general] [WARN] Measurement was sent to probe with icmp-tcp-test-failed status.
```

PR adds filtering. Alternatively, if we need to run on all probes for monitoring purposes, we can add a `system` flag to the schedule configuration and skip the logging.