### PR TITLE
docs: describe HTTP protocol

### DIFF
--- a/public/v1/components/schemas.yaml
+++ b/public/v1/components/schemas.yaml
@@ -65,6 +65,7 @@ components:
       default: A
     HttpProtocol:
       type: string
+      description: The protocol to use for the HTTP request.
       enum:
         - HTTP
         - HTTPS


### PR DESCRIPTION
Documents the HTTP protocol field in the OpenAPI schema so generated clients receive a spec-driven description.