### PR TITLE
test: use mock-fs fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
 				"husky": "^9.1.7",
 				"lint-staged": "^17.0.8",
 				"mocha": "11.6.0",
-				"mock-fs": "^5.5.0",
+				"mock-fs": "github:MartinKolarik/mock-fs#gh-447",
 				"nock": "^14.0.16",
 				"relative-day-utc": "^1.3.0",
 				"rimraf": "^6.1.3",
@@ -11208,8 +11208,7 @@
 		},
 		"node_modules/mock-fs": {
 			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
-			"integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
+			"resolved": "git+ssh://git@github.com/MartinKolarik/mock-fs.git#9a655e5fa9cc05c501d96d73f911e380fd5a57c5",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"husky": "^9.1.7",
 		"lint-staged": "^17.0.8",
 		"mocha": "11.6.0",
-		"mock-fs": "^5.5.0",
+		"mock-fs": "github:MartinKolarik/mock-fs#gh-447",
 		"nock": "^14.0.16",
 		"relative-day-utc": "^1.3.0",
 		"rimraf": "^6.1.3",


### PR DESCRIPTION
Uses the [gh-447 mock-fs fork](https://github.com/MartinKolarik/mock-fs/tree/gh-447) to restore test compatibility with the currently supported Node.js versions.