### PR TITLE
feat: add reliability metrics

### DIFF
--- a/src/lib/metrics-collector.ts
+++ b/src/lib/metrics-collector.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { Queue as BullQueue } from 'bullmq';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
 import type { Knex } from 'knex';
 import type { Pool } from 'tarn';
@@ -9,9 +10,11 @@ import { USERS_TABLE } from './http/auth.js';
 import { dashboardClient } from './sql/client.js';
 import type { IoContext } from './server.js';
 import { registerGuardedMetric } from './metrics.js';
+import { getMeasurementStoreFallbackQueueConnectionOptions, MEASUREMENT_STORE_FALLBACK_QUEUE_NAME } from '../measurement/store-offloader.js';
 
 const logger = scopedLogger('metrics');
 const eventLoopMonitorResolution = 10;
+const measurementOffloadPendingStates = [ 'waiting', 'active', 'delayed', 'paused' ] as const;
 
 export class MetricsCollector {
 	private readonly asyncSeries: Record<string, number[]> = {};
@@ -22,6 +25,7 @@ export class MetricsCollector {
 		private readonly redis: RedisCluster,
 		private readonly sql: Knex,
 		private readonly fetchProbes: IoContext['fetchProbes'],
+		private readonly measurementOffloadQueue: BullQueue,
 	) {}
 
 	run (): void {
@@ -63,6 +67,27 @@ export class MetricsCollector {
 			// 1 global key tracks the in-progress measurements
 			return Math.round((dbSize - awaitingSize - 1) / 2);
 		}, 60 * 1000);
+
+		this.registerAsyncGroupCollector('measurement cleanup stats', async () => {
+			const now = Date.now();
+			const [ inProgressCount, pendingCleanupCount ] = await Promise.all([
+				this.redis.zCard('gp:in-progress-timeouts'),
+				this.redis.zCount('gp:in-progress-timeouts', '-inf', now),
+			]);
+
+			return {
+				'gp.measurement.in_progress.count': inProgressCount,
+				'gp.measurement.cleanup.pending.count': pendingCleanupCount,
+			};
+		}, 10 * 1000);
+
+		this.registerAsyncGroupCollector('measurement offload stats', async () => {
+			const counts = await this.measurementOffloadQueue.getJobCounts(...measurementOffloadPendingStates);
+
+			return {
+				'gp.measurement.offload.pending.count': _.sum(Object.values(counts)),
+			};
+		}, 10 * 1000);
 
 		this.registerAsyncCollector(`gp.probe.count.local`, async () => {
 			return this.fetchRawLocalSockets().then(sockets => sockets.length);
@@ -151,5 +176,9 @@ export class MetricsCollector {
 }
 
 export const initMetricsCollector = (fetchRawLocalSockets: IoContext['fetchRawLocalSockets'], fetchProbes: IoContext['fetchProbes']) => {
-	return new MetricsCollector(fetchRawLocalSockets, getMeasurementRedisClient(), dashboardClient, fetchProbes);
+	const measurementOffloadQueue = new BullQueue(MEASUREMENT_STORE_FALLBACK_QUEUE_NAME, {
+		connection: getMeasurementStoreFallbackQueueConnectionOptions(),
+	});
+
+	return new MetricsCollector(fetchRawLocalSockets, getMeasurementRedisClient(), dashboardClient, fetchProbes, measurementOffloadQueue);
 };

--- a/src/lib/metrics-collector.ts
+++ b/src/lib/metrics-collector.ts
@@ -1,0 +1,155 @@
+import _ from 'lodash';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import type { Knex } from 'knex';
+import type { Pool } from 'tarn';
+
+import { scopedLogger } from './logger.js';
+import { getMeasurementRedisClient, type RedisCluster } from './redis/measurement-client.js';
+import { USERS_TABLE } from './http/auth.js';
+import { dashboardClient } from './sql/client.js';
+import type { IoContext } from './server.js';
+import { registerGuardedMetric } from './metrics.js';
+
+const logger = scopedLogger('metrics');
+const eventLoopMonitorResolution = 10;
+
+export class MetricsCollector {
+	private readonly asyncSeries: Record<string, number[]> = {};
+	private readonly timers: Record<string, NodeJS.Timeout> = {};
+
+	constructor (
+		private readonly fetchRawLocalSockets: IoContext['fetchRawLocalSockets'],
+		private readonly redis: RedisCluster,
+		private readonly sql: Knex,
+		private readonly fetchProbes: IoContext['fetchProbes'],
+	) {}
+
+	run (): void {
+		const loopMonitorP95 = monitorEventLoopDelay({ resolution: eventLoopMonitorResolution });
+		const loopMonitorP99 = monitorEventLoopDelay({ resolution: eventLoopMonitorResolution });
+		const loopMonitorMax = monitorEventLoopDelay({ resolution: eventLoopMonitorResolution });
+		loopMonitorP95.enable();
+		loopMonitorP99.enable();
+		loopMonitorMax.enable();
+
+		const toMs = (value: number) => Math.max(0, Number(value) / 1e6 - eventLoopMonitorResolution);
+
+		registerGuardedMetric('nodejs.eventloop.delay.p95.ms', () => {
+			const loopDelay = toMs(loopMonitorP95.percentile(95));
+			loopMonitorP95.reset();
+			return loopDelay;
+		});
+
+		registerGuardedMetric('nodejs.eventloop.delay.p99.ms', () => {
+			const loopDelay = toMs(loopMonitorP99.percentile(99));
+			loopMonitorP99.reset();
+			return loopDelay;
+		});
+
+		registerGuardedMetric('nodejs.eventloop.delay.max.ms', () => {
+			const loopDelay = toMs(loopMonitorMax.max);
+			loopMonitorMax.reset();
+			return loopDelay;
+		});
+
+		this.registerAsyncCollector(`gp.measurement.stored.count`, async () => {
+			const [ dbSize, awaitingSize ] = await Promise.all([
+				this.redis.reduceMasters<number>(async (accumulator, client) => accumulator + await client.dbSize(), 0),
+				this.redis.zCard('gp:in-progress-timeouts'),
+			]);
+
+			// running measurements use 3 keys
+			// finished measurements use 2 keys
+			// 1 global key tracks the in-progress measurements
+			return Math.round((dbSize - awaitingSize - 1) / 2);
+		}, 60 * 1000);
+
+		this.registerAsyncCollector(`gp.probe.count.local`, async () => {
+			return this.fetchRawLocalSockets().then(sockets => sockets.length);
+		}, 10 * 1000);
+
+		this.registerAsyncGroupCollector('global probe stats', async () => {
+			const probes = await this.fetchProbes();
+			const byContinent = _.groupBy(probes, probe => probe.location.continent);
+
+			const countByContinent = _(byContinent)
+				.mapKeys((_probes, continent) => `gp.probe.count.continent.${continent}`)
+				.mapValues(probes => probes.length)
+				.value();
+
+			return {
+				...countByContinent,
+				'gp.probe.count.adopted': probes.filter(probe => probe.owner).length,
+				'gp.probe.count.total': probes.length,
+			};
+		}, 10 * 1000);
+
+		this.registerAsyncGroupCollector(`user stats`, async () => {
+			const result = await this.sql(USERS_TABLE)
+				.count('user_type as c')
+				.groupBy('user_type')
+				.select<{ user_type: string; c: number }[]>([ 'user_type' ]);
+
+			const countByType = _(result)
+				.mapKeys(record => `gp.user.count.${record.user_type}`)
+				.mapValues(record => record.c)
+				.value();
+
+			return {
+				...countByType,
+				'gp.user.count.total': _.sum(Object.values(countByType)),
+			};
+		}, 60 * 1000);
+
+		const getDashboardPool = (): Pool<unknown> | undefined => {
+			return (this.sql.client as Knex.Client).pool as Pool<unknown> | undefined;
+		};
+
+		registerGuardedMetric('gp.db.dashboard.pool.used', () => getDashboardPool()?.numUsed());
+		registerGuardedMetric('gp.db.dashboard.pool.pending_acquires', () => getDashboardPool()?.numPendingAcquires());
+	}
+
+	private recordAsyncDatapoint (name: string, value: number): void {
+		if (!this.asyncSeries[name]) {
+			this.registerAsyncSeries(name);
+		}
+
+		this.asyncSeries[name]!.push(value);
+	}
+
+	private registerAsyncSeries (name: string): void {
+		this.asyncSeries[name] = [];
+
+		registerGuardedMetric(name, () => {
+			const value = this.asyncSeries[name]!.at(-1);
+			this.asyncSeries[name] = [];
+			return value;
+		});
+	}
+
+	private registerAsyncCollector (name: string, callback: () => Promise<number>, interval: number): void {
+		this.timers[name] = setInterval(() => {
+			callback().then((value) => {
+				this.recordAsyncDatapoint(name, value);
+			}).catch((error) => {
+				logger.error(`Failed to collect an async metric "${name}"`, error);
+			});
+		}, interval);
+	}
+
+	private registerAsyncGroupCollector (groupName: string, callback: () => Promise<{ [k: string]: number }>, interval: number): void {
+		this.timers[groupName] = setInterval(() => {
+			callback().then((group) => {
+				Object.entries(group).forEach(([ key, value ]) => {
+					this.recordAsyncDatapoint(key, value);
+				});
+			}).catch((error) => {
+				logger.error(`Failed to collect an async metric group "${groupName}"`, error);
+			});
+		}, interval);
+	}
+}
+
+export const initMetricsCollector = (fetchRawLocalSockets: IoContext['fetchRawLocalSockets'], fetchProbes: IoContext['fetchProbes']) => {
+	return new MetricsCollector(fetchRawLocalSockets, getMeasurementRedisClient(), dashboardClient, fetchProbes);
+};

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,118 +1,12 @@
 import _ from 'lodash';
 import apmAgent from 'elastic-apm-node';
-import { monitorEventLoopDelay } from 'node:perf_hooks';
-import type { Knex } from 'knex';
-import type { Pool } from 'tarn';
 import type { Middleware } from 'koa';
-
-import { scopedLogger } from './logger.js';
-import { getMeasurementRedisClient, type RedisCluster } from './redis/measurement-client.js';
-import { USERS_TABLE } from './http/auth.js';
-import { dashboardClient } from './sql/client.js';
-import type { IoContext } from './server.js';
-
-const logger = scopedLogger('metrics');
-const eventLoopMonitorResolution = 10;
 
 export class MetricsAgent {
 	private readonly counters: Record<string, number> = {};
 	private readonly statsAvg: Record<string, number[]> = {};
 	private readonly statsMed: Record<string, number[]> = {};
 	private readonly statsMax: Record<string, number[]> = {};
-	private readonly asyncSeries: Record<string, number[]> = {};
-	private readonly timers: Record<string, NodeJS.Timeout> = {};
-
-	constructor (
-		private readonly fetchRawLocalSockets: IoContext['fetchRawLocalSockets'],
-		private readonly redis: RedisCluster,
-		private readonly sql: Knex,
-		private readonly fetchProbes: IoContext['fetchProbes'],
-	) {}
-
-	run (): void {
-		const loopMonitorP95 = monitorEventLoopDelay({ resolution: eventLoopMonitorResolution });
-		const loopMonitorP99 = monitorEventLoopDelay({ resolution: eventLoopMonitorResolution });
-		const loopMonitorMax = monitorEventLoopDelay({ resolution: eventLoopMonitorResolution });
-		loopMonitorP95.enable();
-		loopMonitorP99.enable();
-		loopMonitorMax.enable();
-
-		const toMs = (value: number) => Math.max(0, Number(value) / 1e6 - eventLoopMonitorResolution);
-
-		registerGuardedMetric('nodejs.eventloop.delay.p95.ms', () => {
-			const loopDelay = toMs(loopMonitorP95.percentile(95));
-			loopMonitorP95.reset();
-			return loopDelay;
-		});
-
-		registerGuardedMetric('nodejs.eventloop.delay.p99.ms', () => {
-			const loopDelay = toMs(loopMonitorP99.percentile(99));
-			loopMonitorP99.reset();
-			return loopDelay;
-		});
-
-		registerGuardedMetric('nodejs.eventloop.delay.max.ms', () => {
-			const loopDelay = toMs(loopMonitorMax.max);
-			loopMonitorMax.reset();
-			return loopDelay;
-		});
-
-		this.registerAsyncCollector(`gp.measurement.stored.count`, async () => {
-			const [ dbSize, awaitingSize ] = await Promise.all([
-				this.redis.reduceMasters<number>(async (accumulator, client) => accumulator + await client.dbSize(), 0),
-				this.redis.zCard('gp:in-progress-timeouts'),
-			]);
-
-			// running measurements use 3 keys
-			// finished measurements use 2 keys
-			// 1 global key tracks the in-progress measurements
-			return Math.round((dbSize - awaitingSize - 1) / 2);
-		}, 60 * 1000);
-
-		this.registerAsyncCollector(`gp.probe.count.local`, async () => {
-			return this.fetchRawLocalSockets().then(sockets => sockets.length);
-		}, 10 * 1000);
-
-		this.registerAsyncGroupCollector('global probe stats', async () => {
-			const probes = await this.fetchProbes();
-			const byContinent = _.groupBy(probes, probe => probe.location.continent);
-
-			const countByContinent = _(byContinent)
-				.mapKeys((_probes, continent) => `gp.probe.count.continent.${continent}`)
-				.mapValues(probes => probes.length)
-				.value();
-
-			return {
-				...countByContinent,
-				'gp.probe.count.adopted': probes.filter(probe => probe.owner).length,
-				'gp.probe.count.total': probes.length,
-			};
-		}, 10 * 1000);
-
-		this.registerAsyncGroupCollector(`user stats`, async () => {
-			const result = await this.sql(USERS_TABLE)
-				.count('user_type as c')
-				.groupBy('user_type')
-				.select<{ user_type: string; c: number }[]>([ 'user_type' ]);
-
-			const countByType = _(result)
-				.mapKeys(record => `gp.user.count.${record.user_type}`)
-				.mapValues(record => record.c)
-				.value();
-
-			return {
-				...countByType,
-				'gp.user.count.total': _.sum(Object.values(countByType)),
-			};
-		}, 60 * 1000);
-
-		const getDashboardPool = (): Pool<unknown> | undefined => {
-			return (this.sql.client as Knex.Client).pool as Pool<unknown> | undefined;
-		};
-
-		registerGuardedMetric('gp.db.dashboard.pool.used', () => getDashboardPool()?.numUsed());
-		registerGuardedMetric('gp.db.dashboard.pool.pending_acquires', () => getDashboardPool()?.numPendingAcquires());
-	}
 
 	recordMeasurementTime (type: string, time: number): void {
 		this.recordStats(`gp.measurement.time.${type}`, time);
@@ -180,51 +74,9 @@ export class MetricsAgent {
 			return value;
 		});
 	}
-
-	private recordAsyncDatapoint (name: string, value: number): void {
-		if (!this.asyncSeries[name]) {
-			this.registerAsyncSeries(name);
-		}
-
-		this.asyncSeries[name]!.push(value);
-	}
-
-	private registerAsyncSeries (name: string): void {
-		this.asyncSeries[name] = [];
-
-		registerGuardedMetric(name, () => {
-			const value = this.asyncSeries[name]!.at(-1);
-			this.asyncSeries[name] = [];
-			return value;
-		});
-	}
-
-	private registerAsyncCollector (name: string, callback: () => Promise<number>, interval: number): void {
-		this.timers[name] = setInterval(() => {
-			callback().then((value) => {
-				this.recordAsyncDatapoint(name, value);
-			}).catch((error) => {
-				logger.error(`Failed to collect an async metric "${name}"`, error);
-			});
-		}, interval);
-	}
-
-	private registerAsyncGroupCollector (groupName: string, callback: () => Promise<{ [k: string]: number }>, interval: number): void {
-		this.timers[groupName] = setInterval(() => {
-			callback().then((group) => {
-				Object.entries(group).forEach(([ key, value ]) => {
-					this.recordAsyncDatapoint(key, value);
-				});
-			}).catch((error) => {
-				logger.error(`Failed to collect an async metric group "${groupName}"`, error);
-			});
-		}, interval);
-	}
 }
 
-export const initMetricsAgent = (fetchRawLocalSockets: IoContext['fetchRawLocalSockets'], fetchProbes: IoContext['fetchProbes']) => {
-	return new MetricsAgent(fetchRawLocalSockets, getMeasurementRedisClient(), dashboardClient, fetchProbes);
-};
+export const metricsAgent = new MetricsAgent();
 
 export const captureSpan = <R>(name: string, fn: () => R): R => {
 	const span = apmAgent.startSpan(name, 'app', 'custom');
@@ -322,7 +174,7 @@ function median (values: number[]): number | undefined {
 	return (values[half - 1]! + values[half]!) / 2;
 }
 
-function registerGuardedMetric (name: string, callback: () => number | undefined): void {
+export function registerGuardedMetric (name: string, callback: () => number | undefined): void {
 	apmAgent.registerMetric(name, () => {
 		const value = callback();
 		return value || 0; // NaN/undefined => 0

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -23,6 +23,30 @@ export class MetricsAgent {
 		this.incrementCounter(`gp.probe.disconnect_${type.replaceAll(' ', '_')}`);
 	}
 
+	recordProbeSyncGap (operation: 'push' | 'pull', value: number): void {
+		this.recordStats(`gp.probe_sync.${operation}_gap.ms`, value);
+	}
+
+	recordProbeSyncPullEvents (eventType: 'alive' | 'reload' | 'remove' | 'update' | 'stats', value: number): void {
+		this.incrementCounter(`gp.probe_sync.pull.event.count.${eventType}`, value);
+	}
+
+	recordNoProbesFound (): void {
+		this.incrementCounter('gp.measurement.no_probes_found.count');
+	}
+
+	recordMeasurementCompleted (type: string): void {
+		this.incrementCounter(`gp.measurement.completed.count.${type}`);
+		this.incrementCounter('gp.measurement.completed.count.total');
+	}
+
+	recordMeasurementTimeout (type: string, testCount: number): void {
+		this.incrementCounter(`gp.measurement.timeout.count.${type}`);
+		this.incrementCounter('gp.measurement.timeout.count.total');
+		this.incrementCounter(`gp.test.timeout.count.${type}`, testCount);
+		this.incrementCounter('gp.test.timeout.count.total', testCount);
+	}
+
 	private incrementCounter (name: string, value: number = 1): void {
 		if (!this.counters[name]) {
 			this.registerCounter(name);

--- a/src/lib/redis/scripts.ts
+++ b/src/lib/redis/scripts.ts
@@ -145,6 +145,7 @@ const markFinishedByTimeout = defineScript({
 	local keyMeasurementAwaiting = KEYS[2]
 	local date = ARGV[1]
 	local timeoutMessage = ARGV[2]
+	local timedOutTests = 0
 
 	local measurementJson = redis.pcall('JSON.GET', keyMeasurementResults, '$')
 	if not measurementJson or measurementJson.err then
@@ -163,6 +164,7 @@ const markFinishedByTimeout = defineScript({
 
 	for index, resultObject in ipairs(measurement.results) do
 		if resultObject.result.status == 'in-progress' then
+			timedOutTests = timedOutTests + 1
 			local rawOutput = resultObject.result.rawOutput or ''
 			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.status', '"failed"')
 			redis.call('JSON.SET', keyMeasurementResults, '$.results[' .. (index - 1) .. '].result.failureSource', '"internal"')
@@ -172,7 +174,7 @@ const markFinishedByTimeout = defineScript({
 
 	redis.call('COMPRESSED.JSON.COMPRESS', keyMeasurementResults)
 
-	return redis.call('COMPRESSED.JSON.GET', keyMeasurementResults)
+	return { redis.call('COMPRESSED.JSON.GET', keyMeasurementResults), timedOutTests }
 	`,
 	parseCommand (parser: CommandParser, measurementId: string) {
 		pushMeasurementKeys(parser, measurementId);
@@ -182,8 +184,15 @@ const markFinishedByTimeout = defineScript({
 			'The measurement timed out.',
 		);
 	},
-	transformReply (reply: Buffer | null) {
-		return reply;
+	transformReply (reply: [Buffer, number] | null) {
+		if (!reply) {
+			return null;
+		}
+
+		return {
+			recordBuffer: reply[0],
+			timedOutTests: reply[1],
+		};
 	},
 });
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -91,7 +91,6 @@ export const createServer = async ({ startBackgroundJobs = true }: CreateServerO
 
 	const adoptionToken = initAdoptionToken(adoptedProbes);
 	const probeIpLimit = new ProbeIpLimit(syncedProbeList, disconnectBySocketId, adoptedProbes, adoptionToken);
-	const metricsCollector = initMetricsCollector(fetchRawLocalSockets, fetchProbes);
 	const altIpsClient = initAltIpsClient(probeOverride, getProbeByIp, disconnectBySocketId);
 	const probesLocationFilter = initProbesLocationFilter(onProbesUpdate);
 	const probeRouter = initProbeRouter(onProbesUpdate, probesLocationFilter);
@@ -142,7 +141,7 @@ export const createServer = async ({ startBackgroundJobs = true }: CreateServerO
 		probeIpLimit.scheduleSync();
 		auth.scheduleSync();
 		reconnectProbes(fetchRawSockets);
-		metricsCollector.run();
+		initMetricsCollector(fetchRawLocalSockets, fetchProbes).run();
 	}
 
 	return { httpServer, ioContext };

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -1,6 +1,6 @@
 import { initRedisClient } from './redis/client.js';
 import { initWsServer, PROBES_NAMESPACE, type WsServer } from './ws/server.js';
-import { initMetricsAgent, type MetricsAgent } from './metrics.js';
+import { initMetricsCollector } from './metrics-collector.js';
 import { populateMemList as populateMemMalwareList } from './malware/client.js';
 import { populateMemList as populateMemCloudIpRangesList } from './cloud-ip-ranges.js';
 import { populateMemList as populateMemBlockedIpRangesList } from './blocked-ip-ranges.js';
@@ -44,7 +44,6 @@ export type IoContext = {
 	adminData: AdminData;
 	probeOverride: ProbeOverride;
 	probeIpLimit: ProbeIpLimit;
-	metricsAgent: MetricsAgent;
 	measurementRunner: MeasurementRunner;
 	codeSender: CodeSender;
 	scheduleExecutor: StreamScheduleExecutor;
@@ -92,11 +91,11 @@ export const createServer = async ({ startBackgroundJobs = true }: CreateServerO
 
 	const adoptionToken = initAdoptionToken(adoptedProbes);
 	const probeIpLimit = new ProbeIpLimit(syncedProbeList, disconnectBySocketId, adoptedProbes, adoptionToken);
-	const metricsAgent = initMetricsAgent(fetchRawLocalSockets, fetchProbes);
+	const metricsCollector = initMetricsCollector(fetchRawLocalSockets, fetchProbes);
 	const altIpsClient = initAltIpsClient(probeOverride, getProbeByIp, disconnectBySocketId);
 	const probesLocationFilter = initProbesLocationFilter(onProbesUpdate);
 	const probeRouter = initProbeRouter(onProbesUpdate, probesLocationFilter);
-	const measurementRunner = initMeasurementRunner(io, probeRouter, metricsAgent);
+	const measurementRunner = initMeasurementRunner(io, probeRouter);
 	const codeSender = initCodeSender(io, getProbeByIp);
 
 	initStreamScheduleLoader({ scheduleSync: startBackgroundJobs });
@@ -115,7 +114,6 @@ export const createServer = async ({ startBackgroundJobs = true }: CreateServerO
 		adminData,
 		probeOverride,
 		probeIpLimit,
-		metricsAgent,
 		measurementRunner,
 		codeSender,
 		scheduleExecutor,
@@ -144,7 +142,7 @@ export const createServer = async ({ startBackgroundJobs = true }: CreateServerO
 		probeIpLimit.scheduleSync();
 		auth.scheduleSync();
 		reconnectProbes(fetchRawSockets);
-		metricsAgent.run();
+		metricsCollector.run();
 	}
 
 	return { httpServer, ioContext };

--- a/src/lib/ws/gateway.ts
+++ b/src/lib/ws/gateway.ts
@@ -17,11 +17,12 @@ import { handleAltIps } from '../../probe/handler/alt-ips.js';
 import { handleAdoptionServerStart } from '../../probe/handler/local-adoption-server.js';
 import { handleSettingsUpdate } from '../../probe/handler/settings.js';
 import type { IoContext } from '../server.js';
+import { metricsAgent } from '../metrics.js';
 
 const logger = scopedLogger('gateway');
 
 export const initGateway = (ioContext: IoContext) => {
-	const { io, adoptedProbes, probeOverride, metricsAgent, adoptionToken, probeIpLimit, measurementRunner, altIpsClient } = ioContext;
+	const { io, adoptedProbes, probeOverride, adoptionToken, probeIpLimit, measurementRunner, altIpsClient } = ioContext;
 
 	io
 		.of(PROBES_NAMESPACE)

--- a/src/lib/ws/synced-probe-list.ts
+++ b/src/lib/ws/synced-probe-list.ts
@@ -8,6 +8,7 @@ import type { FetchRawLocalSockets } from './server.js';
 import type { ServerProbe, ProbeStats, SocketProbe } from '../../probe/types.js';
 import type { ProbeOverride } from '../override/probe-override.js';
 import type { RedisClient } from '../redis/shared.js';
+import { metricsAgent } from '../metrics.js';
 
 type NodeData = {
 	nodeId: string;
@@ -44,6 +45,14 @@ const MESSAGE_TYPES = {
 	STATS: 's',
 };
 
+const PULL_EVENT_TYPES = [
+	[ MESSAGE_TYPES.ALIVE, 'alive' ],
+	[ MESSAGE_TYPES.RELOAD, 'reload' ],
+	[ MESSAGE_TYPES.REMOVE, 'remove' ],
+	[ MESSAGE_TYPES.UPDATE, 'update' ],
+	[ MESSAGE_TYPES.STATS, 'stats' ],
+] as const;
+
 export class SyncedProbeList extends EventEmitter {
 	remoteDataTtl = 60 * 60 * 1000;
 	syncInterval = 2000;
@@ -61,6 +70,8 @@ export class SyncedProbeList extends EventEmitter {
 	private pushTimer: NodeJS.Timeout | undefined;
 	private pullTimer: NodeJS.Timeout | undefined;
 	private lastReadEventId: string;
+	private lastPushTimestamp: number | undefined;
+	private lastPullTimestamp: number | undefined;
 
 	private readonly nodeId: string;
 	private readonly nodeData: TTLCache<string, NodeData>;
@@ -291,6 +302,14 @@ export class SyncedProbeList extends EventEmitter {
 	}
 
 	async syncPush () {
+		const now = Date.now();
+
+		if (this.lastPushTimestamp !== undefined) {
+			metricsAgent.recordProbeSyncGap('push', now - this.lastPushTimestamp);
+		}
+
+		this.lastPushTimestamp = now;
+
 		const sockets = await this.fetchRawLocalSockets();
 		const currentProbes = sockets.map(socket => _.cloneDeep(socket.data.probe));
 		const previousNodeData = this.nodeData.get(this.nodeId);
@@ -389,6 +408,14 @@ export class SyncedProbeList extends EventEmitter {
 	}
 
 	async syncPull () {
+		const now = Date.now();
+
+		if (this.lastPullTimestamp !== undefined) {
+			metricsAgent.recordProbeSyncGap('pull', now - this.lastPullTimestamp);
+		}
+
+		this.lastPullTimestamp = now;
+
 		// Returns an *inclusive* range starting from this.lastReadEventId
 		const events = await this.redis.xRange(this.remoteEventsStream, this.lastReadEventId, '+');
 		const hasMissedEvents = events[0]?.id !== this.lastReadEventId;
@@ -402,6 +429,16 @@ export class SyncedProbeList extends EventEmitter {
 		if (!eventsToProcess.length) {
 			return;
 		}
+
+		const pullEventMetrics = eventsToProcess.reduce((metrics, event) => {
+			for (const [ messageType, eventType ] of PULL_EVENT_TYPES) {
+				if (messageType in event.message) {
+					metrics[eventType] = (metrics[eventType] ?? 0) + 1;
+				}
+			}
+
+			return metrics;
+		}, {} as Partial<Record<(typeof PULL_EVENT_TYPES)[number][1], number>>);
 
 		const eventsByNode = _.groupBy(eventsToProcess, event => event.message[MESSAGE_TYPES.NODE]);
 		let nodeDataChanged = false;
@@ -508,6 +545,14 @@ export class SyncedProbeList extends EventEmitter {
 		}
 
 		this.lastReadEventId = events.at(-1)!.id;
+
+		for (const [ , eventType ] of PULL_EVENT_TYPES) {
+			const value = pullEventMetrics[eventType];
+
+			if (value) {
+				metricsAgent.recordProbeSyncPullEvents(eventType, value);
+			}
+		}
 	}
 
 	async sync () {

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -29,6 +29,7 @@ export class MeasurementRunner {
 		const ipVersion = userRequest.measurementOptions?.ipVersion;
 
 		if (allProbes.length === 0) {
+			metricsAgent.recordNoProbesFound();
 			throw createHttpError(422, `No matching IPv${ipVersion} probes available.`, { type: 'no_probes_found' });
 		}
 
@@ -41,6 +42,8 @@ export class MeasurementRunner {
 
 		if (onlineProbesMap.size) {
 			this.sendToProbes(measurementId, onlineProbesMap, request);
+		} else {
+			metricsAgent.recordMeasurementCompleted(request.type);
 		}
 
 		metricsAgent.recordMeasurement(request.type, onlineProbesMap.size);
@@ -56,6 +59,7 @@ export class MeasurementRunner {
 		const record = await this.store.storeMeasurementResult(data);
 
 		if (record) {
+			metricsAgent.recordMeasurementCompleted(record.type);
 			metricsAgent.recordMeasurementTime(record.type, Date.now() - new Date(record.createdAt).getTime());
 		}
 	}

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -59,7 +59,6 @@ export class MeasurementRunner {
 		const record = await this.store.storeMeasurementResult(data);
 
 		if (record) {
-			metricsAgent.recordMeasurementCompleted(record.type);
 			metricsAgent.recordMeasurementTime(record.type, Date.now() - new Date(record.createdAt).getTime());
 		}
 	}

--- a/src/measurement/runner.ts
+++ b/src/measurement/runner.ts
@@ -5,7 +5,7 @@ import apmAgent from 'elastic-apm-node';
 import { PROBES_NAMESPACE } from '../lib/ws/server.js';
 import type { ProbeRouter } from '../probe/router.js';
 import type { ServerProbe } from '../probe/types.js';
-import type { MetricsAgent } from '../lib/metrics.js';
+import { metricsAgent } from '../lib/metrics.js';
 import type { MeasurementStore } from './store.js';
 import { getMeasurementStore } from './store.js';
 import type { MeasurementRequest, MeasurementResultMessage, MeasurementProgressMessage, UserRequest, MeasurementRequestMessage } from './types.js';
@@ -19,7 +19,6 @@ export class MeasurementRunner {
 		private readonly router: ProbeRouter,
 		private readonly precheckRateLimit: typeof precheckPostMeasurementRateLimit,
 		private readonly checkRateLimit: typeof checkPostMeasurementRateLimit,
-		private readonly metrics: MetricsAgent,
 	) {}
 
 	async run (ctx: ExtendedContext): Promise<{ measurementId: string; probesCount: number }> {
@@ -44,7 +43,7 @@ export class MeasurementRunner {
 			this.sendToProbes(measurementId, onlineProbesMap, request);
 		}
 
-		this.metrics.recordMeasurement(request.type, onlineProbesMap.size);
+		metricsAgent.recordMeasurement(request.type, onlineProbesMap.size);
 
 		return { measurementId, probesCount: allProbes.length };
 	}
@@ -57,7 +56,7 @@ export class MeasurementRunner {
 		const record = await this.store.storeMeasurementResult(data);
 
 		if (record) {
-			this.metrics.recordMeasurementTime(record.type, Date.now() - new Date(record.createdAt).getTime());
+			metricsAgent.recordMeasurementTime(record.type, Date.now() - new Date(record.createdAt).getTime());
 		}
 	}
 
@@ -95,13 +94,12 @@ export class MeasurementRunner {
 	}
 }
 
-export const initMeasurementRunner = (io: Server, router: ProbeRouter, metricsAgent: MetricsAgent) => {
+export const initMeasurementRunner = (io: Server, router: ProbeRouter) => {
 	return new MeasurementRunner(
 		io,
 		getMeasurementStore(),
 		router,
 		precheckPostMeasurementRateLimit,
 		checkPostMeasurementRateLimit,
-		metricsAgent,
 	);
 };

--- a/src/measurement/store-offloader.ts
+++ b/src/measurement/store-offloader.ts
@@ -15,21 +15,30 @@ import { MeasurementStore } from './store.js';
 const logger = scopedLogger('db-store');
 const brotliCompress = promisify(brotliCompressCallback);
 
+export const MEASUREMENT_STORE_FALLBACK_QUEUE_NAME = 'measurement-db-store-fallback';
+
+export const getMeasurementStoreFallbackQueueConnectionOptions = () => {
+	const url = config.get<string>('redis.standalonePersistentNoEviction.url');
+	const password = config.get<string>('redis.sharedOptions.password');
+	const tls = config.get<boolean>('redis.sharedOptions.socket.tls');
+
+	return { url, password, tls };
+};
+
 const compressRecord = (record: string): Promise<Buffer> => {
 	return brotliCompress(record, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: 5 } });
 };
 
 export class MeasurementStoreOffloader {
 	private readonly fallbackQueue: BullQueue;
-	private readonly fallbackQueueName = 'measurement-db-store-fallback';
 	private readonly offloadQueues: Record<UserTier, InstanceType<typeof BatchQueue>>;
 
 	constructor (
 		private readonly measurementStoreDb: Knex,
 		private readonly primaryMeasurementStore: MeasurementStore,
 	) {
-		this.fallbackQueue = new BullQueue<{ tier: UserTier; ids: string[] }>(this.fallbackQueueName, {
-			connection: this.getBullConnectionOptions(),
+		this.fallbackQueue = new BullQueue<{ tier: UserTier; ids: string[] }>(MEASUREMENT_STORE_FALLBACK_QUEUE_NAME, {
+			connection: getMeasurementStoreFallbackQueueConnectionOptions(),
 			defaultJobOptions: {
 				attempts: 28,
 				backoff: { type: 'custom' },
@@ -72,12 +81,12 @@ export class MeasurementStoreOffloader {
 
 	startRetryWorker () {
 		const worker = new Worker<{ tier: UserTier; ids: string[] }>(
-			this.fallbackQueueName,
+			MEASUREMENT_STORE_FALLBACK_QUEUE_NAME,
 			async (job) => {
 				await this.insertBatchToDbByIds(job.data.tier, job.data.ids);
 			},
 			{
-				connection: this.getBullConnectionOptions(),
+				connection: getMeasurementStoreFallbackQueueConnectionOptions(),
 				concurrency: 4,
 				settings: {
 					backoffStrategy (attempts) {
@@ -120,14 +129,6 @@ export class MeasurementStoreOffloader {
 				}
 			}
 		}, { batchSize: 100, timeout: 2000 });
-	}
-
-	private getBullConnectionOptions () {
-		const url = config.get<string>('redis.standalonePersistentNoEviction.url');
-		const password = config.get<string>('redis.sharedOptions.password');
-		const tls = config.get<boolean>('redis.sharedOptions.socket.tls');
-
-		return { url, password, tls };
 	}
 
 	private getTierFromMeasurementId (id: string): UserTier {

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -25,6 +25,7 @@ import { MeasurementStoreOffloader } from './store-offloader.js';
 import { measurementStoreClient } from '../lib/sql/client.js';
 import { scopedFlight } from '../lib/single-flight.js';
 import type { ExportMeta } from './types.js';
+import { metricsAgent } from '../lib/metrics.js';
 
 const logger = scopedLogger('store');
 const singleFlight = scopedFlight('store');
@@ -191,14 +192,21 @@ export class MeasurementStore {
 		}
 
 		const measurements = (await Bluebird.map(ids, async (id) => {
-			const recordBuffer = await this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).markFinishedByTimeout(id);
-			return parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
+			const result = await this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).markFinishedByTimeout(id);
+
+			if (!result) {
+				return null;
+			}
+
+			const measurement = await parseCompressedJsonBuffer<MeasurementRecord>(result.recordBuffer);
+			return measurement && { measurement, timedOutTests: result.timedOutTests };
 		}, { concurrency: 32 })).filter(is.truthy);
 
 		await this.redis.zRem('gp:in-progress-timeouts', ids);
 
-		for (const measurement of measurements) {
+		for (const { measurement, timedOutTests } of measurements) {
 			this.offloader.enqueueForOffload(measurement);
+			metricsAgent.recordMeasurementTimeout(measurement.type, timedOutTests);
 		}
 	}
 

--- a/src/measurement/store.ts
+++ b/src/measurement/store.ts
@@ -1,6 +1,5 @@
 import { promisify } from 'node:util';
 import { brotliDecompress as brotliDecompressCallback } from 'node:zlib';
-import is from '@sindresorhus/is';
 import Bluebird from 'bluebird';
 import config from 'config';
 import _ from 'lodash';
@@ -179,8 +178,9 @@ export class MeasurementStore {
 		const record = await parseCompressedJsonBuffer<MeasurementRecord>(recordBuffer);
 
 		if (record) {
-			await this.redis.zRem('gp:in-progress-timeouts', data.measurementId);
 			this.offloader.enqueueForOffload(record);
+			metricsAgent.recordMeasurementCompleted(record.type);
+			await this.redis.zRem('gp:in-progress-timeouts', data.measurementId);
 		}
 
 		return record;
@@ -191,23 +191,24 @@ export class MeasurementStore {
 			return;
 		}
 
-		const measurements = (await Bluebird.map(ids, async (id) => {
+		await Bluebird.map(ids, async (id) => {
 			const result = await this.redis.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer }).markFinishedByTimeout(id);
 
 			if (!result) {
-				return null;
+				return;
 			}
 
 			const measurement = await parseCompressedJsonBuffer<MeasurementRecord>(result.recordBuffer);
-			return measurement && { measurement, timedOutTests: result.timedOutTests };
-		}, { concurrency: 32 })).filter(is.truthy);
+
+			if (!measurement) {
+				return;
+			}
+
+			this.offloader.enqueueForOffload(measurement);
+			metricsAgent.recordMeasurementTimeout(measurement.type, result.timedOutTests);
+		}, { concurrency: 32 });
 
 		await this.redis.zRem('gp:in-progress-timeouts', ids);
-
-		for (const { measurement, timedOutTests } of measurements) {
-			this.offloader.enqueueForOffload(measurement);
-			metricsAgent.recordMeasurementTimeout(measurement.type, timedOutTests);
-		}
 	}
 
 	async cleanup () {

--- a/src/schedule/executor.ts
+++ b/src/schedule/executor.ts
@@ -2,6 +2,7 @@ import config from 'config';
 import _ from 'lodash';
 import { PROBES_NAMESPACE } from '../lib/ws/server.js';
 import { scopedLogger } from '../lib/logger.js';
+import { metricsAgent } from '../lib/metrics.js';
 import type { ServerProbe } from '../probe/types.js';
 import type { ProbesLocationFilter } from '../probe/probes-location-filter.js';
 import type { MeasurementRequest } from '../measurement/types.js';
@@ -147,6 +148,7 @@ export class StreamScheduleExecutor {
 				const measurementId = await this.store.createMeasurement(requestBase, probesMap, probesChunk, 'special', {
 					timeSeriesEnabled: Boolean(schedule.time_series_enabled),
 				});
+				metricsAgent.recordMeasurement(requestBase.type, probesMap.size);
 
 				logger.debug(`Executing a scheduled measurement.`, { measurementId, scheduleId });
 

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -29,6 +29,8 @@ describe('MeasurementRunner', () => {
 	const router = sandbox.createStubInstance(ProbeRouter);
 	const recordMeasurement = sandbox.stub();
 	const recordMeasurementTime = sandbox.stub();
+	const recordNoProbesFound = sandbox.stub();
+	const recordMeasurementCompleted = sandbox.stub();
 	const rateLimit = sandbox.stub();
 	const precheckRateLimit = sandbox.stub();
 	let runner: MeasurementRunner;
@@ -45,6 +47,8 @@ describe('MeasurementRunner', () => {
 			metricsAgent: {
 				recordMeasurement,
 				recordMeasurementTime,
+				recordNoProbesFound,
+				recordMeasurementCompleted,
 			},
 		});
 

--- a/test/tests/unit/measurement/runner.test.ts
+++ b/test/tests/unit/measurement/runner.test.ts
@@ -4,12 +4,12 @@ import { expect } from 'chai';
 import * as td from 'testdouble';
 import { MeasurementStore } from '../../../../src/measurement/store.js';
 import { ProbeRouter } from '../../../../src/probe/router.js';
-import { MetricsAgent } from '../../../../src/lib/metrics.js';
 import type { ServerProbe } from '../../../../src/probe/types.js';
 import type { MeasurementRunner } from '../../../../src/measurement/runner.js';
 import type { MeasurementRecord, MeasurementResultMessage } from '../../../../src/measurement/types.js';
 import createHttpError from 'http-errors';
 import type { ExtendedContext } from '../../../../src/types.js';
+import * as metricsModule from '../../../../src/lib/metrics.js';
 
 const getProbe = (id: number) => ({ client: id } as unknown as ServerProbe);
 
@@ -27,7 +27,8 @@ describe('MeasurementRunner', () => {
 	const io = sandbox.createStubInstance(Server);
 	const store = sandbox.createStubInstance(MeasurementStore);
 	const router = sandbox.createStubInstance(ProbeRouter);
-	const metrics = sandbox.createStubInstance(MetricsAgent);
+	const recordMeasurement = sandbox.stub();
+	const recordMeasurementTime = sandbox.stub();
 	const rateLimit = sandbox.stub();
 	const precheckRateLimit = sandbox.stub();
 	let runner: MeasurementRunner;
@@ -38,8 +39,17 @@ describe('MeasurementRunner', () => {
 
 	before(async () => {
 		await td.replaceEsm('crypto-random-string', null, () => testId++);
+
+		await td.replaceEsm('../../../../src/lib/metrics.ts', {
+			...metricsModule,
+			metricsAgent: {
+				recordMeasurement,
+				recordMeasurementTime,
+			},
+		});
+
 		const { MeasurementRunner } = await import('../../../../src/measurement/runner.js');
-		runner = new MeasurementRunner(io, store, router, precheckRateLimit, rateLimit, metrics);
+		runner = new MeasurementRunner(io, store, router, precheckRateLimit, rateLimit);
 	});
 
 	beforeEach(() => {
@@ -183,8 +193,8 @@ describe('MeasurementRunner', () => {
 			testId: '3',
 		}]);
 
-		expect(metrics.recordMeasurement.callCount).to.equal(1);
-		expect(metrics.recordMeasurement.args[0]).to.deep.equal([ 'ping', 4 ]);
+		expect(recordMeasurement.callCount).to.equal(1);
+		expect(recordMeasurement.args[0]).to.deep.equal([ 'ping', 4 ]);
 	});
 
 	it('should send `inProgressUpdates: true` to the first N probes if requested', async () => {
@@ -303,8 +313,8 @@ describe('MeasurementRunner', () => {
 			testId: '3',
 		}]);
 
-		expect(metrics.recordMeasurement.callCount).to.equal(1);
-		expect(metrics.recordMeasurement.args[0]).to.deep.equal([ 'ping', 4 ]);
+		expect(recordMeasurement.callCount).to.equal(1);
+		expect(recordMeasurement.args[0]).to.deep.equal([ 'ping', 4 ]);
 	});
 
 	it('should properly handle result events from probes', async () => {
@@ -324,8 +334,8 @@ describe('MeasurementRunner', () => {
 		expect(store.storeMeasurementResult.args[0]).to.deep.equal([{ measurementId: mockedMeasurementId, testId: 'testid1', result: {} }]);
 		expect(store.storeMeasurementResult.args[1]).to.deep.equal([{ measurementId: mockedMeasurementId, testId: 'testid2', result: {} }]);
 		expect(store.storeMeasurementResult.args[2]).to.deep.equal([{ measurementId: mockedMeasurementId, testId: 'testid3', result: {} }]);
-		expect(metrics.recordMeasurementTime.callCount).to.equal(1);
-		expect(metrics.recordMeasurementTime.args[0]).to.deep.equal([ 'ping', 25000 ]);
+		expect(recordMeasurementTime.callCount).to.equal(1);
+		expect(recordMeasurementTime.args[0]).to.deep.equal([ 'ping', 25000 ]);
 	});
 
 	it('should call rate limiter with the number of online probes', async () => {

--- a/test/tests/unit/measurement/store.test.ts
+++ b/test/tests/unit/measurement/store.test.ts
@@ -152,10 +152,13 @@ describe('measurement store', () => {
 
 		redisMock.claimTimedOutMeasurements.resolves([ mockedMeasurementId1, mockedMeasurementId2 ]);
 
-		redisMock.markFinishedByTimeout.onFirstCall().resolves(Buffer.concat([
-			Buffer.from([ 0x00 ]),
-			Buffer.from(JSON.stringify(finishedRecord)),
-		]));
+		redisMock.markFinishedByTimeout.onFirstCall().resolves({
+			recordBuffer: Buffer.concat([
+				Buffer.from([ 0x00 ]),
+				Buffer.from(JSON.stringify(finishedRecord)),
+			]),
+			timedOutTests: 1,
+		});
 
 		redisMock.markFinishedByTimeout.onSecondCall().resolves(null);
 


### PR DESCRIPTION
Adds metrics for probe-sync delays and event volume, no-probe measurement failures, measurement completion and timeout outcomes, and persistence backlog depth.

Note that there's a small race between timeout tracking and completion when the results arrive near the timeout, I think it's acceptable and introducing a new redis data structure needed to avoid it is not worth it.