### PR TITLE
fix: reliably acknowledge probe events

### DIFF
--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -45,7 +45,7 @@ export const initGateway = (ioContext: IoContext) => {
 			// Handlers
 			subscribeWithHandler(socket, 'probe:status:update', handleStatusUpdate(probe));
 			subscribeWithAckHandler(socket, 'probe:logs', handleNewLogs(probe));
-			subscribeWithHandler(socket, 'probe:alt-ips', handleAltIps(probe, altIpsClient));
+			subscribeWithAckHandler(socket, 'probe:alt-ips', handleAltIps(probe, altIpsClient));
 			subscribeWithHandler(socket, 'probe:isIPv6Supported:update', handleIsIPv6SupportedUpdate(probe));
 			subscribeWithHandler(socket, 'probe:isIPv4Supported:update', handleIsIPv4SupportedUpdate(probe));
 			subscribeWithHandler(socket, 'probe:dns:update', handleDnsUpdate(probe));

--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -10,7 +10,7 @@ import { PROBES_NAMESPACE, type ServerSocket } from './server.js';
 import { health } from './middleware/health.js';
 import { probeMetadata } from './middleware/probe-metadata.js';
 import { errorHandler } from './helper/error-handler.js';
-import { subscribeWithHandler } from './helper/subscribe-handler.js';
+import { subscribeWithAckHandler, subscribeWithHandler } from './helper/subscribe-handler.js';
 import { handleIsIPv4SupportedUpdate, handleIsIPv6SupportedUpdate } from '../../probe/handler/ip-version.js';
 import { handleNewLogs } from '../../probe/handler/logs.js';
 import { handleAltIps } from '../../probe/handler/alt-ips.js';
@@ -45,7 +45,7 @@ export const initGateway = (ioContext: IoContext) => {
 
 			// Handlers
 			subscribeWithHandler(socket, 'probe:status:update', handleStatusUpdate(probe));
-			subscribeWithHandler(socket, 'probe:logs', handleNewLogs(probe));
+			subscribeWithAckHandler(socket, 'probe:logs', handleNewLogs(probe));
 			subscribeWithHandler(socket, 'probe:alt-ips', handleAltIps(probe, altIpsClient));
 			subscribeWithHandler(socket, 'probe:isIPv6Supported:update', handleIsIPv6SupportedUpdate(probe));
 			subscribeWithHandler(socket, 'probe:isIPv4Supported:update', handleIsIPv4SupportedUpdate(probe));

--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -1,5 +1,4 @@
 import { listenMeasurementRequest } from '../../measurement/handler/request.js';
-import { handleMeasurementAck } from '../../measurement/handler/ack.js';
 import { handleMeasurementResult } from '../../measurement/handler/result.js';
 import { handleMeasurementProgress } from '../../measurement/handler/progress.js';
 import { handleStatusUpdate } from '../../probe/handler/status.js';
@@ -52,7 +51,6 @@ export const initGateway = (ioContext: IoContext) => {
 			subscribeWithHandler(socket, 'probe:dns:update', handleDnsUpdate(probe));
 			subscribeWithHandler(socket, 'probe:stats:report', handleStatsReport(probe));
 			socket.onAnyOutgoing(listenMeasurementRequest(probe));
-			subscribeWithHandler(socket, 'probe:measurement:ack', handleMeasurementAck(probe));
 			subscribeWithHandler(socket, 'probe:measurement:progress', handleMeasurementProgress(probe, measurementRunner));
 			subscribeWithHandler(socket, 'probe:measurement:result', handleMeasurementResult(probe, measurementRunner));
 			subscribeWithHandler(socket, 'probe:adoption:ready', handleAdoptionServerStart(probe));

--- a/src/lib/ws/helper/subscribe-handler.ts
+++ b/src/lib/ws/helper/subscribe-handler.ts
@@ -40,3 +40,29 @@ export const subscribeWithHandler = (socket: ServerSocket, event: string, method
 		}
 	});
 };
+
+export const subscribeWithAckHandler = (socket: ServerSocket, event: string, method: HandlerMethod) => {
+	subscribeWithHandler(socket, event, async (...args) => {
+		const lastArg: unknown = args.at(-1);
+		const callback = typeof lastArg === 'function' ? lastArg as (response?: unknown) => void : undefined;
+		const handlerArgs = callback ? args.slice(0, -1) : args;
+		let acknowledged = false;
+
+		const wrappedCallback = callback ? (response?: unknown) => {
+			acknowledged = true;
+			callback(response);
+		} : undefined;
+
+		try {
+			await method(...handlerArgs, wrappedCallback as never);
+
+			if (wrappedCallback && !acknowledged) {
+				throw new Error(`Ack handler for event "${event}" resolved without acknowledging.`);
+			}
+		} finally {
+			if (wrappedCallback && !acknowledged) {
+				wrappedCallback();
+			}
+		}
+	});
+};

--- a/src/measurement/handler/ack.ts
+++ b/src/measurement/handler/ack.ts
@@ -1,6 +1,0 @@
-import type { SocketProbe } from '../../probe/types.js';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const handleMeasurementAck = (_probe: SocketProbe) => async (_data: null, ack?: () => void): Promise<void> => {
-	ack?.();
-};

--- a/src/probe/handler/logs.ts
+++ b/src/probe/handler/logs.ts
@@ -14,11 +14,11 @@ export type LogMessage = {
 
 const probeLogStorage = getProbeLogStorage();
 
-export const handleNewLogs = (probe: SocketProbe) => async (logMessage: LogMessage, callback?: (arg: string) => void) => {
+export const handleNewLogs = (probe: SocketProbe) => async (logMessage: LogMessage, callback?: (response: 'success' | 'discard') => void) => {
 	const validation = logMessageSchema.validate(logMessage);
 
 	if (validation.error) {
-		callback?.('error');
+		callback?.('discard');
 		throw validation.error;
 	}
 

--- a/test/tests/integration/alternative-ip.test.ts
+++ b/test/tests/integration/alternative-ip.test.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import { setTimeout } from 'node:timers/promises';
 import nock from 'nock';
 import * as sinon from 'sinon';
 import request, { type Agent } from 'supertest';
@@ -150,5 +151,16 @@ describe('Alternative IPs', () => {
 
 		expect(ack.callCount).to.equal(1);
 		expect(ack.args[0]![0]).to.deep.equal({ addedAltIps: [], rejectedIpsToReasons: { '1.2.3.4': 'Invalid alt IP token.' } });
+	});
+
+	it('should acknowledge invalid alt ip updates', async () => {
+		nockGeoIpProviders();
+		const probe = await addFakeProbe();
+		const response = await Promise.race([
+			new Promise(resolve => probe.emit('probe:alt-ips', null as never, (response: unknown) => resolve(response))),
+			setTimeout(1000, 'timeout'),
+		]);
+
+		expect(response).to.equal(null);
 	});
 });

--- a/test/tests/integration/measurement/probe-communication.test.ts
+++ b/test/tests/integration/measurement/probe-communication.test.ts
@@ -174,8 +174,6 @@ describe('Create measurement request', () => {
 				expect(response).to.matchApiSchema();
 			});
 
-		probe.emit('probe:measurement:ack', null, () => {});
-
 		probe.emit('probe:measurement:progress', {
 			testId: '0',
 			measurementId: mockedMeasurementId,
@@ -355,8 +353,6 @@ describe('Create measurement request', () => {
 				rawOutput: '',
 			});
 		});
-
-		probe.emit('probe:measurement:ack', null, () => {});
 
 		probe.emit('probe:measurement:progress', {
 			testId: '0',

--- a/test/tests/unit/ws/probe-logs.test.ts
+++ b/test/tests/unit/ws/probe-logs.test.ts
@@ -6,7 +6,7 @@ import type { ServerProbe } from '../../../../src/probe/types.js';
 
 describe('probe logs', () => {
 	let sandbox: sinon.SinonSandbox;
-	let logHandler: (logMessage: LogMessage, callback?: () => void) => Promise<void>;
+	let logHandler: (logMessage: LogMessage, callback?: (response: 'success' | 'discard') => void) => Promise<void>;
 
 	let transactionStub: {
 		xAdd: sinon.SinonStub;
@@ -43,7 +43,8 @@ describe('probe logs', () => {
 	});
 
 	it('should throw on invalid inputs', async () => {
-		const result1 = await logHandler({ skipped: 0 } as LogMessage).catch(err => err);
+		const callback = sandbox.stub();
+		const result1 = await logHandler({ skipped: 0 } as LogMessage, callback).catch(err => err);
 		const result2 = await logHandler({ logs: [] } as unknown as LogMessage).catch(err => err);
 		const result3 = await logHandler({ skipped: 1, logs: [{ invalid: true }] } as unknown as LogMessage).catch(err => err);
 		const result4 = await logHandler({ skipped: 1, logs: [], extra: true } as LogMessage).catch(err => err);
@@ -57,23 +58,36 @@ describe('probe logs', () => {
 		expect(result3).to.be.instanceof(Error);
 		expect(result4).to.be.instanceof(Error);
 		expect(result5).to.be.instanceof(Error);
-
+		expect(callback.calledOnceWithExactly('discard')).to.equal(true);
 		expect(multiStub.called).to.equal(false);
 		expect(transactionStub.xAdd.called).to.equal(false);
 		expect(transactionStub.pExpire.called).to.equal(false);
 		expect(transactionStub.exec.called).to.equal(false);
 	});
 
+	it('throws when writing logs fails', async () => {
+		const callback = sandbox.stub();
+		const error = new Error('Redis write failed.');
+		transactionStub.exec.rejects(error);
+
+		const result = await logHandler({ skipped: 0, logs: [] }, callback).catch(err => err);
+
+		expect(result).to.equal(error);
+		expect(callback.called).to.equal(false);
+	});
+
 	it('writes only provided logs when skipped = 0', async () => {
+		const callback = sandbox.stub();
 		const logs = [
 			{ message: '1', timestamp: 't1', level: 'info', scope: 'system' },
 			{ message: '2'.repeat(8192), timestamp: 't2', level: 'warn', scope: 'system' },
 		];
 
-		await logHandler({ skipped: 0, logs });
+		await logHandler({ skipped: 0, logs }, callback);
 
 		expect(multiStub.calledOnce).to.equal(true);
 		expect(transactionStub.xAdd.callCount).to.equal(2);
+		expect(callback.calledOnceWithExactly('success')).to.equal(true);
 
 		for (let i = 0; i < logs.length; i++) {
 			const call = transactionStub.xAdd.getCall(i);


### PR DESCRIPTION
Ensures probe event handlers that expect acknowledgements always respond after settling, including validation and handler failures, and removes the redundant `probe:measurement:ack` event.

Needs to be deployed after [globalping-probe#413](https://github.com/jsdelivr/globalping-probe/pull/413).